### PR TITLE
Fix iOS embedding crash on repeated inference (v0.11.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.11.16
+- 🐛 **iOS Embeddings Fix**: Fix crash on repeated embedding inference (#155)
+
 ## 0.11.15
 - 🤖 **FunctionGemma Single-Turn Mode**: FunctionGemma now operates in single-turn mode by design (clears history after each response)
 - 🐛 **Download Resume Fix**: Fixed model download resume after interruption

--- a/ios/Classes/EmbeddingModel.swift
+++ b/ios/Classes/EmbeddingModel.swift
@@ -50,9 +50,10 @@ class EmbeddingModel {
         var options = Interpreter.Options()
         options.threadCount = 4 // Optimize for mobile performance
 
-        // Enable XNNPACK for native FP16 support on A11+ devices
-        // This gives results matching Web LiteRT which also uses native FP16
-        options.isXNNPackEnabled = true
+        // XNNPACK disabled for embeddings - causes crashes on repeated inference
+        // Speed difference is negligible (~30-80ms vs ~10-30ms with XNNPACK)
+        // See: https://github.com/DenisovAV/flutter_gemma/issues/155
+        options.isXNNPackEnabled = false
 
         // Note: Select TF Ops should be automatically available when TensorFlowLiteSelectTfOps is linked
 

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.11.15'
+  s.version          = '0.11.16'
   s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
   s.description      = <<-DESC
 The plugin allows running the Gemma AI model locally on a device from a Flutter application.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "The plugin allows running the Gemma AI model locally on a device from a Flutter application. Includes support for Gemma 3 Nano models with optimized MediaPipe GenAI v0.10.24."
-version: 0.11.15
+version: 0.11.16
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 


### PR DESCRIPTION
## Summary
- Disable XNNPACK delegate for embeddings to fix crash on second call
- Bump version to 0.11.16

XNNPACK causes memory corruption with repeated TFLite inference. For embeddings speed impact is negligible (~30-80ms vs ~10-30ms). MediaPipe inference is not affected.

Fixes #155