### PR TITLE
Update models: add desktop support, new models, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/flutter_gemma)
 
-**The plugin supports not only Gemma, but also other models. Here's the full list of supported models:** [Gemma 2B](https://huggingface.co/google/gemma-2b-it) & [Gemma 7B](https://huggingface.co/google/gemma-7b-it), [Gemma-2 2B](https://huggingface.co/google/gemma-2-2b-it), [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT), [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it), [Gemma 3 Nano 2B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview), [Gemma 3 Nano 4B](https://huggingface.co/google/gemma-3n-E4B-it-litert-preview), [TinyLlama 1.1B](https://huggingface.co/litert-community/TinyLlama-1.1B-Chat-v1.0), [Hammer 2.1 0.5B](https://huggingface.co/litert-community/Hammer2.1-0.5b), [Llama 3.2 1B](https://huggingface.co/litert-community/Llama-3.2-1B-Instruct), Phi-2, Phi-3 , [Phi-4](https://huggingface.co/litert-community/Phi-4-mini-instruct), [DeepSeek](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B), [Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct), Falcon-RW-1B, StableLM-3B.
+**The plugin supports not only Gemma, but also other models. Here's the full list of supported models:** [Gemma3n E2B/E4B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview), [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B), [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT), [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it), [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it), [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B), [Qwen 2.5](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct), [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct), [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B), [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct).
 
