### PR TITLE
Fix Gemma3n desktop URLs - use native litertlm format

### DIFF
--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_element_parameter
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model.dart';
 import 'package:flutter_gemma/pigeon.g.dart';


### PR DESCRIPTION
Changed desktopUrl for Gemma3n E2B and E4B models from -Web.litertlm (WebGPU optimized) to regular .litertlm format compatible with native LiteRT-LM engine on desktop platforms.