### PR TITLE
Ignore .DS_Store for MacOS dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dart_tool/
+.DS_Store


### PR DESCRIPTION
Ignore `.DS_Store` files for MacOS dev environment.