-*Note: Currently, the flutter_gemma plugin supports Gemma-3, Gemma 3 270M, Gemma 3 Nano (with **multimodal vision support**), TinyLlama, Hammer 2.1, Llama 3.2, Phi-4, DeepSeek and Qwen2.5.
+*Note: The flutter_gemma plugin supports Gemma3n (with **multimodal vision support**), FastVLM (vision), Gemma-3, FunctionGemma, Qwen3, Qwen 2.5, Phi-4, DeepSeek R1 and SmolLM. Desktop platforms (macOS, Windows, Linux) require `.litertlm` model format.
 
 [Gemma](https://ai.google.dev/gemma) is a family of lightweight, state-of-the art open models built from the same research and technology used to create the Gemini models
 
@@ -29,7 +29,7 @@ There is an example of using:
 - **Local Execution:** Run Gemma models directly on user devices for enhanced privacy and offline functionality.
 - **Platform Support:** Compatible with iOS, Android, Web, macOS, Windows, and Linux platforms.
 - **🖥️ Desktop Support:** Native desktop apps with GPU acceleration via LiteRT-LM (gRPC architecture).
-- **🖼️ Multimodal Support:** Text + Image input with Gemma 3 Nano vision models 
+- **🖼️ Multimodal Support:** Text + Image input with Gemma3n vision models 
 - **🛠️ Function Calling:** Enable your models to call external functions and integrate with other services (supported by select models)
 - **🧠 Thinking Mode:** View the reasoning process of DeepSeek models with <think> blocks 
 - **🛑 Stop Generation:** Cancel text generation mid-process on Android devices 
@@ -70,16 +70,16 @@ The example app offers a curated list of models, each suited for different tasks
 
 | Model Family | Best For | Function Calling | Thinking Mode | Vision | Languages | Size |
 |---|---|:---:|:---:|:---:|---|---|
-| **Gemma 3 Nano** | On-device multimodal chat and image analysis. | ✅ | ❌ | ✅ | Multilingual | 3-6GB |
-| **Phi-4 Mini** | Advanced reasoning and instruction following. | ✅ | ❌ | ❌ | Multilingual | 3.9GB |
-| **DeepSeek R1** | High-performance reasoning and code generation. | ✅ | ✅ | ❌ | Multilingual | 1.7GB |
-| **Qwen 2.5** | Strong multilingual chat and instruction following. | ✅ | ❌ | ❌ | Multilingual | 1.6GB |
-| **Hammer 2.1** | Lightweight action model for tool usage. | ✅ | ❌ | ❌ | Multilingual | 0.5GB |
-| **Gemma 3 1B** | Balanced and efficient text generation. | ✅ | ❌ | ❌ | Multilingual | 0.5GB |
-| **Gemma 3 270M**| Ideal for fine-tuning (LoRA) for specific tasks | ❌ | ❌ | ❌ | Multilingual | 0.3GB |
-| **FunctionGemma 270M**| Specialized for function calling on-device | ✅ | ❌ | ❌ | Multilingual | 0.3GB |
-| **TinyLlama 1.1B**| Extremely compact, general-purpose chat. | ❌ | ❌ | ❌ | English-focused | 1.2GB |
-| **Llama 3.2 1B** | Efficient instruction following | ❌ | ❌ | ❌ | Multilingual | 1.1GB |
+| **Gemma3n** | On-device multimodal chat and image analysis | ✅ | ❌ | ✅ | Multilingual | 3-6GB |
+| **FastVLM 0.5B** | Fast vision-language inference | ❌ | ❌ | ✅ | Multilingual | 0.5GB |
+| **Phi-4 Mini** | Advanced reasoning and instruction following | ✅ | ❌ | ❌ | Multilingual | 3.9GB |
+| **DeepSeek R1** | High-performance reasoning and code generation | ✅ | ✅ | ❌ | Multilingual | 1.7GB |
+| **Qwen3 0.6B** | Compact multilingual chat with function calling | ✅ | ❌ | ❌ | Multilingual | 586MB |
+| **Qwen 2.5** | Strong multilingual chat and instruction following | ✅ | ❌ | ❌ | Multilingual | 0.5-1.6GB |
+| **Gemma 3 1B** | Balanced and efficient text generation | ❌ | ❌ | ❌ | Multilingual | 0.5GB |
+| **Gemma 3 270M** | Ideal for fine-tuning (LoRA) for specific tasks | ❌ | ❌ | ❌ | Multilingual | 0.3GB |
+| **FunctionGemma 270M** | Specialized for function calling on-device | ✅ | ❌ | ❌ | Multilingual | 284MB |
+| **SmolLM 135M** | Ultra-compact, resource-constrained devices | ❌ | ❌ | ❌ | English | 135MB |
 
 ## ModelType Reference
 
@@ -87,13 +87,11 @@ When installing models, you need to specify the correct `ModelType`. Use this ta
 
 | Model Family | ModelType | Examples |
 |--------------|-----------|----------|
-| **Gemma (all variants)** | `ModelType.gemmaIt` | Gemma 2B, Gemma 7B, Gemma-2 2B, Gemma-3 1B, Gemma 3 270M, Gemma 3 Nano E2B/E4B |
-| **DeepSeek** | `ModelType.deepSeek` | DeepSeek R1, DeepSeek-R1-Distill-Qwen-1.5B |
-| **Qwen** | `ModelType.qwen` | Qwen 2.5 1.5B Instruct |
-| **Llama** | `ModelType.llama` | Llama 3.2 1B, TinyLlama 1.1B |
-| **Hammer** | `ModelType.hammer` | Hammer 2.1 0.5B |
+| **Gemma (all variants)** | `ModelType.gemmaIt` | Gemma 3 1B, Gemma 3 270M, Gemma3n E2B/E4B |
+| **DeepSeek** | `ModelType.deepSeek` | DeepSeek R1 |
+| **Qwen** | `ModelType.qwen` | Qwen3 0.6B, Qwen 2.5 1.5B, Qwen 2.5 0.5B |
 | **FunctionGemma** | `ModelType.functionGemma` | FunctionGemma 270M IT |
-| **Phi / Falcon / StableLM** | `ModelType.general` | Phi-2, Phi-3, Phi-4, Falcon-RW-1B, StableLM-3B |
+| **General** | `ModelType.general` | Phi-4 Mini, FastVLM 0.5B, SmolLM 135M |
 
 **Usage Example:**
 ```dart
@@ -126,7 +124,7 @@ await FlutterGemma.installModel(modelType: ModelType.general)
 > **⚠️ Important:** Complete platform-specific setup before using the plugin.
 
 1. **Download Model and optionally LoRA Weights:** Obtain a pre-trained Gemma model (recommended: 2b or 2b-it) [from Kaggle](https://www.kaggle.com/models/google/gemma/frameworks/tfLite/)
-* For **multimodal support**, download [Gemma 3 Nano models](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview) or [Gemma 3 Nano in LitertLM format](https://huggingface.co/google/gemma-3n-E2B-it-litert-lm) that support vision input
+* For **multimodal support**, download [Gemma3n models](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview) or [Gemma3n in LitertLM format](https://huggingface.co/google/gemma-3n-E2B-it-litert-lm) that support vision input
 * Optionally, [fine-tune a model for your specific use case]( https://www.kaggle.com/code/juanmerinobermejo/llm-pr-fine-tuning-with-gemma-2b?scriptVersionId=169776634)
 * If you have LoRA weights, you can use them to customize the model's behavior without retraining the entire model.
 * [There is an article that described all approaches](https://medium.com/@denisov.shureg/fine-tuning-gemma-with-lora-for-on-device-inference-android-ios-web-with-separate-lora-weights-f05d1db30d86)
@@ -452,7 +450,7 @@ void main() {
 ```
 
 **Configuration Options:**
-- `huggingFaceToken`: Authentication token for gated models (Gemma 3 Nano, EmbeddingGemma)
+- `huggingFaceToken`: Authentication token for gated models (Gemma3n, EmbeddingGemma)
 - `maxDownloadRetries`: Number of retry attempts for failed downloads (default: 10)
 - `enableWebCache`: **(Web only)** Enable persistent caching via Cache API (default: true)
   - `true`: Models persist across browser restarts (recommended for production)
@@ -547,13 +545,13 @@ await FlutterGemma.installModel(
 ### Which Models Require Authentication?
 
 **Common gated models:**
-- ✅ **Gemma 3 Nano** (E2B, E4B) - `google/` repos are gated
+- ✅ **Gemma3n** (E2B, E4B) - `google/` repos are gated
 - ✅ **Gemma 3 1B** - `litert-community/` requires access
 - ✅ **Gemma 3 270M** - `litert-community/` requires access
 - ✅ **EmbeddingGemma** - `litert-community/` requires access
 
 **Public models (no auth needed):**
-- ❌ **DeepSeek, Qwen2.5, TinyLlama** - Public repos
+- ❌ **DeepSeek, Qwen3, Qwen 2.5, SmolLM, Phi-4, FastVLM** - Public repos
 
 **Get your token:** https://huggingface.co/settings/tokens
 
@@ -730,8 +728,9 @@ await FlutterGemma.installModel(
 ```
 
 **App Size Impact:**
+- SmolLM 135M: ~135MB
 - Gemma 3 270M: ~300MB
-- TinyLlama 1.1B: ~1.2GB
+- Qwen3 0.6B: ~586MB
 - Consider hosting large models for download instead
 
 ### FileSource - External Files (Mobile Only)
@@ -1853,7 +1852,7 @@ chat.generateChatResponseAsync().listen((response) {
     // Use response.token to update your UI incrementally
     
   } else if (response is FunctionCallResponse) {
-    // Model wants to call a function (Gemma 3 Nano, DeepSeek, Qwen2.5)
+    // Model wants to call a function (Gemma3n, DeepSeek, Qwen2.5)
     print('Function: ${response.name}');
     print('Arguments: ${response.args}');
     
@@ -1877,24 +1876,22 @@ chat.generateChatResponseAsync().listen((response) {
 
 ## 🎯 Supported Models
 
-### Text-Only Models
-- [Gemma 2B](https://huggingface.co/google/gemma-2b-it) & [Gemma 7B](https://huggingface.co/google/gemma-7b-it)
-- [Gemma-2 2B](https://huggingface.co/google/gemma-2-2b-it)
-- [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT)
-- [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it) - Ultra-compact model
-- [FunctionGemma 270M](https://huggingface.co/google/functiongemma-270m-it) - Specialized function calling model
-- [TinyLlama 1.1B](https://huggingface.co/litert-community/TinyLlama-1.1B-Chat-v1.0) - Lightweight chat model
-- [Hammer 2.1 0.5B](https://huggingface.co/litert-community/Hammer2.1-0.5b) - Action model with function calling
-- [Llama 3.2 1B](https://huggingface.co/litert-community/Llama-3.2-1B-Instruct) - Instruction-tuned model
-- [Phi-4](https://huggingface.co/litert-community/Phi-4-mini-instruct)
-- [DeepSeek](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B)
-- Phi-2, Phi-3, Falcon-RW-1B, StableLM-3B
+### Platform Support
 
-### 🖼️ Multimodal Models (Vision + Text)
-- [Gemma 3 Nano E2B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview) - 2B parameters with vision support
-- [Gemma 3 Nano E4B](https://huggingface.co/google/gemma-3n-E4B-it-litert-preview) - 4B parameters with vision support
-- [Gemma 3 Nano E2B LitertLM](https://huggingface.co/google/gemma-3n-E2B-it-litert-lm) - 2B parameters with vision support
-- [Gemma 3 Nano E4B LitertLM](https://huggingface.co/google/gemma-3n-E4B-it-litert-lm) - 4B parameters with vision support
+| Model | Size | Desktop | Mobile | Web |
+|-------|------|:-------:|:------:|:---:|
+| [Gemma3n E2B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview) | 3.1GB | ✅ | ✅ | ✅ |
+| [Gemma3n E4B](https://huggingface.co/google/gemma-3n-E4B-it-litert-preview) | 6.5GB | ✅ | ✅ | ✅ |
+| [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B) | 0.5GB | ✅ | ❌ | ❌ |
+| [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT) | 0.5GB | ✅ | ✅ | ✅ |
+| [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it) | 0.3GB | ✅ | ✅ | ✅ |
+| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ❌ |
+| [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ✅ |
+| [Qwen 2.5 1.5B](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct) | 1.6GB | ✅ | ✅ | ❌ |
+| [Qwen 2.5 0.5B](https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct) | 0.5GB | ❌ | ✅ | ❌ |
+| [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct) | 135MB | ❌ | ✅ | ❌ |
+| [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct) | 3.9GB | ✅ | ✅ | ✅ |
+| [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B) | 1.7GB | ❌ | ✅ | ❌ |
 
 ### 📊 Text Embedding Models
 
@@ -1925,19 +1922,17 @@ All embedding models generate **768-dimensional vectors**. The numbers in names 
 Function calling is currently supported by the following models:
 
 ### ✅ Models with Function Calling Support
-- **Gemma 3 Nano** models (E2B, E4B) - Full function calling support
-- **FunctionGemma 270M** - Google's specialized function calling model (Android/iOS only)
-- **Hammer 2.1 0.5B** - Action model with strong function calling capabilities
-- **DeepSeek** models - Function calling + thinking mode support
-- **Qwen** models - Full function calling support
+- **Gemma3n** models (E2B, E4B) - Full function calling support
+- **FunctionGemma 270M** - Google's specialized function calling model
+- **DeepSeek R1** - Function calling + thinking mode support
+- **Qwen** models (0.5B, 0.6B, 1.5B) - Full function calling support
 - **Phi-4 Mini** - Advanced reasoning with function calling support
 
 ### ❌ Models WITHOUT Function Calling Support
-- **Gemma 3 1B** models - Text generation only
+- **Gemma 3 1B** - Text generation only
 - **Gemma 3 270M** - Text generation only
-- **TinyLlama 1.1B** - Text generation only
-- **Llama 3.2 1B** - Text generation only
-- **Phi-2, Phi-3** models - Text generation only
+- **SmolLM 135M** - Text generation only
+- **FastVLM 0.5B** - Vision model, no function calling
 
 **Important Notes:**
 - When using unsupported models with tools, the plugin will log a warning and ignore the tools
@@ -1951,7 +1946,7 @@ Function calling is currently supported by the following models:
 | Feature | Android | iOS | Web | Notes |
 |---------|---------|-----|-----|-------|
 | **Text Generation** | ✅ Full | ✅ Full | ✅ Full | All models supported |
-| **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | Gemma 3 Nano models |
+| **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | Gemma3n models |
 | **Function Calling** | ✅ Full | ✅ Full | ✅ Full | Select models only |
 | **Thinking Mode** | ✅ Full | ✅ Full | ✅ Full | DeepSeek models |
 | **Stop Generation** | ✅ Android only | ❌ Not supported | ❌ Not supported | Cancel mid-process |
@@ -1969,7 +1964,7 @@ Function calling is currently supported by the following models:
 ### Web Platform Specifics
 
 #### Authentication
-- **Required for gated models:** Gemma 3 Nano, Gemma 3 1B/270M, EmbeddingGemma
+- **Required for gated models:** Gemma3n, Gemma 3 1B/270M, EmbeddingGemma
 - **Configuration:** Use `FlutterGemma.initialize(huggingFaceToken: '...')` or pass token per-download
 - **Storage:** Tokens stored in browser memory (not localStorage)
 
@@ -2028,7 +2023,7 @@ await FlutterGemma.instance.modelManager.clearCache();
 - **Best models for web:**
   - Gemma 3 270M (300MB)
   - Gemma 3 1B (500MB-1GB)
-  - Gemma 3 Nano E2B (3GB) - requires 6GB+ device RAM
+  - Gemma3n E2B (3GB) - requires 6GB+ device RAM
 
 #### Browser Cache Storage Limits
 
@@ -2056,9 +2051,9 @@ The full and complete example you can find in `example` folder
 ## **Important Considerations**
 
 * **Model Size:** Larger models (such as 7b and 7b-it) might be too resource-intensive for on-device inference.
-* **Function Calling Support:** Gemma 3 Nano and DeepSeek models support function calling. Other models will ignore tools and show a warning.
+* **Function Calling Support:** Gemma3n and DeepSeek models support function calling. Other models will ignore tools and show a warning.
 * **Thinking Mode:** Only DeepSeek models support thinking mode. Enable with `isThinking: true` and `modelType: ModelType.deepSeek`.
-* **Multimodal Models:** Gemma 3 Nano models with vision support require more memory and are recommended for devices with 8GB+ RAM.
+* **Multimodal Models:** Gemma3n models with vision support require more memory and are recommended for devices with 8GB+ RAM.
 * **iOS Memory Requirements:** Large models require memory entitlements in `Runner.entitlements` and minimum iOS 16.0.
 * **LoRA Weights:** They provide efficient customization without the need for full model retraining.
 * **Development vs. Production:** For production apps, do not embed the model or LoRA weights within your assets. Instead, load them once and store them securely on the device or via a network drive.
@@ -2068,7 +2063,7 @@ The full and complete example you can find in `example` folder
 ## **🛟 Troubleshooting**
 
 **Multimodal Issues:**
-- Ensure you're using a multimodal model (Gemma 3 Nano E2B/E4B)
+- Ensure you're using a multimodal model (Gemma3n E2B/E4B)
 - Set `supportImage: true` when creating model and chat
 - Check device memory - multimodal models require more RAM
 

--- a/example/lib/model_selection_screen.dart
+++ b/example/lib/model_selection_screen.dart
@@ -5,6 +5,12 @@ import 'package:flutter_gemma_example/chat_screen.dart';
 import 'package:flutter_gemma_example/model_download_screen.dart';
 import 'package:flutter_gemma_example/models/model.dart';
 
+bool get _isDesktop =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux);
+
 enum SortType {
   defaultOrder('Default'),
   alphabetical('Alphabetical'),
@@ -85,6 +91,11 @@ class _ModelSelectionScreenState extends State<ModelSelectionScreen> {
   Widget build(BuildContext context) {
     // Show all models on all platforms
     var models = Model.values.toList();
+
+    // On desktop, only show models with desktopUrl (litertlm format required)
+    if (_isDesktop) {
+      models = models.where((model) => model.localModel || model.supportsDesktop).toList();
+    }
 
     // On web, only show models with webUrl or local models
     if (kIsWeb) {

--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -3,6 +3,14 @@ import 'package:flutter_gemma/core/model.dart';
 import 'package:flutter_gemma/pigeon.g.dart';
 import 'base_model.dart';
 
+// Platform detection that's safe for web
+bool get _isDesktop {
+  if (kIsWeb) return false;
+  return defaultTargetPlatform == TargetPlatform.macOS ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.linux;
+}
+
 enum Model implements InferenceModelInterface {
   // === GEMMA MODELS (Top Priority) ===
 
@@ -11,6 +19,8 @@ enum Model implements InferenceModelInterface {
     baseUrl:
         'https://huggingface.co/google/gemma-3n-E2B-it-litert-preview/resolve/main/gemma-3n-E2B-it-int4.task',
     webUrl:
+        'https://huggingface.co/google/gemma-3n-E2B-it-litert-lm/resolve/main/gemma-3n-E2B-it-int4-Web.litertlm',
+    desktopUrl:
         'https://huggingface.co/google/gemma-3n-E2B-it-litert-lm/resolve/main/gemma-3n-E2B-it-int4-Web.litertlm',
     filename: 'gemma-3n-E2B-it-int4.task',
     displayName: 'Gemma 3 Nano E2B IT',
@@ -31,6 +41,8 @@ enum Model implements InferenceModelInterface {
     baseUrl:
         'https://huggingface.co/google/gemma-3n-E4B-it-litert-preview/resolve/main/gemma-3n-E4B-it-int4.task',
     webUrl:
+        'https://huggingface.co/google/gemma-3n-E4B-it-litert-lm/resolve/main/gemma-3n-E4B-it-int4-Web.litertlm',
+    desktopUrl:
         'https://huggingface.co/google/gemma-3n-E4B-it-litert-lm/resolve/main/gemma-3n-E4B-it-int4-Web.litertlm',
     filename: 'gemma-3n-E4B-it-int4.task',
     displayName: 'Gemma 3 Nano E4B IT',
@@ -54,6 +66,8 @@ enum Model implements InferenceModelInterface {
         'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4.task',
     webUrl:
         'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4-web.task',
+    desktopUrl:
+        'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm',
     filename: 'gemma3-1b-it-int4.task',
     displayName: 'Gemma 3 1B IT',
     size: '0.5GB',
@@ -73,6 +87,8 @@ enum Model implements InferenceModelInterface {
         'https://huggingface.co/litert-community/gemma-3-270m-it/resolve/main/gemma3-270m-it-q8.task',
     webUrl:
         'https://huggingface.co/litert-community/gemma-3-270m-it/resolve/main/gemma3-270m-it-q8-web.task',
+    desktopUrl:
+        'https://huggingface.co/litert-community/gemma-3-270m-it/resolve/main/gemma3-270m-it-q8.litertlm',
     filename: 'gemma3-270m-it-q8.task',
     displayName: 'Gemma 3 270M IT',
     size: '0.3GB',
@@ -143,6 +159,8 @@ enum Model implements InferenceModelInterface {
   qwen3_0_6B(
     baseUrl:
         'https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/Qwen3-0.6B.litertlm',
+    desktopUrl:
+        'https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/Qwen3-0.6B.litertlm',
     filename: 'Qwen3-0.6B.litertlm',
     displayName: 'Qwen3 0.6B',
     size: '586MB',
@@ -155,23 +173,6 @@ enum Model implements InferenceModelInterface {
     topP: 0.95,
     maxTokens: 4096,
     supportsFunctionCalls: true,
-  ),
-
-  // Gemma 3 1B IT (LiteRT-LM format for desktop)
-  gemma3_1B_litertlm(
-    baseUrl:
-        'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4.litertlm',
-    filename: 'gemma3-1b-it-int4.litertlm',
-    displayName: 'Gemma 3 1B IT (LiteRT-LM)',
-    size: '529MB',
-    licenseUrl: 'https://huggingface.co/litert-community/Gemma3-1B-IT',
-    needsAuth: true,
-    preferredBackend: PreferredBackend.cpu,
-    modelType: ModelType.gemmaIt,
-    temperature: 1.0,
-    topK: 64,
-    topP: 0.95,
-    maxTokens: 1024,
   ),
 
   deepseek(
@@ -191,10 +192,12 @@ enum Model implements InferenceModelInterface {
     isThinking: true,
   ),
 
-  // Models from JSON - Qwen2.5 1.5B Instruct q8
-  qwen25_1_5B_InstructCpu(
+  // Qwen2.5 1.5B Instruct
+  qwen25_1_5B_Instruct(
     baseUrl:
         'https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct/resolve/main/Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
+    desktopUrl:
+        'https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct/resolve/main/Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv4096.litertlm',
     filename: 'Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
     displayName: 'Qwen 2.5 1.5B Instruct',
     size: '1.6GB',
@@ -209,17 +212,35 @@ enum Model implements InferenceModelInterface {
     supportsFunctionCalls: true,
   ),
 
-  // TinyLlama 1.1B Chat
-  tinyLlama_1_1B(
+  // Qwen2.5 0.5B Instruct (mobile only - no litertlm)
+  qwen25_0_5B_Instruct(
     baseUrl:
-        'https://huggingface.co/litert-community/TinyLlama-1.1B-Chat-v1.0/resolve/main/TinyLlama-1.1B-Chat-v1.0_multi-prefill-seq_q8_ekv1280.task',
-    filename: 'TinyLlama-1.1B-Chat-v1.0_multi-prefill-seq_q8_ekv1280.task',
-    displayName: 'TinyLlama 1.1B Chat',
-    size: '1.2GB',
-    licenseUrl: 'https://huggingface.co/litert-community/TinyLlama-1.1B-Chat-v1.0',
+        'https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct/resolve/main/Qwen2.5-0.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
+    filename: 'Qwen2.5-0.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
+    displayName: 'Qwen 2.5 0.5B Instruct',
+    size: '0.5GB',
+    licenseUrl: 'https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct',
     needsAuth: false,
     preferredBackend: PreferredBackend.cpu,
-    modelType: ModelType.llama,
+    modelType: ModelType.qwen,
+    temperature: 1.0,
+    topK: 40,
+    topP: 0.95,
+    maxTokens: 1024,
+    supportsFunctionCalls: true,
+  ),
+
+  // SmolLM 135M Instruct (Ultra-small, mobile only)
+  smolLM_135M(
+    baseUrl:
+        'https://huggingface.co/litert-community/SmolLM-135M-Instruct/resolve/main/SmolLM-135M-Instruct_multi-prefill-seq_q8_ekv1280.task',
+    filename: 'SmolLM-135M-Instruct_multi-prefill-seq_q8_ekv1280.task',
+    displayName: 'SmolLM 135M Instruct',
+    size: '135MB',
+    licenseUrl: 'https://huggingface.co/litert-community/SmolLM-135M-Instruct',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.cpu,
+    modelType: ModelType.general,
     temperature: 0.7,
     topK: 40,
     topP: 0.9,
@@ -227,41 +248,26 @@ enum Model implements InferenceModelInterface {
     supportsFunctionCalls: false,
   ),
 
-  // Hammer 2.1 0.5B (Action Model with strong function calling)
-  hammer2_1_0_5B(
+  // FastVLM 0.5B (Vision-Language Model, desktop only - litertlm)
+  fastVLM_0_5B(
     baseUrl:
-        'https://huggingface.co/litert-community/Hammer2.1-0.5b/resolve/main/hammer2p1_05b_.task',
-    filename: 'hammer2p1_05b_.task',
-    displayName: 'Hammer 2.1 0.5B Action Model',
+        'https://huggingface.co/litert-community/FastVLM-0.5B/resolve/main/FastVLM-0.5B.litertlm',
+    desktopUrl:
+        'https://huggingface.co/litert-community/FastVLM-0.5B/resolve/main/FastVLM-0.5B.litertlm',
+    filename: 'FastVLM-0.5B.litertlm',
+    displayName: 'FastVLM 0.5B (Vision)',
     size: '0.5GB',
-    licenseUrl: 'https://huggingface.co/litert-community/Hammer2.1-0.5b',
-    needsAuth: true,
-    preferredBackend: PreferredBackend.cpu,
-    modelType: ModelType.hammer,
-    temperature: 0.3,
+    licenseUrl: 'https://huggingface.co/litert-community/FastVLM-0.5B',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.gpu,
+    modelType: ModelType.general,
+    temperature: 0.7,
     topK: 40,
-    topP: 0.8,
-    maxTokens: 1024,
-    supportsFunctionCalls: true,
-  ),
-
-  // Llama 3.2 1B Instruct
-  llama32_1B(
-    baseUrl:
-        'https://huggingface.co/litert-community/Llama-3.2-1B-Instruct/resolve/main/Llama-3.2-1B-Instruct_seq128_q8_ekv1280.tflite',
-    filename: 'Llama-3.2-1B-Instruct_seq128_q8_ekv1280.tflite',
-    displayName: 'Llama 3.2 1B Instruct',
-    size: '1.1GB',
-    licenseUrl: 'https://huggingface.co/litert-community/Llama-3.2-1B-Instruct',
-    needsAuth: true,
-    preferredBackend: PreferredBackend.cpu,
-    modelType: ModelType.llama,
-    temperature: 0.6,
-    topK: 40,
-    topP: 0.9,
-    maxTokens: 1024,
+    topP: 0.95,
+    maxTokens: 2048,
+    supportImage: true,
+    maxNumImages: 1,
     supportsFunctionCalls: false,
-    fileType: ModelFileType.binary,
   ),
 
   // Phi-4 Mini Instruct
@@ -269,6 +275,8 @@ enum Model implements InferenceModelInterface {
     baseUrl:
         'https://huggingface.co/litert-community/Phi-4-mini-instruct/resolve/main/Phi-4-mini-instruct_multi-prefill-seq_q8_ekv4096.task',
     webUrl:
+        'https://huggingface.co/litert-community/Phi-4-mini-instruct/resolve/main/Phi-4-mini-instruct_multi-prefill-seq_q8_ekv4096.litertlm',
+    desktopUrl:
         'https://huggingface.co/litert-community/Phi-4-mini-instruct/resolve/main/Phi-4-mini-instruct_multi-prefill-seq_q8_ekv4096.litertlm',
     filename: 'Phi-4-mini-instruct_multi-prefill-seq_q8_ekv4096.task',
     displayName: 'Phi-4 Mini Instruct',
@@ -290,6 +298,8 @@ enum Model implements InferenceModelInterface {
   functionGemma_270M(
     baseUrl:
         'https://huggingface.co/sasha-denisov/function-gemma-270M-it/resolve/main/functiongemma-270M-it.task',
+    desktopUrl:
+        'https://huggingface.co/sasha-denisov/function-gemma-270M-it/resolve/main/functiongemma-270M-it.litertlm',
     filename: 'functiongemma-270M-it.task',
     displayName: 'FunctionGemma 270M IT',
     size: '284MB',
@@ -343,6 +353,7 @@ enum Model implements InferenceModelInterface {
   // Define fields for the enum
   final String baseUrl;
   final String? webUrl;
+  final String? desktopUrl;
 
   @override
   final String filename;
@@ -377,19 +388,30 @@ enum Model implements InferenceModelInterface {
   final bool isThinking;
   final ModelFileType fileType;
 
-  // Getter for url - returns webUrl on web platform if available, otherwise baseUrl
+  // Getter for url - returns platform-specific URL
   @override
   String get url {
+    // Desktop platforms require .litertlm format
+    if (_isDesktop && desktopUrl != null && desktopUrl!.isNotEmpty) {
+      return desktopUrl!;
+    }
+    // Web platform may have different URL
     if (kIsWeb && webUrl != null && webUrl!.isNotEmpty) {
       return webUrl!;
     }
     return baseUrl;
   }
 
+  // Check if model supports desktop (has .litertlm URL)
+  bool get supportsDesktop =>
+      (desktopUrl != null && desktopUrl!.isNotEmpty) ||
+      baseUrl.endsWith('.litertlm');
+
   // Constructor for the enum
   const Model({
     required this.baseUrl,
     this.webUrl,
+    this.desktopUrl,
     required this.filename,
     required this.displayName,
     required this.size,

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_gemma/flutter_gemma_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_gemma_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterGemmaPlugin");
+  flutter_gemma_plugin_register_with_registrar(flutter_gemma_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  flutter_gemma
   url_launcher_linux
 )
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -185,7 +185,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.11.14"
+    version: "0.12.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_windows/file_selector_windows.h>
+#include <flutter_gemma/flutter_gemma_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  FlutterGemmaPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterGemmaPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
+  flutter_gemma
   url_launcher_windows
 )
 

--- a/linux/scripts/setup_desktop.sh
+++ b/linux/scripts/setup_desktop.sh
@@ -58,7 +58,7 @@ JRE_URL="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${
 
 # JAR settings
 JAR_NAME="litertlm-server.jar"
-JAR_VERSION="0.11.16"
+JAR_VERSION="0.12.0"
 JAR_URL="https://github.com/DenisovAV/flutter_gemma/releases/download/v${JAR_VERSION}/${JAR_NAME}"
 JAR_CHECKSUM="914b9d2526b5673eb810a6080bbc760e537322aaee8e19b9cd49609319cfbdc8"
 

--- a/macos/scripts/prepare_resources.sh
+++ b/macos/scripts/prepare_resources.sh
@@ -34,7 +34,7 @@ JRE_CHECKSUM_X64="0e0dcb571f7bf7786c111fe066932066d9eab080c9f86d8178da3e564324ee
 
 # JAR settings
 JAR_NAME="litertlm-server.jar"
-JAR_VERSION="0.11.16"
+JAR_VERSION="0.12.0"
 JAR_URL="https://github.com/DenisovAV/flutter_gemma/releases/download/v${JAR_VERSION}/${JAR_NAME}"
 JAR_CHECKSUM="914b9d2526b5673eb810a6080bbc760e537322aaee8e19b9cd49609319cfbdc8"
 JAR_CACHE_DIR="$HOME/Library/Caches/flutter_gemma/jar"

--- a/macos/scripts/setup_desktop.sh
+++ b/macos/scripts/setup_desktop.sh
@@ -57,7 +57,7 @@ JRE_CHECKSUM_X64="0e0dcb571f7bf7786c111fe066932066d9eab080c9f86d8178da3e564324ee
 
 # JAR settings
 JAR_NAME="litertlm-server.jar"
-JAR_VERSION="0.11.16"
+JAR_VERSION="0.12.0"
 JAR_URL="https://github.com/DenisovAV/flutter_gemma/releases/download/v${JAR_VERSION}/${JAR_NAME}"
 JAR_CHECKSUM="914b9d2526b5673eb810a6080bbc760e537322aaee8e19b9cd49609319cfbdc8"
 JAR_CACHE_DIR="$HOME/Library/Caches/flutter_gemma/jar"

--- a/windows/scripts/setup_desktop.ps1
+++ b/windows/scripts/setup_desktop.ps1
@@ -88,7 +88,7 @@ $JreChecksums = @{
 
 # JAR settings
 $JarName = "litertlm-server.jar"
-$JarVersion = "0.11.16"
+$JarVersion = "0.12.0"
 $JarUrl = "https://github.com/DenisovAV/flutter_gemma/releases/download/v$JarVersion/$JarName"
 $JarChecksum = "914b9d2526b5673eb810a6080bbc760e537322aaee8e19b9cd49609319cfbdc8"
 $JarCacheDir = "$env:LOCALAPPDATA\flutter_gemma\jar"


### PR DESCRIPTION
Models:
- Add desktopUrl field for .litertlm format support
- Add supportsDesktop getter for platform filtering
- Add: FastVLM 0.5B, Qwen 2.5 0.5B, SmolLM 135M, Qwen3 0.6B
- Remove: TinyLlama, Hammer 2.1, Llama 3.2 (no litertlm)
- Merge gemma3_1B_litertlm into gemma3_1B
- Add desktopUrl to: gemma3n, gemma3_1B, gemma3_270M, qwen, phi4, functionGemma

UI:
- Filter models by supportsDesktop on desktop platforms

README:
- Update Model Capabilities table with new models
- Update Platform Support table (Desktop/Mobile/Web only)
- Update ModelType Reference
- Rename 'Gemma 3 Nano' to 'Gemma3n' for clarity

Scripts:
- Update JAR version to 0.12.0 in all desktop setup scripts