### PR TITLE
Fix race condition and UI bugs in download implementation

### DIFF
--- a/example/lib/model_download_screen.dart
+++ b/example/lib/model_download_screen.dart
@@ -186,9 +186,9 @@ class _ModelDownloadScreenState extends State<ModelDownloadScreen> {
                   ? Column(
                       children: [
                         Text(
-                            'Download Progress: ${(_progress).toStringAsFixed(1)}%'),
+                            'Download Progress: ${_progress.toStringAsFixed(1)}%'),
                         const SizedBox(height: 8),
-                        LinearProgressIndicator(value: _progress),
+                        LinearProgressIndicator(value: _progress / 100.0),
                       ],
                     )
                   : ElevatedButton(

--- a/example/lib/services/model_download_service.dart
+++ b/example/lib/services/model_download_service.dart
@@ -71,7 +71,12 @@ class ModelDownloadService {
   }) async {
     try {
       final stream = FlutterGemmaPlugin.instance.modelManager.downloadModelFromNetworkWithProgress(modelUrl, token: token);
-      stream.listen((progress) => onProgress(progress.toDouble()));
+      
+      // Wait for stream to complete - same logic as original but with new downloader
+      await for (final progress in stream) {
+        // Keep progress as 0-100 (double)
+        onProgress(progress.toDouble());
+      }
     } catch (e) {
       if (kDebugMode) {
         print('Error downloading model: $e');


### PR DESCRIPTION
- Use await for instead of stream.listen() to properly wait for download completion
- Fix LinearProgressIndicator to display progress correctly (divide by 100.0)
- Add proper error handling with progress.close() calls in all error cases
- Improve async initialization with .then() chain and try-catch