### PR TITLE
Fix: cancel download not working

### DIFF
--- a/lib/mobile/smart_downloader.dart
+++ b/lib/mobile/smart_downloader.dart
@@ -184,8 +184,8 @@ class SmartDownloader {
     }
 
     // Configure FileDownloader and start download
-    _ensureConfigured(foreground).then((_) {
-      _downloadWithSmartRetry(
+    _ensureConfigured(foreground).then((_) async {
+      await _downloadWithSmartRetry(
         url: url,
         targetPath: targetPath,
         token: token,


### PR DESCRIPTION
## Problem

Cancelling a download via `CancelToken` had no effect — the download continued running even after cancellation was requested.

## Root Cause

In `SmartDownloader.downloadWithProgress()`, the `.then()` callback was not `async` and `_downloadWithSmartRetry()` was not awaited:

```dart
// Before (broken)
_ensureConfigured(foreground).then((_) {
  _downloadWithSmartRetry(...);  // unawaited!
}).whenComplete(() {
  cancellationListener?.cancel();  // fires immediately!
});
