### PR TITLE
Release 0.13.3: fix macOS SIGSEGV, iOS pod install, Windows >2GB, iOS simulator build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.13.3
+- **Fix macOS SIGSEGV (#219)**: Per-conversation mutex in gRPC server prevents `conversation.close()` racing with `sendMessageAsync` on a native thread → use-after-free in C++ fixed
+- **Fix macOS desktop Metal accelerator**: `setup_desktop.sh` now downloads `libLiteRtMetalAccelerator.dylib` from GitHub Release so GPU inference uses the Metal delegate instead of falling back to static C API
+- **Fix iOS pod install hanging (#220)**: Replaced `TensorFlowLiteSwift` (source pod — cloned entire TensorFlow repo) with direct `TensorFlowLiteC` C API in `EmbeddingModel.swift`
+- **Fix Windows >2 GB model error (#212)**: Clear error message when model file exceeds 2 GB on Windows (known upstream 32-bit stat() overflow in litertlm_jni.dll, google-ai-edge/LiteRT-LM#1494)
+- **Fix iOS arm64 simulator build (#216)**: Excluded arm64 from simulator archs to fix build on Apple Silicon Macs
+
 ## 0.13.2
 - **FileSource absolute paths**: Accept both Unix (`/path`) and Windows (`C:\path`) absolute paths in FileSource validation
 - **Package metadata**: Updated pubspec description to reflect current feature set (desktop, vision, audio, function calling, embeddings, on-device RAG)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM Android**: `com.google.ai.edge.litertlm:litertlm-android:0.10.0`
-- **Current Version**: 0.13.2
+- **Current Version**: 0.13.3
 
 ## Platform-Specific Setup
 

--- a/DOWNLOAD_TESTING.md
+++ b/DOWNLOAD_TESTING.md
@@ -1,0 +1,135 @@
+# Download Testing Guide
+
+Manual testing guide for large model downloads, including reproduction of issue #192
+(Android download timeout on slow connections).
+
+---
+
+## Issue #192: Android 9-minute timeout on slow connections
+
+### Root cause
+
+`background_downloader` uses Android WorkManager internally. `TaskRunner` has a hard
+9-minute internal timeout that applies to **all** workers, including foreground service workers.
+`foreground: true` does NOT bypass this limit — it only prevents the OS from killing the
+process due to battery optimization. On slow connections (< 2 Mbps), downloading a 2.6 GB
+model takes > 9 minutes → `TaskConnectionException: Task timed out`.
+
+### Why `allowPause` doesn't help
+
+HuggingFace CDN returns **weak ETags** (`W/"..."`). `background_downloader` refuses to resume
+a partial download if the ETag is weak (both Android and Desktop implementations check this).
+So even if allowPause were enabled for HF URLs, the resume would be rejected and the download
+would restart from byte 0 — making the situation worse.
+
+### Potential fix: `ParallelDownloadTask`
+
+`background_downloader` supports splitting a download into parallel chunks
+(`ParallelDownloadTask`). This bypasses the 9-minute timeout because each chunk is a
+separate task with its own timer. Requirements:
+
+- Server must support `Accept-Ranges: bytes` ✅ (HF CDN does)
+- Server must return `Content-Length` ✅ (HF CDN does after redirect)
+- Each chunk must complete within 9 minutes
+
+The CDN contract integration tests (Group A in `download_reliability_test.dart`) verify
+that these prerequisites are met for HuggingFace URLs.
+
+---
+
+## Reproducing issue #192
+
+### Requirements
+
+- Android device (physical)
+- Slow WiFi connection (< 2 Mbps sustained) or network throttling
+- Model > 2 GB (e.g., Gemma 4 E2B IT ~2.6 GB)
+- HuggingFace token (for gated models)
+
+### Steps
+
+1. Connect device to throttled network
+2. Run the download reliability tests:
+   ```bash
+   flutter test integration_test/download_reliability_test.dart \
+     -d <device_id> \
+     --dart-define=HF_TOKEN=<your_token> \
+     2>&1 | tee /tmp/download_test.log
+   ```
+3. Observe: download starts, reaches ~70–90%, then fails with:
+   ```
+   TaskConnectionException: Task timed out
+   ```
+4. Note: progress may reset to 0% and retry — this is the "silent restart" behavior
+   (Group B test B2 catches this regression)
+
+### Expected after fix
+
+Download completes or uses chunked parallel download that avoids the 9-minute limit.
+
+---
+
+## Network throttling
+
+### Android emulator (Linux/macOS host)
+
+Add traffic shaping via `adb shell` (requires root or emulator):
+```bash
+# Throttle to 2 Mbps
+adb shell tc qdisc add dev eth0 root tbf rate 2mbit burst 32kbit latency 400ms
+
+# Remove throttling
+adb shell tc qdisc del dev eth0 root
+```
+
+### Android device via WiFi router
+
+Use router QoS settings to limit bandwidth for the device's MAC address to 2 Mbps.
+
+### Android Developer Options (Android 8+)
+
+Some devices have "Simulated network conditions" in Developer Options (requires Wireless
+ADB). This option is device/manufacturer-specific.
+
+### macOS Network Link Conditioner
+
+Useful for testing on iOS/macOS. Install via Xcode → Additional Tools → Network Link
+Conditioner.prefPane. Set profile to "Edge" (240 Kbps) or create a custom profile.
+
+---
+
+## Running only CDN contract tests (CI-friendly, no device needed)
+
+Group A tests use only HEAD requests — no model download, no device required.
+They can run on any host with internet access:
+
+```bash
+# These tests can run on any Flutter-supported platform
+flutter test integration_test/download_reliability_test.dart \
+  --name "HuggingFace CDN contract" \
+  -d macos \
+  2>&1 | tee /tmp/cdn_contract_test.log
+```
+
+Expected output:
+```
+[CDN] Accept-Ranges: bytes
+[CDN] Content-Length: 297893376
+[CDN] Model size: 284.1 MB
+[CDN] ETag: W/"..."
+[CDN] ETag is WEAK
+[CDN] KNOWN LIMITATION (issue #192): weak ETag prevents background_downloader from
+      resuming interrupted downloads. timeout → fail → full restart from byte 0.
+```
+
+---
+
+## Test matrix
+
+| Test group | Android | iOS | macOS/Win/Linux | CI |
+|------------|---------|-----|-----------------|-----|
+| A: CDN contract | ✅ | ✅ | ✅ | ✅ |
+| B: Download behavior | ✅ | ✅ | ✅ | ⚠️ needs network |
+| C: Foreground service | ✅ | ❌ skip | ❌ skip | ❌ skip |
+
+CI note: Group A runs fast (HEAD-only, ~2s per test). Group B requires downloading 284 MB.

--- a/example/integration_test/desktop_crash_regression_test.dart
+++ b/example/integration_test/desktop_crash_regression_test.dart
@@ -26,6 +26,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
@@ -106,7 +107,7 @@ void main() {
         });
 
         final text = chunks.join();
-        print(
+        debugPrint(
             '[A1] Response: "${text.length > 80 ? text.substring(0, 80) : text}"');
         expect(text, isNotEmpty,
             reason: 'First message must produce a response. '
@@ -154,7 +155,7 @@ void main() {
           });
 
           final text = chunks.join();
-          print(
+          debugPrint(
               '[A2] Message $i response: "${text.length > 60 ? text.substring(0, 60) : text}"');
           expect(text, isNotEmpty,
               reason: 'Message $i must produce a response. '
@@ -184,7 +185,7 @@ void main() {
       ).fromFile(modelPath).install();
 
       for (var cycle = 1; cycle <= 3; cycle++) {
-        print('[B1] Cycle $cycle/3 — opening model...');
+        debugPrint('[B1] Cycle $cycle/3 — opening model...');
         final model = await FlutterGemma.getActiveModel(
           maxTokens: 128,
           preferredBackend: PreferredBackend.gpu,
@@ -206,13 +207,13 @@ void main() {
           });
 
           final text = chunks.join();
-          print(
+          debugPrint(
               '[B1] Cycle $cycle response: "${text.length > 60 ? text.substring(0, 60) : text}"');
           expect(text, isNotEmpty,
               reason: 'Cycle $cycle must produce a response.');
         } finally {
           await model.close();
-          print('[B1] Cycle $cycle/3 — model closed');
+          debugPrint('[B1] Cycle $cycle/3 — model closed');
         }
 
         // Brief pause between cycles to allow gRPC teardown.
@@ -239,7 +240,7 @@ void main() {
       ).fromFile(modelPath).install();
 
       // First request: close the model after receiving just the first chunk.
-      print('[B2] Starting first request (will disconnect mid-stream)...');
+      debugPrint('[B2] Starting first request (will disconnect mid-stream)...');
       final model1 = await FlutterGemma.getActiveModel(
         maxTokens: 512,
         preferredBackend: PreferredBackend.gpu,
@@ -261,7 +262,7 @@ void main() {
                 chunksReceived++;
                 if (chunksReceived >= 3) {
                   // Disconnect mid-stream by closing the model.
-                  print(
+                  debugPrint(
                       '[B2] Disconnecting mid-stream after $chunksReceived chunks...');
                   break;
                 }
@@ -274,13 +275,13 @@ void main() {
       });
 
       await model1.close();
-      print('[B2] model1 closed (mid-stream disconnect done)');
+      debugPrint('[B2] model1 closed (mid-stream disconnect done)');
 
       // Give native code time to race (makes Bug B more likely to manifest).
       await Future<void>.delayed(const Duration(seconds: 2));
 
       // Second request: server must still be alive.
-      print(
+      debugPrint(
           '[B2] Starting second request (verifying server is still alive)...');
       final model2 = await FlutterGemma.getActiveModel(
         maxTokens: 128,
@@ -303,7 +304,7 @@ void main() {
         });
 
         final text = chunks.join();
-        print(
+        debugPrint(
             '[B2] Second response: "${text.length > 80 ? text.substring(0, 80) : text}"');
         expect(text, isNotEmpty,
             reason: 'Server must still respond after mid-stream disconnect. '
@@ -369,7 +370,7 @@ void main() {
         });
 
         final text = chunks.join();
-        print(
+        debugPrint(
             '[C1] Qwen response: "${text.length > 80 ? text.substring(0, 80) : text}"');
         expect(text, isNotEmpty,
             reason: 'First message on Qwen 2.5 must complete without SIGSEGV. '
@@ -417,7 +418,7 @@ void main() {
           });
 
           final text = chunks.join();
-          print(
+          debugPrint(
               '[C2] Msg $i: "${text.length > 60 ? text.substring(0, 60) : text}"');
           expect(text, isNotEmpty,
               reason:
@@ -456,7 +457,7 @@ void main() {
           'This should be at least 2000 words.';
 
       for (var attempt = 1; attempt <= 3; attempt++) {
-        print(
+        debugPrint(
             '[C3] Attempt $attempt/3 — starting generation then disconnecting during prefill...');
 
         final model1 = await FlutterGemma.getActiveModel(
@@ -489,7 +490,7 @@ void main() {
         // so this hits squarely in the middle of prefill execution.
         await Future<void>.delayed(const Duration(seconds: 2));
         await model1.close();
-        print(
+        debugPrint(
             '[C3] Attempt $attempt: model1 closed (streamStarted=$streamStarted)');
 
         // Wait for the stream future to settle.
@@ -500,7 +501,8 @@ void main() {
 
         // If server crashed (SIGSEGV), the next model creation or request
         // will fail / hang. This is the observable test signal.
-        print('[C3] Attempt $attempt — verifying server is still alive...');
+        debugPrint(
+            '[C3] Attempt $attempt — verifying server is still alive...');
         final model2 = await FlutterGemma.getActiveModel(
           maxTokens: 64,
           preferredBackend: PreferredBackend.gpu,
@@ -520,7 +522,7 @@ void main() {
           });
 
           final text = chunks.join();
-          print(
+          debugPrint(
               '[C3] Attempt $attempt alive-check: "${text.length > 50 ? text.substring(0, 50) : text}"');
           expect(text, isNotEmpty,
               reason:

--- a/example/integration_test/desktop_crash_regression_test.dart
+++ b/example/integration_test/desktop_crash_regression_test.dart
@@ -1,0 +1,431 @@
+// Regression tests for macOS desktop SIGSEGV crashes (issue #219).
+//
+// Bug A — Missing Metal accelerator (deterministic first-message crash):
+//   setup_desktop.sh does not download libLiteRtMetalAccelerator.dylib.
+//   LiteRT-LM falls through Metal → WebGPU → CPU sampler fallback.
+//   GPU execution + CPU sampler mismatch → null tensor buffer → SIGSEGV.
+//
+// Bug B — gRPC callbackFlow race (non-deterministic crash after disconnect):
+//   awaitClose { } is empty in chat()/chatWithImage()/chatWithAudio().
+//   When the Dart gRPC client disconnects, the coroutine exits immediately,
+//   but native sendMessageAsync still holds MessageCallback → SIGSEGV in
+//   jni_CallVoidMethodV.
+//
+// TDD order: run these tests BEFORE applying fixes to confirm they fail,
+// then apply fixes and confirm they pass.
+//
+// Prerequisites:
+//   Copy a .litertlm model to the app sandbox container:
+//   cp ~/Downloads/gemma-3n-E2B-it-int4.litertlm \
+//      ~/Library/Containers/dev.flutterberlin.flutterGemmaExample55/Data/Documents/
+//
+// Run:
+//   cd example
+//   flutter test integration_test/desktop_crash_regression_test.dart -d macos \
+//     2>&1 | tee /tmp/desktop_crash_regression.log
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+// Default model for groups A/B. Must be pre-installed in the sandbox.
+const _modelFileName = 'gemma-3n-E2B-it-int4.litertlm';
+
+// Qwen model that triggered the original issue #219 crash.
+// Use for group C (issue reproduction) tests.
+const _qwenModelFileName =
+    'Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv4096.litertlm';
+
+String _resolveModelPath([String? fileName]) {
+  final home = Platform.environment['HOME'] ?? '';
+  return '$home/Documents/${fileName ?? _modelFileName}';
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late String modelPath;
+
+  setUpAll(() {
+    if (!Platform.isMacOS) {
+      fail(
+          'These tests target macOS desktop only. Skipping on ${Platform.operatingSystem}.');
+    }
+    modelPath = _resolveModelPath();
+    if (!File(modelPath).existsSync()) {
+      fail(
+        'Model not found: $modelPath\n'
+        'Copy a .litertlm model to the sandbox:\n'
+        '  cp ~/Downloads/$_modelFileName \\\n'
+        '     ~/Library/Containers/dev.flutterberlin.flutterGemmaExample55/Data/Documents/',
+      );
+    }
+  });
+
+  // ──────────────────────────────────────────────────
+  // Group A: Metal accelerator (Bug A)
+  // ──────────────────────────────────────────────────
+  group('Metal accelerator (Bug A)', () {
+    // A1: No "WebGPU sampler not available" warning in server logs.
+    //     If libLiteRtMetalAccelerator.dylib is missing, LiteRT-LM falls to
+    //     WebGPU → CPU, and logs this warning. Fix: dylib must be present.
+    //     NOTE: We cannot intercept server stderr from Dart; this test instead
+    //     verifies that initialization + first message succeeds without crash,
+    //     which is the observable symptom of the missing dylib.
+    testWidgets(
+        'A1: first message completes without crash (Metal accelerator present)',
+        (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(modelPath).install();
+
+      expect(FlutterGemma.hasActiveModel(), isTrue);
+
+      final model = await FlutterGemma.getActiveModel(
+        maxTokens: 256,
+        preferredBackend: PreferredBackend.gpu,
+      );
+
+      try {
+        final chat = await model.createChat();
+        await chat
+            .addQueryChunk(const Message(text: 'Say "hello"', isUser: true));
+
+        final chunks = <String>[];
+        await tester.runAsync(() async {
+          await for (final response in chat.generateChatResponseAsync()) {
+            if (response is TextResponse) {
+              chunks.add(response.token);
+            }
+          }
+        });
+
+        final text = chunks.join();
+        print(
+            '[A1] Response: "${text.length > 80 ? text.substring(0, 80) : text}"');
+        expect(text, isNotEmpty,
+            reason: 'First message must produce a response. '
+                'SIGSEGV here = Metal accelerator missing (Bug A).');
+      } finally {
+        await model.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 5)));
+
+    // A2: Three consecutive messages in the same chat session do not crash.
+    //     Without Metal accelerator, the first decode already crashes.
+    //     This test ensures all three complete, giving extra signal that GPU
+    //     execution is fully stable.
+    testWidgets('A2: three consecutive messages complete without crash',
+        (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(modelPath).install();
+
+      final model = await FlutterGemma.getActiveModel(
+        maxTokens: 256,
+        preferredBackend: PreferredBackend.gpu,
+      );
+
+      try {
+        final chat = await model.createChat();
+
+        for (var i = 1; i <= 3; i++) {
+          await chat.addQueryChunk(
+            Message(
+                text: 'Message $i: reply with just the number $i',
+                isUser: true),
+          );
+
+          final chunks = <String>[];
+          await tester.runAsync(() async {
+            await for (final response in chat.generateChatResponseAsync()) {
+              if (response is TextResponse) {
+                chunks.add(response.token);
+              }
+            }
+          });
+
+          final text = chunks.join();
+          print(
+              '[A2] Message $i response: "${text.length > 60 ? text.substring(0, 60) : text}"');
+          expect(text, isNotEmpty,
+              reason: 'Message $i must produce a response. '
+                  'SIGSEGV here = Metal accelerator missing (Bug A).');
+        }
+      } finally {
+        await model.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 10)));
+  });
+
+  // ──────────────────────────────────────────────────
+  // Group B: callbackFlow race condition (Bug B)
+  // ──────────────────────────────────────────────────
+  group('callbackFlow race condition (Bug B)', () {
+    // B1: Sequential chat sessions — open model, chat, close, repeat 3x.
+    //     The non-deterministic crash (Bug B) most often manifests when
+    //     model.close() races with an ongoing sendMessageAsync. Repeating
+    //     close/reopen increases the chance of triggering the race.
+    testWidgets('B1: sequential open/chat/close cycles do not crash the server',
+        (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(modelPath).install();
+
+      for (var cycle = 1; cycle <= 3; cycle++) {
+        print('[B1] Cycle $cycle/3 — opening model...');
+        final model = await FlutterGemma.getActiveModel(
+          maxTokens: 128,
+          preferredBackend: PreferredBackend.gpu,
+        );
+
+        try {
+          final chat = await model.createChat();
+          await chat.addQueryChunk(
+            Message(text: 'Cycle $cycle: say "ok"', isUser: true),
+          );
+
+          final chunks = <String>[];
+          await tester.runAsync(() async {
+            await for (final response in chat.generateChatResponseAsync()) {
+              if (response is TextResponse) {
+                chunks.add(response.token);
+              }
+            }
+          });
+
+          final text = chunks.join();
+          print(
+              '[B1] Cycle $cycle response: "${text.length > 60 ? text.substring(0, 60) : text}"');
+          expect(text, isNotEmpty,
+              reason: 'Cycle $cycle must produce a response.');
+        } finally {
+          await model.close();
+          print('[B1] Cycle $cycle/3 — model closed');
+        }
+
+        // Brief pause between cycles to allow gRPC teardown.
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      }
+    }, timeout: const Timeout(Duration(minutes: 15)));
+
+    // B2: Client disconnects while streaming — close model mid-response.
+    //     model.close() triggers gRPC channel teardown which cancels the
+    //     callbackFlow coroutine. Without the fix, the empty awaitClose { }
+    //     lets the coroutine exit while native sendMessageAsync is still
+    //     running → SIGSEGV in jni_CallVoidMethodV.
+    //     After the fix, awaitClose calls cancelProcess() and waits up to 5s.
+    //
+    //     Success criterion: after the mid-stream close, a NEW model instance
+    //     can be created and a full response received (server is still alive).
+    testWidgets('B2: mid-stream disconnect does not crash server',
+        (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(modelPath).install();
+
+      // First request: close the model after receiving just the first chunk.
+      print('[B2] Starting first request (will disconnect mid-stream)...');
+      final model1 = await FlutterGemma.getActiveModel(
+        maxTokens: 512,
+        preferredBackend: PreferredBackend.gpu,
+      );
+
+      await model1.createChat().then((chat) async {
+        await chat.addQueryChunk(
+          const Message(
+            text: 'Write a very long story about a dragon. At least 500 words.',
+            isUser: true,
+          ),
+        );
+
+        var chunksReceived = 0;
+        try {
+          await tester.runAsync(() async {
+            await for (final response in chat.generateChatResponseAsync()) {
+              if (response is TextResponse && response.token.isNotEmpty) {
+                chunksReceived++;
+                if (chunksReceived >= 3) {
+                  // Disconnect mid-stream by closing the model.
+                  print(
+                      '[B2] Disconnecting mid-stream after $chunksReceived chunks...');
+                  break;
+                }
+              }
+            }
+          });
+        } catch (_) {
+          // Expected: stream may throw when we break out.
+        }
+      });
+
+      await model1.close();
+      print('[B2] model1 closed (mid-stream disconnect done)');
+
+      // Give native code time to race (makes Bug B more likely to manifest).
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      // Second request: server must still be alive.
+      print(
+          '[B2] Starting second request (verifying server is still alive)...');
+      final model2 = await FlutterGemma.getActiveModel(
+        maxTokens: 128,
+        preferredBackend: PreferredBackend.gpu,
+      );
+
+      try {
+        final chat2 = await model2.createChat();
+        await chat2.addQueryChunk(
+          const Message(text: 'Say "alive"', isUser: true),
+        );
+
+        final chunks = <String>[];
+        await tester.runAsync(() async {
+          await for (final response in chat2.generateChatResponseAsync()) {
+            if (response is TextResponse) {
+              chunks.add(response.token);
+            }
+          }
+        });
+
+        final text = chunks.join();
+        print(
+            '[B2] Second response: "${text.length > 80 ? text.substring(0, 80) : text}"');
+        expect(text, isNotEmpty,
+            reason: 'Server must still respond after mid-stream disconnect. '
+                'If SIGSEGV occurred in the first request, this will time out or throw. '
+                'See issue #219 (Bug B: empty awaitClose race condition).');
+      } finally {
+        await model2.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 10)));
+  });
+
+  // ──────────────────────────────────────────────────
+  // Group C: Issue #219 reproduction with Qwen 2.5
+  // Uses the exact model that triggered the original crash.
+  // ──────────────────────────────────────────────────
+  group('Issue #219 reproduction (Qwen 2.5)', () {
+    late String qwenModelPath;
+
+    setUpAll(() {
+      qwenModelPath = _resolveModelPath(_qwenModelFileName);
+      if (!File(qwenModelPath).existsSync()) {
+        fail(
+          'Qwen model not found: $qwenModelPath\n'
+          'Download from HuggingFace:\n'
+          '  curl -L "https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct/resolve/main/$_qwenModelFileName" \\\n'
+          '    -o ~/Library/Containers/dev.flutterberlin.flutterGemmaExample55/Data/Documents/$_qwenModelFileName',
+        );
+      }
+    });
+
+    // C1: First message on Qwen 2.5 does not crash (original issue #219 repro).
+    //     Before fixes: SIGSEGV in nativeSendMessageAsync on first decode.
+    //     Stack: jni_CallVoidMethodV → nativeSendMessageAsync → Tasks::Decode
+    //     After Fix B: awaitClose waits for native code → no dangling callback.
+    testWidgets('C1: first message on Qwen 2.5 does not crash', (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.qwen,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(qwenModelPath).install();
+
+      expect(FlutterGemma.hasActiveModel(), isTrue);
+
+      final model = await FlutterGemma.getActiveModel(
+        maxTokens: 2048,
+        preferredBackend: PreferredBackend.gpu,
+      );
+
+      try {
+        final chat = await model.createChat();
+        await chat.addQueryChunk(
+          const Message(text: 'Say "hello"', isUser: true),
+        );
+
+        final chunks = <String>[];
+        await tester.runAsync(() async {
+          await for (final response in chat.generateChatResponseAsync()) {
+            if (response is TextResponse) {
+              chunks.add(response.token);
+            }
+          }
+        });
+
+        final text = chunks.join();
+        print(
+            '[C1] Qwen response: "${text.length > 80 ? text.substring(0, 80) : text}"');
+        expect(text, isNotEmpty,
+            reason: 'First message on Qwen 2.5 must complete without SIGSEGV. '
+                'Original crash: jni_CallVoidMethodV → nativeSendMessageAsync '
+                '→ Tasks::Decode. See issue #219.');
+      } finally {
+        await model.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 5)));
+
+    // C2: Several messages on Qwen 2.5 do not crash.
+    //     The original reporter said crash happens "after some messages".
+    //     This test sends 5 messages to increase crash probability.
+    testWidgets('C2: five consecutive messages on Qwen 2.5 do not crash',
+        (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.qwen,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(qwenModelPath).install();
+
+      final model = await FlutterGemma.getActiveModel(
+        maxTokens: 2048,
+        preferredBackend: PreferredBackend.gpu,
+      );
+
+      try {
+        final chat = await model.createChat();
+
+        for (var i = 1; i <= 5; i++) {
+          await chat.addQueryChunk(
+            Message(
+                text: 'Message $i: reply with just the number $i',
+                isUser: true),
+          );
+
+          final chunks = <String>[];
+          await tester.runAsync(() async {
+            await for (final response in chat.generateChatResponseAsync()) {
+              if (response is TextResponse) {
+                chunks.add(response.token);
+              }
+            }
+          });
+
+          final text = chunks.join();
+          print(
+              '[C2] Msg $i: "${text.length > 60 ? text.substring(0, 60) : text}"');
+          expect(text, isNotEmpty,
+              reason:
+                  'Message $i on Qwen 2.5 must complete. SIGSEGV here = issue #219 not fixed.');
+        }
+      } finally {
+        await model.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 10)));
+  });
+}

--- a/example/integration_test/desktop_crash_regression_test.dart
+++ b/example/integration_test/desktop_crash_regression_test.dart
@@ -427,5 +427,112 @@ void main() {
         await model.close();
       }
     }, timeout: const Timeout(Duration(minutes: 10)));
+
+    // C3: Disconnect during prefill — the most reliable way to trigger Bug B.
+    //     Prefill takes ~1-2s on Qwen 2.5. We start generation and close the
+    //     model after a short delay, before the first token arrives.
+    //     At that moment native sendMessageAsync is guaranteed to be running.
+    //     Without Fix B: awaitClose { } exits immediately → SIGSEGV.
+    //     After Fix B: cancelProcess() + done.await() → clean shutdown.
+    //
+    //     Success: a subsequent request on a NEW model instance works,
+    //     proving the server did not crash.
+    testWidgets('C3: disconnect during prefill does not crash server',
+        (tester) async {
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.qwen,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(qwenModelPath).install();
+
+      // Long prompt forces a slow prefill (~1-2s), giving us a reliable window
+      // to disconnect before the first decode token arrives.
+      const longPrompt =
+          'Please write a very detailed essay about the history of computing, '
+          'starting from Charles Babbage and Ada Lovelace, through ENIAC, '
+          'transistors, integrated circuits, personal computers, the internet, '
+          'smartphones, and modern AI. Include technical details about each era. '
+          'This should be at least 2000 words.';
+
+      for (var attempt = 1; attempt <= 3; attempt++) {
+        print(
+            '[C3] Attempt $attempt/3 — starting generation then disconnecting during prefill...');
+
+        final model1 = await FlutterGemma.getActiveModel(
+          maxTokens: 2048,
+          preferredBackend: PreferredBackend.gpu,
+        );
+
+        // Start generation and close immediately — race is guaranteed if
+        // prefill hasn't finished yet (typically ~1s for this prompt).
+        bool streamStarted = false;
+        final streamFuture = tester.runAsync(() async {
+          try {
+            final chat = await model1.createChat();
+            await chat.addQueryChunk(
+              const Message(text: longPrompt, isUser: true),
+            );
+            await for (final response in chat.generateChatResponseAsync()) {
+              if (response is TextResponse && response.token.isNotEmpty) {
+                streamStarted = true;
+                // First token received — stop consuming, trigger disconnect.
+                break;
+              }
+            }
+          } catch (_) {
+            // Expected: stream throws when model is closed mid-generation.
+          }
+        });
+
+        // Close the model 2s after starting — prefill takes ~4s on this prompt,
+        // so this hits squarely in the middle of prefill execution.
+        await Future<void>.delayed(const Duration(seconds: 2));
+        await model1.close();
+        print(
+            '[C3] Attempt $attempt: model1 closed (streamStarted=$streamStarted)');
+
+        // Wait for the stream future to settle.
+        await streamFuture;
+
+        // Give native code time to invoke the callback on a dead coroutine.
+        await Future<void>.delayed(const Duration(seconds: 1));
+
+        // If server crashed (SIGSEGV), the next model creation or request
+        // will fail / hang. This is the observable test signal.
+        print('[C3] Attempt $attempt — verifying server is still alive...');
+        final model2 = await FlutterGemma.getActiveModel(
+          maxTokens: 64,
+          preferredBackend: PreferredBackend.gpu,
+        );
+
+        try {
+          final chat2 = await model2.createChat();
+          await chat2.addQueryChunk(
+            const Message(text: 'Say "ok"', isUser: true),
+          );
+
+          final chunks = <String>[];
+          await tester.runAsync(() async {
+            await for (final response in chat2.generateChatResponseAsync()) {
+              if (response is TextResponse) chunks.add(response.token);
+            }
+          });
+
+          final text = chunks.join();
+          print(
+              '[C3] Attempt $attempt alive-check: "${text.length > 50 ? text.substring(0, 50) : text}"');
+          expect(text, isNotEmpty,
+              reason:
+                  'Server crashed after attempt $attempt disconnect during prefill. '
+                  'Bug B: empty awaitClose let coroutine exit while native code ran. '
+                  'See issue #219.');
+        } finally {
+          await model2.close();
+        }
+
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      }
+    }, timeout: const Timeout(Duration(minutes: 15)));
   });
 }

--- a/example/integration_test/download_reliability_test.dart
+++ b/example/integration_test/download_reliability_test.dart
@@ -20,6 +20,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
@@ -53,7 +54,7 @@ void main() {
         (tester) async {
       final response = await _headFollowingRedirects(client, _smallModelUrl);
       final acceptRanges = response.headers['accept-ranges'];
-      print('[CDN] Accept-Ranges: $acceptRanges');
+      debugPrint('[CDN] Accept-Ranges: $acceptRanges');
       expect(acceptRanges, equals('bytes'),
           reason: 'ParallelDownloadTask requires Range request support. '
               'If this fails, chunked download cannot be used with HuggingFace URLs.');
@@ -65,17 +66,17 @@ void main() {
         (tester) async {
       final response = await _headFollowingRedirects(client, _smallModelUrl);
       final contentLength = response.headers['content-length'];
-      print('[CDN] Content-Length: $contentLength');
+      debugPrint('[CDN] Content-Length: $contentLength');
 
       // Document result — don't hard-fail since CDN nodes may vary.
       // If null → ParallelDownloadTask will fail with HuggingFace URLs.
       if (contentLength == null) {
-        print('[CDN] WARNING: Content-Length missing after redirects. '
+        debugPrint('[CDN] WARNING: Content-Length missing after redirects. '
             'ParallelDownloadTask will NOT work with this HF URL. '
             'Workaround: pass Known-Content-Length header manually.');
       } else {
         final bytes = int.tryParse(contentLength) ?? 0;
-        print(
+        debugPrint(
             '[CDN] Model size: ${(bytes / 1024 / 1024).toStringAsFixed(1)} MB');
         expect(bytes, greaterThan(0),
             reason: 'Content-Length must be a positive integer');
@@ -90,20 +91,20 @@ void main() {
         (tester) async {
       final response = await _headFollowingRedirects(client, _smallModelUrl);
       final etag = response.headers['etag'];
-      print('[CDN] ETag: $etag');
+      debugPrint('[CDN] ETag: $etag');
 
       final isWeak = etag?.startsWith('W/') ?? false;
       final isStrong = etag != null && !isWeak;
-      print(
+      debugPrint(
           '[CDN] ETag is ${isWeak ? "WEAK" : isStrong ? "STRONG" : "ABSENT"}');
 
       if (isWeak) {
-        print('[CDN] KNOWN LIMITATION (issue #192): weak ETag prevents '
+        debugPrint('[CDN] KNOWN LIMITATION (issue #192): weak ETag prevents '
             'background_downloader from resuming interrupted downloads. '
             'timeout → fail → full restart from byte 0. '
             'Fix: wait for HF to switch to strong ETags, or use ParallelDownloadTask.');
       } else if (isStrong) {
-        print(
+        debugPrint(
             '[CDN] Strong ETag detected — allowPause: true fix is NOW viable! '
             'Consider re-enabling pause/resume for HuggingFace URLs.');
       }
@@ -140,7 +141,7 @@ void main() {
         modelType: ModelType.functionGemma,
         fileType: ModelFileType.task,
       ).fromNetwork(_smallModelUrl).withProgress((p) {
-        print('[Download] Progress: $p%');
+        debugPrint('[Download] Progress: $p%');
         progressValues.add(p);
       }).install();
 
@@ -173,7 +174,7 @@ void main() {
         if (p > 0 && p < maxProgress - 5) {
           progressReset = true;
           resetFromPercent = maxProgress;
-          print(
+          debugPrint(
               '[Download] Progress reset detected: was $maxProgress%, now $p%');
         }
         if (p > maxProgress) maxProgress = p;
@@ -234,7 +235,7 @@ void main() {
           fileType: ModelFileType.task,
         )
             .fromNetwork(_smallModelUrl, foreground: true)
-            .withProgress((p) => print('[Foreground] Progress: $p%'))
+            .withProgress((p) => debugPrint('[Foreground] Progress: $p%'))
             .install();
 
         expect(await FlutterGemma.isModelInstalled(_smallModelFilename), isTrue,
@@ -259,7 +260,7 @@ Future<http.Response> _headFollowingRedirects(
 
   while (hops < maxHops) {
     final response = await client.head(uri);
-    print('[CDN] HEAD $uri → ${response.statusCode}');
+    debugPrint('[CDN] HEAD $uri → ${response.statusCode}');
 
     if (response.statusCode == 301 ||
         response.statusCode == 302 ||
@@ -270,7 +271,7 @@ Future<http.Response> _headFollowingRedirects(
       uri = uri.resolve(location);
       hops++;
     } else {
-      print('[CDN] Final URL after $hops redirects: $uri');
+      debugPrint('[CDN] Final URL after $hops redirects: $uri');
       return response;
     }
   }

--- a/example/integration_test/download_reliability_test.dart
+++ b/example/integration_test/download_reliability_test.dart
@@ -1,0 +1,281 @@
+// Integration tests: download reliability for issue #192.
+//
+// Tests are grouped into three categories:
+//
+// A) CDN Contract Tests — fast HEAD-only checks, no large downloads, CI-friendly.
+//    Verify HuggingFace CDN headers needed for future fixes (ParallelDownloadTask, allowPause).
+//    Run on any platform.
+//
+// B) Download Behavior — real download of a small (284 MB) public model.
+//    Verify progress reporting, monotonic progress (no silent restarts), and cancel cleanup.
+//    Require a network connection. Run on Android, iOS, desktop.
+//
+// C) Foreground Service (Android only) — documents that foreground:true starts the service
+//    correctly (TaskStatus.running received). Does not fix the 9-min TaskRunner timeout.
+//
+// Run:
+//   flutter test integration_test/download_reliability_test.dart -d <device>
+//
+// See DOWNLOAD_TESTING.md for manual slow-network repro of issue #192.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+import 'inference_test_helpers.dart';
+
+// Small public model — 284 MB, no auth token required.
+const _smallModelUrl =
+    'https://huggingface.co/sasha-denisov/function-gemma-270M-it/resolve/main/functiongemma-270M-it.task';
+const _smallModelFilename = 'functiongemma-270M-it.task';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // ─────────────────────────────────────────────
+  // Group A: HuggingFace CDN contract tests
+  // Fast HEAD-only, no model download, CI-friendly.
+  // ─────────────────────────────────────────────
+  group('HuggingFace CDN contract', () {
+    late http.Client client;
+
+    setUp(() {
+      client = http.Client();
+    });
+
+    tearDown(() {
+      client.close();
+    });
+
+    // A1: Range requests supported → prerequisite for ParallelDownloadTask and allowPause resume.
+    testWidgets('HF CDN supports byte range requests (Accept-Ranges: bytes)',
+        (tester) async {
+      final response = await _headFollowingRedirects(client, _smallModelUrl);
+      final acceptRanges = response.headers['accept-ranges'];
+      print('[CDN] Accept-Ranges: $acceptRanges');
+      expect(acceptRanges, equals('bytes'),
+          reason: 'ParallelDownloadTask requires Range request support. '
+              'If this fails, chunked download cannot be used with HuggingFace URLs.');
+    }, timeout: const Timeout(Duration(minutes: 2)));
+
+    // A2: Content-Length after redirect → required for ParallelDownloadTask chunk size calculation.
+    // background_downloader throws IllegalStateException if Content-Length is missing.
+    testWidgets('HF CDN returns Content-Length after following redirects',
+        (tester) async {
+      final response = await _headFollowingRedirects(client, _smallModelUrl);
+      final contentLength = response.headers['content-length'];
+      print('[CDN] Content-Length: $contentLength');
+
+      // Document result — don't hard-fail since CDN nodes may vary.
+      // If null → ParallelDownloadTask will fail with HuggingFace URLs.
+      if (contentLength == null) {
+        print('[CDN] WARNING: Content-Length missing after redirects. '
+            'ParallelDownloadTask will NOT work with this HF URL. '
+            'Workaround: pass Known-Content-Length header manually.');
+      } else {
+        final bytes = int.tryParse(contentLength) ?? 0;
+        print(
+            '[CDN] Model size: ${(bytes / 1024 / 1024).toStringAsFixed(1)} MB');
+        expect(bytes, greaterThan(0),
+            reason: 'Content-Length must be a positive integer');
+      }
+    }, timeout: const Timeout(Duration(minutes: 2)));
+
+    // A3: ETag type — documents whether HF uses weak or strong ETags.
+    // background_downloader refuses to resume if ETag is weak (W/"...").
+    // If this ever changes to strong ETag, allowPause: true becomes viable for HF.
+    testWidgets(
+        'HF CDN ETag type is documented (weak blocks allowPause resume)',
+        (tester) async {
+      final response = await _headFollowingRedirects(client, _smallModelUrl);
+      final etag = response.headers['etag'];
+      print('[CDN] ETag: $etag');
+
+      final isWeak = etag?.startsWith('W/') ?? false;
+      final isStrong = etag != null && !isWeak;
+      print(
+          '[CDN] ETag is ${isWeak ? "WEAK" : isStrong ? "STRONG" : "ABSENT"}');
+
+      if (isWeak) {
+        print('[CDN] KNOWN LIMITATION (issue #192): weak ETag prevents '
+            'background_downloader from resuming interrupted downloads. '
+            'timeout → fail → full restart from byte 0. '
+            'Fix: wait for HF to switch to strong ETags, or use ParallelDownloadTask.');
+      } else if (isStrong) {
+        print(
+            '[CDN] Strong ETag detected — allowPause: true fix is NOW viable! '
+            'Consider re-enabling pause/resume for HuggingFace URLs.');
+      }
+
+      // Always passes — this test documents behavior, not enforces it.
+      // Change this expect to isStrong when we want to assert the fix is needed.
+      expect(etag, isNotNull, reason: 'ETag header should always be present');
+    }, timeout: const Timeout(Duration(minutes: 2)));
+  });
+
+  // ─────────────────────────────────────────────
+  // Group B: Download behavior
+  // Real download of 284 MB model. Requires network.
+  // ─────────────────────────────────────────────
+  group('Download behavior', () {
+    setUpAll(() async {
+      await FlutterGemma.initialize();
+    });
+
+    tearDown(() async {
+      // Clean up after each test to avoid state pollution.
+      try {
+        if (await FlutterGemma.isModelInstalled(_smallModelFilename)) {
+          await FlutterGemma.uninstallModel(_smallModelFilename);
+        }
+      } catch (_) {}
+    });
+
+    // B1: Download completes and fires progress callbacks.
+    testWidgets('download completes and reports progress', (tester) async {
+      final progressValues = <int>[];
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.functionGemma,
+        fileType: ModelFileType.task,
+      ).fromNetwork(_smallModelUrl).withProgress((p) {
+        print('[Download] Progress: $p%');
+        progressValues.add(p);
+      }).install();
+
+      expect(FlutterGemma.hasActiveModel(), isTrue,
+          reason: 'Active model should be set after install');
+      expect(await FlutterGemma.isModelInstalled(_smallModelFilename), isTrue,
+          reason: 'Model file should exist on disk');
+      expect(progressValues, isNotEmpty,
+          reason: 'Progress callbacks should fire during download');
+      expect(progressValues.last, equals(100),
+          reason: 'Final progress should be 100%');
+    }, timeout: const Timeout(Duration(minutes: 15)));
+
+    // B2: Progress is monotonically non-decreasing.
+    // A silent restart (e.g., from weak ETag mismatch or retry) causes progress to
+    // reset to 0 mid-download. This test catches such regressions.
+    // NOTE: On slow connections with issue #192 active, this test may time out before
+    // the download completes — that is the expected failure mode.
+    testWidgets('download progress does not reset to zero mid-download',
+        (tester) async {
+      int maxProgress = 0;
+      bool progressReset = false;
+      int resetFromPercent = 0;
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.functionGemma,
+        fileType: ModelFileType.task,
+      ).fromNetwork(_smallModelUrl).withProgress((p) {
+        // Allow small backwards movement (±2%) for rounding, but not a full reset.
+        if (p > 0 && p < maxProgress - 5) {
+          progressReset = true;
+          resetFromPercent = maxProgress;
+          print(
+              '[Download] Progress reset detected: was $maxProgress%, now $p%');
+        }
+        if (p > maxProgress) maxProgress = p;
+      }).install();
+
+      expect(progressReset, isFalse,
+          reason: 'Progress reset from $resetFromPercent% to near 0 — '
+              'indicates a silent download restart. '
+              'Possible cause: weak ETag mismatch on resume, or network retry. '
+              'See issue #192.');
+    }, timeout: const Timeout(Duration(minutes: 15)));
+
+    // B3: Cancelling (uninstall after partial) cleans up properly.
+    // We install the model fully, then uninstall — verifies cleanup works.
+    // Full cancel-mid-download is not testable without a public cancel API.
+    testWidgets('uninstalled model is removed from disk', (tester) async {
+      await FlutterGemma.installModel(
+        modelType: ModelType.functionGemma,
+        fileType: ModelFileType.task,
+      ).fromNetwork(_smallModelUrl).install();
+
+      expect(await FlutterGemma.isModelInstalled(_smallModelFilename), isTrue);
+
+      await FlutterGemma.uninstallModel(_smallModelFilename);
+
+      expect(await FlutterGemma.isModelInstalled(_smallModelFilename), isFalse,
+          reason: 'Model file should be removed after uninstall');
+    }, timeout: const Timeout(Duration(minutes: 15)));
+  });
+
+  // ─────────────────────────────────────────────
+  // Group C: Foreground service (Android only)
+  // ─────────────────────────────────────────────
+  group('Foreground service', () {
+    setUpAll(() async {
+      if (!Platform.isAndroid) return;
+      await FlutterGemma.initialize();
+    });
+
+    tearDown(() async {
+      if (!Platform.isAndroid) return;
+      try {
+        if (await FlutterGemma.isModelInstalled(_smallModelFilename)) {
+          await FlutterGemma.uninstallModel(_smallModelFilename);
+        }
+      } catch (_) {}
+    });
+
+    // C1: foreground: true starts the download and reaches running status.
+    // Does NOT verify that the download completes on slow connections — that is
+    // the known bug (issue #192): TaskRunner 9-min timeout kills the task.
+    // See DOWNLOAD_TESTING.md for manual slow-network repro.
+    testWidgets(
+      'foreground: true download starts and completes on fast network',
+      (tester) async {
+        await FlutterGemma.installModel(
+          modelType: ModelType.functionGemma,
+          fileType: ModelFileType.task,
+        )
+            .fromNetwork(_smallModelUrl, foreground: true)
+            .withProgress((p) => print('[Foreground] Progress: $p%'))
+            .install();
+
+        expect(await FlutterGemma.isModelInstalled(_smallModelFilename), isTrue,
+            reason:
+                'foreground: true download should complete on fast network. '
+                'On slow connections (< 2 Mbps for 2.6 GB), this times out — '
+                'see issue #192 for the known bug.');
+      },
+      skip: !Platform.isAndroid,
+      timeout: const Timeout(Duration(minutes: 15)),
+    );
+  });
+}
+
+// Follows HTTP redirects manually for HEAD requests.
+// Returns the final response after all redirects are resolved.
+Future<http.Response> _headFollowingRedirects(
+    http.Client client, String url) async {
+  var uri = Uri.parse(url);
+  int hops = 0;
+  const maxHops = 10;
+
+  while (hops < maxHops) {
+    final response = await client.head(uri);
+    print('[CDN] HEAD $uri → ${response.statusCode}');
+
+    if (response.statusCode == 301 ||
+        response.statusCode == 302 ||
+        response.statusCode == 307 ||
+        response.statusCode == 308) {
+      final location = response.headers['location'];
+      if (location == null) break;
+      uri = uri.resolve(location);
+      hops++;
+    } else {
+      print('[CDN] Final URL after $hops redirects: $uri');
+      return response;
+    }
+  }
+
+  throw Exception('Too many redirects (>$maxHops) for $url');
+}

--- a/example/integration_test/download_reliability_test.dart
+++ b/example/integration_test/download_reliability_test.dart
@@ -25,8 +25,6 @@ import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 
-import 'inference_test_helpers.dart';
-
 // Small public model — 284 MB, no auth token required.
 const _smallModelUrl =
     'https://huggingface.co/sasha-denisov/function-gemma-270M-it/resolve/main/functiongemma-270M-it.task';

--- a/example/integration_test/tool_calling_test.dart
+++ b/example/integration_test/tool_calling_test.dart
@@ -13,6 +13,7 @@
 //   - streaming: function call detection in async mode
 //   - parallel: multi-action prompt for multiple function calls
 
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
@@ -63,7 +64,8 @@ const _testModels = [
   ),
   ToolCallingTestModel(
     name: 'Qwen 2.5 0.5B',
-    filePath: '$_deviceModelDir/Qwen2.5-0.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
+    filePath:
+        '$_deviceModelDir/Qwen2.5-0.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
     filename: 'Qwen2.5-0.5B-Instruct_multi-prefill-seq_q8_ekv1280.task',
     modelType: ModelType.qwen,
   ),
@@ -145,14 +147,14 @@ void main() {
       testWidgets('install model', (tester) async {
         await FlutterGemma.initialize();
 
-        print('[${model.name}] Installing from file: ${model.filePath}');
+        debugPrint('[${model.name}] Installing from file: ${model.filePath}');
         await FlutterGemma.installModel(
           modelType: model.modelType,
           fileType: model.fileType,
         ).fromFile(model.filePath).install();
 
         expect(FlutterGemma.hasActiveModel(), isTrue);
-        print('[${model.name}] Installed successfully');
+        debugPrint('[${model.name}] Installed successfully');
       }, timeout: const Timeout(Duration(minutes: 10)));
 
       testWidgets('ToolChoice.auto — model calls function on action request',
@@ -185,20 +187,21 @@ void main() {
           );
 
           final response = await chat.generateChatResponse();
-          print('[${model.name}/auto] Response type: ${response.runtimeType}');
+          debugPrint(
+              '[${model.name}/auto] Response type: ${response.runtimeType}');
 
           if (response is FunctionCallResponse) {
-            print(
+            debugPrint(
                 '[${model.name}/auto] Function: ${response.name}(${response.args})');
             expect(response.name, equals('show_alert'));
             expect(response.args['title'], isNotNull);
           } else if (response is ParallelFunctionCallResponse) {
-            print(
+            debugPrint(
                 '[${model.name}/auto] Parallel calls: ${response.calls.length}');
             expect(response.calls, isNotEmpty);
             expect(response.calls.first.name, equals('show_alert'));
           } else if (response is TextResponse) {
-            print(
+            debugPrint(
                 '[${model.name}/auto] Text: "${_truncate(response.token)}"');
           }
         } finally {
@@ -236,19 +239,19 @@ void main() {
           );
 
           final response = await chat.generateChatResponse();
-          print(
+          debugPrint(
               '[${model.name}/required] Response type: ${response.runtimeType}');
 
           if (response is FunctionCallResponse) {
-            print(
+            debugPrint(
                 '[${model.name}/required] Function: ${response.name}(${response.args})');
             expect(response.name, isNotEmpty);
           } else if (response is ParallelFunctionCallResponse) {
-            print(
+            debugPrint(
                 '[${model.name}/required] Parallel calls: ${response.calls.length}');
             expect(response.calls, isNotEmpty);
           } else {
-            print(
+            debugPrint(
                 '[${model.name}/required] WARNING: Expected function call but got ${response.runtimeType}');
           }
         } finally {
@@ -286,13 +289,14 @@ void main() {
           );
 
           final response = await chat.generateChatResponse();
-          print('[${model.name}/none] Response type: ${response.runtimeType}');
+          debugPrint(
+              '[${model.name}/none] Response type: ${response.runtimeType}');
 
           expect(response, isA<TextResponse>(),
               reason:
                   'ToolChoice.none should produce text response, not function call');
           final text = (response as TextResponse).token;
-          print('[${model.name}/none] Text: "${_truncate(text)}"');
+          debugPrint('[${model.name}/none] Text: "${_truncate(text)}"');
           expect(text, isNotEmpty);
         } finally {
           await inferenceModel.close();
@@ -342,7 +346,7 @@ void main() {
             }
           }
 
-          print(
+          debugPrint(
               '[${model.name}/streaming] FunctionCall: ${functionCall?.name}, '
               'Parallel: ${parallelCall?.calls.length}, '
               'Text: "${_truncate(textBuffer.toString())}"');
@@ -381,35 +385,48 @@ void main() {
 
           await chat.addQueryChunk(
             const Message(
-              text: 'Do two things: 1) Change the app title to "New Title" 2) Change the background color to blue',
+              text:
+                  'Do two things: 1) Change the app title to "New Title" 2) Change the background color to blue',
               isUser: true,
             ),
           );
 
           final response = await chat.generateChatResponse();
-          print('[${model.name}/parallel] Response type: ${response.runtimeType}');
+          debugPrint(
+              '[${model.name}/parallel] Response type: ${response.runtimeType}');
 
           if (response is FunctionCallResponse) {
-            print('[${model.name}/parallel] Single call: ${response.name}(${response.args})');
-            expect(response.name, isNotEmpty, reason: 'Function name must not be empty');
-            print('[${model.name}/parallel] VERIFIED: parser returned valid function name "${response.name}"');
+            debugPrint(
+                '[${model.name}/parallel] Single call: ${response.name}(${response.args})');
+            expect(response.name, isNotEmpty,
+                reason: 'Function name must not be empty');
+            debugPrint(
+                '[${model.name}/parallel] VERIFIED: parser returned valid function name "${response.name}"');
           } else if (response is ParallelFunctionCallResponse) {
-            print('[${model.name}/parallel] Parallel calls: ${response.calls.length}');
+            debugPrint(
+                '[${model.name}/parallel] Parallel calls: ${response.calls.length}');
             for (final call in response.calls) {
-              print('[${model.name}/parallel]   CALL: ${call.name}(${call.args})');
-              expect(call.name, isNotEmpty, reason: 'Each parallel call must have a name');
+              debugPrint(
+                  '[${model.name}/parallel]   CALL: ${call.name}(${call.args})');
+              expect(call.name, isNotEmpty,
+                  reason: 'Each parallel call must have a name');
             }
             expect(response.calls.length, greaterThanOrEqualTo(2));
-            print('[${model.name}/parallel] VERIFIED: ${response.calls.length} parallel calls parsed');
+            debugPrint(
+                '[${model.name}/parallel] VERIFIED: ${response.calls.length} parallel calls parsed');
           } else if (response is TextResponse) {
             final rawText = response.token;
-            print('[${model.name}/parallel] Text response: "${_truncate(rawText)}"');
+            debugPrint(
+                '[${model.name}/parallel] Text response: "${_truncate(rawText)}"');
             // Verify parseAll on raw text to confirm no calls were missed
-            final manualParse = FunctionCallParser.parseAll(rawText, modelType: model.modelType);
-            print('[${model.name}/parallel] Manual parseAll: found ${manualParse.length} calls');
+            final manualParse = FunctionCallParser.parseAll(rawText,
+                modelType: model.modelType);
+            debugPrint(
+                '[${model.name}/parallel] Manual parseAll: found ${manualParse.length} calls');
             if (manualParse.isNotEmpty) {
               for (final call in manualParse) {
-                print('[${model.name}/parallel]   MISSED CALL: ${call.name}(${call.args})');
+                debugPrint(
+                    '[${model.name}/parallel]   MISSED CALL: ${call.name}(${call.args})');
               }
             }
           }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - background_downloader (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_gemma (0.13.0):
+  - flutter_gemma (0.13.2):
     - Flutter
     - MediaPipeTasksGenAI (= 0.10.33)
     - MediaPipeTasksGenAIC (= 0.10.33)
@@ -101,7 +101,7 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   background_downloader: 50e91d979067b82081aba359d7d916b3ba5fadad
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_gemma: 68d9763fd4d9281348678039358bf3deb706c74b
+  flutter_gemma: 549d359b171922b98406d8e24571609268501e4c
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,13 +4,12 @@ PODS:
   - background_downloader (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_gemma (0.13.2):
+  - flutter_gemma (0.13.3):
     - Flutter
     - MediaPipeTasksGenAI (= 0.10.33)
     - MediaPipeTasksGenAIC (= 0.10.33)
     - TensorFlowLiteC (= 0.0.1-nightly.20250619)
     - TensorFlowLiteSelectTfOps (= 0.0.1-nightly.20250619)
-    - TensorFlowLiteSwift (= 0.0.1-nightly.20250619)
   - image_picker_ios (0.0.1):
     - Flutter
   - integration_test (0.0.1):
@@ -37,12 +36,6 @@ PODS:
     - TensorFlowLiteC/Core (= 0.0.1-nightly.20250619)
   - TensorFlowLiteC/Core (0.0.1-nightly.20250619)
   - TensorFlowLiteSelectTfOps (0.0.1-nightly.20250619)
-  - TensorFlowLiteSwift (0.0.1-nightly.20250619):
-    - TensorFlowLiteSwift/Core (= 0.0.1-nightly.20250619)
-  - TensorFlowLiteSwift/Core (0.0.1-nightly.20250619):
-    - TensorFlowLiteC (= 0.0.1-nightly.20250619)
-    - TensorFlowLiteSwift/Privacy (= 0.0.1-nightly.20250619)
-  - TensorFlowLiteSwift/Privacy (0.0.1-nightly.20250619)
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -67,7 +60,6 @@ SPEC REPOS:
     - MediaPipeTasksGenAIC
     - TensorFlowLiteC
     - TensorFlowLiteSelectTfOps
-    - TensorFlowLiteSwift
 
 EXTERNAL SOURCES:
   audio_session:
@@ -101,7 +93,7 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   background_downloader: 50e91d979067b82081aba359d7d916b3ba5fadad
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_gemma: 549d359b171922b98406d8e24571609268501e4c
+  flutter_gemma: 285a66dbfff8949e1eeef7dfeb76a5840fb49b16
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
@@ -114,7 +106,6 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   TensorFlowLiteC: 215ef57653dd0fa09a474e7d94d79ae64a870b28
   TensorFlowLiteSelectTfOps: c71d7dcd063f5d66ae1b9a85cc5aa993f824eff9
-  TensorFlowLiteSwift: 6de8da348de331778167a0f751ad74c41d8b0554
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 3efd182c50317a46ac0f4e91a35a38918e286303

--- a/example/test/desktop_chat_test.dart
+++ b/example/test/desktop_chat_test.dart
@@ -1,6 +1,7 @@
 // Integration test for Desktop LiteRT-LM chat
 // Run with: cd example && flutter test test/desktop_chat_test.dart -d macos
 
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma/core/model_response.dart';
@@ -13,18 +14,19 @@ void main() {
     late InferenceChat chat;
 
     setUpAll(() async {
-      print('=== Setting up Desktop Chat Test ===');
+      debugPrint('=== Setting up Desktop Chat Test ===');
 
       // Initialize FlutterGemma
       await FlutterGemma.initialize();
-      print('FlutterGemma initialized');
+      debugPrint('FlutterGemma initialized');
 
       // Check if model is installed
       final hasModel = FlutterGemma.hasActiveModel();
-      print('Has active model: $hasModel');
+      debugPrint('Has active model: $hasModel');
 
       if (!hasModel) {
-        fail('No active model set. Install gemma-3n-E2B-it-int4 first via the example app.');
+        fail(
+            'No active model set. Install gemma-3n-E2B-it-int4 first via the example app.');
       }
 
       // Create model with minimal config - NO audio/image support to test pure text
@@ -34,30 +36,30 @@ void main() {
         supportAudio: false,
         supportImage: false,
       );
-      print('Model created: ${model.runtimeType}');
+      debugPrint('Model created: ${model.runtimeType}');
 
       // Create chat
       chat = await model.createChat();
-      print('Chat created: ${chat.runtimeType}');
+      debugPrint('Chat created: ${chat.runtimeType}');
     });
 
     tearDownAll(() async {
-      print('=== Tearing down ===');
+      debugPrint('=== Tearing down ===');
       await model.close();
     });
 
     test('Simple text chat should work', () async {
-      print('\n=== Test: Simple text chat ===');
+      debugPrint('\n=== Test: Simple text chat ===');
 
       // Add a simple query
       const query = 'Hi';
-      print('Sending query: "$query"');
+      debugPrint('Sending query: "$query"');
 
       await chat.addQueryChunk(const Message(text: query, isUser: true));
-      print('Query added to chat');
+      debugPrint('Query added to chat');
 
       // Get response
-      print('Getting response...');
+      debugPrint('Getting response...');
       final response = await chat.generateChatResponse();
 
       String responseText = '';
@@ -65,31 +67,32 @@ void main() {
         responseText = response.token;
       }
 
-      print('Response received: "${responseText.take(100)}"');
-      print('Response length: ${responseText.length}');
+      debugPrint('Response received: "${responseText.take(100)}"');
+      debugPrint('Response length: ${responseText.length}');
 
       expect(responseText, isNotEmpty);
       expect(responseText.length, greaterThan(1));
     });
 
     test('Streaming response should work', () async {
-      print('\n=== Test: Streaming response ===');
+      debugPrint('\n=== Test: Streaming response ===');
 
-      await chat.addQueryChunk(const Message(text: 'Count from 1 to 3', isUser: true));
+      await chat.addQueryChunk(
+          const Message(text: 'Count from 1 to 3', isUser: true));
 
       final chunks = <String>[];
       await for (final response in chat.generateChatResponseAsync()) {
         if (response is TextResponse) {
           chunks.add(response.token);
           if (chunks.length <= 10) {
-            print('Chunk ${chunks.length}: "${response.token}"');
+            debugPrint('Chunk ${chunks.length}: "${response.token}"');
           }
         }
       }
 
       final fullResponse = chunks.join();
-      print('Total chunks: ${chunks.length}');
-      print('Full response: "${fullResponse.take(100)}"');
+      debugPrint('Total chunks: ${chunks.length}');
+      debugPrint('Full response: "${fullResponse.take(100)}"');
 
       expect(chunks, isNotEmpty);
       expect(fullResponse, isNotEmpty);

--- a/ios/Classes/EmbeddingModel.swift
+++ b/ios/Classes/EmbeddingModel.swift
@@ -23,6 +23,9 @@ class EmbeddingModel {
     private var paddedTokensBuffer: [Int32] = []
     private var outputBuffer: [Float] = []
 
+    // XNNPack delegate — caller owns it in TFLiteC API, must be deleted after interpreter
+    private var xnnpackDelegate: OpaquePointer?
+
     // MARK: - Initialization
 
     init(modelPath: String, tokenizerPath: String, useGPU: Bool = true) {
@@ -54,9 +57,12 @@ class EmbeddingModel {
         // now resolved (pure Swift BPETokenizer).
         var xnnpackOptions = TfLiteXNNPackDelegateOptionsDefault()
         xnnpackOptions.num_threads = 6
-        if let xnnpackDelegate = TfLiteXNNPackDelegateCreate(&xnnpackOptions) {
-            TfLiteInterpreterOptionsAddDelegate(options, xnnpackDelegate)
-            // Delegate is owned by the interpreter after this point
+        // NOTE: TfLiteXNNPackDelegateCreate returns a caller-owned pointer.
+        // TfLiteInterpreterOptionsAddDelegate does NOT take ownership in the C API.
+        // We store it in self.xnnpackDelegate and delete it in close() AFTER the interpreter.
+        if let xDelegate = TfLiteXNNPackDelegateCreate(&xnnpackOptions) {
+            TfLiteInterpreterOptionsAddDelegate(options, xDelegate)
+            xnnpackDelegate = xDelegate
         }
 
         guard let interp = TfLiteInterpreterCreate(model, options) else {
@@ -104,6 +110,11 @@ class EmbeddingModel {
         if let interp = interpreter {
             TfLiteInterpreterDelete(interp)
             interpreter = nil
+        }
+        // Delete XNNPack delegate AFTER interpreter (interpreter must not use it after this)
+        if let xDelegate = xnnpackDelegate {
+            TfLiteXNNPackDelegateDelete(xDelegate)
+            xnnpackDelegate = nil
         }
         tokenizer = nil
         paddedTokensBuffer.removeAll()
@@ -156,8 +167,11 @@ class EmbeddingModel {
         if outputBuffer.count != floatCount {
             outputBuffer = [Float](repeating: 0.0, count: floatCount)
         }
-        outputBuffer.withUnsafeMutableBytes { ptr in
+        let outputStatus = outputBuffer.withUnsafeMutableBytes { ptr in
             TfLiteTensorCopyToBuffer(outputTensor, ptr.baseAddress!, outputByteCount)
+        }
+        guard outputStatus == kTfLiteOk else {
+            throw EmbeddingError.inferenceFailed("TfLiteTensorCopyToBuffer failed")
         }
 
         guard outputBuffer.count >= embeddingDimension else {

--- a/ios/Classes/EmbeddingModel.swift
+++ b/ios/Classes/EmbeddingModel.swift
@@ -1,162 +1,171 @@
 import Foundation
-import TensorFlowLite
+import TensorFlowLiteC
 
 /// iOS implementation of EmbeddingGemma model - equivalent to Android LiteRT implementation
 /// Supports any .tflite embedding model with 768-dimensional output
 class EmbeddingModel {
-    
+
     // MARK: - Properties
-    private var interpreter: Interpreter?
+    // TfLiteInterpreter* — owned, deleted in close()
+    private var interpreter: OpaquePointer?
     private var tokenizer: TokenizerProtocol?
     private let modelPath: String
     private let tokenizerPath: String
-    private let useGPU: Bool
-    
-    // Model configuration
-    private var maxSequenceLength = 1024 // Will be detected from model
-    private var embeddingDimension = 768 // Will be detected from model
+
+    // Model configuration — detected from model tensors after allocateTensors
+    private var maxSequenceLength = 1024
+    private var embeddingDimension = 768
 
     private let taskPrefix = "task: search result | query: "
     private let docPrefix = "title: none | text: "
 
-    // Memory optimization: Reuse buffers to avoid allocations
-    private var inputBuffer: Data?
-    private var paddedTokensBuffer: [Int] = []
+    // Memory optimization: reuse buffers to avoid per-inference allocations
+    private var paddedTokensBuffer: [Int32] = []
     private var outputBuffer: [Float] = []
 
-    
     // MARK: - Initialization
-    
-    /// Initialize embedding model with paths
-    /// - Parameters:
-    ///   - modelPath: Path to .tflite model file
-    ///   - tokenizerPath: Path to sentencepiece.model file
-    ///   - useGPU: Whether to use GPU acceleration
+
     init(modelPath: String, tokenizerPath: String, useGPU: Bool = true) {
         self.modelPath = modelPath
         self.tokenizerPath = tokenizerPath
-        self.useGPU = useGPU
+        // useGPU kept for API compatibility; threading handles performance
     }
-    
+
     /// Load model and tokenizer (equivalent to Android's loadModel)
     func loadModel() throws {
-        // Auto-detect tokenizer type from JSON model.type field
         tokenizer = try EmbeddingModel.loadTokenizer(jsonPath: tokenizerPath)
 
-        // Configure TensorFlow Lite options
-        var options = Interpreter.Options()
-        options.threadCount = 4 // Optimize for mobile performance
-
-        // XNNPACK required for correct mixed-precision inference
-        // Was disabled in v0.11.16 (#155) due to crash, but root cause was
-        // SentencePiece C++ protobuf conflict — now resolved (pure Swift BPETokenizer)
-        options.isXNNPackEnabled = true
-
-        // Note: Select TF Ops should be automatically available when TensorFlowLiteSelectTfOps is linked
-
-        // Load the model with optimized settings
-        do {
-            // Use optimized threading based on GPU preference
-            if useGPU {
-                options.threadCount = 6 // Use more threads for GPU-level performance
-            } else {
-                options.threadCount = 4
-            }
-
-            interpreter = try Interpreter(modelPath: modelPath, options: options)
-            try interpreter?.allocateTensors()
-
-            // Extract dimensions from model tensors
-            if let inputTensor = try? interpreter?.input(at: 0) {
-                let detectedSequenceLength = inputTensor.shape.dimensions[1]
-                if detectedSequenceLength != maxSequenceLength {
-                    maxSequenceLength = detectedSequenceLength
-                }
-            }
-
-            if let outputTensor = try? interpreter?.output(at: 0) {
-                let detectedEmbeddingDimension = outputTensor.shape.dimensions[1]
-                if detectedEmbeddingDimension != embeddingDimension {
-                    embeddingDimension = detectedEmbeddingDimension
-                }
-            }
-
-        } catch let error as InterpreterError {
-            print("[MODEL] InterpreterError: \(error)")
-            throw EmbeddingError.modelLoadFailed("InterpreterError: \(error)")
-        } catch {
-            print("[MODEL] Unknown error: \(error)")
-            throw EmbeddingError.modelLoadFailed("Failed to load model: \(error.localizedDescription)")
+        // Load model from file
+        guard let model = TfLiteModelCreateFromFile(modelPath) else {
+            throw EmbeddingError.modelLoadFailed("TfLiteModelCreateFromFile failed for: \(modelPath)")
         }
+        defer { TfLiteModelDelete(model) }
+
+        // Build interpreter options
+        guard let options = TfLiteInterpreterOptionsCreate() else {
+            throw EmbeddingError.modelLoadFailed("Failed to create interpreter options")
+        }
+        defer { TfLiteInterpreterOptionsDelete(options) }
+
+        TfLiteInterpreterOptionsSetNumThreads(options, 6)
+
+        // XNNPACK required for correct mixed-precision inference.
+        // Was disabled in v0.11.16 (#155) due to SentencePiece C++ protobuf conflict —
+        // now resolved (pure Swift BPETokenizer).
+        var xnnpackOptions = TfLiteXNNPackDelegateOptionsDefault()
+        xnnpackOptions.num_threads = 6
+        if let xnnpackDelegate = TfLiteXNNPackDelegateCreate(&xnnpackOptions) {
+            TfLiteInterpreterOptionsAddDelegate(options, xnnpackDelegate)
+            // Delegate is owned by the interpreter after this point
+        }
+
+        guard let interp = TfLiteInterpreterCreate(model, options) else {
+            throw EmbeddingError.modelLoadFailed("TfLiteInterpreterCreate failed")
+        }
+
+        guard TfLiteInterpreterAllocateTensors(interp) == kTfLiteOk else {
+            TfLiteInterpreterDelete(interp)
+            throw EmbeddingError.modelLoadFailed("TfLiteInterpreterAllocateTensors failed")
+        }
+
+        // Detect sequence length from input tensor shape [1, seqLen]
+        if let inputTensor = TfLiteInterpreterGetInputTensor(interp, 0) {
+            let dims = TfLiteTensorNumDims(inputTensor)
+            if dims >= 2 {
+                let detected = Int(TfLiteTensorDim(inputTensor, 1))
+                if detected > 0 { maxSequenceLength = detected }
+            }
+        }
+
+        // Detect embedding dimension from output tensor shape [1, dim]
+        if let outputTensor = TfLiteInterpreterGetOutputTensor(interp, 0) {
+            let dims = TfLiteTensorNumDims(outputTensor)
+            if dims >= 2 {
+                let detected = Int(TfLiteTensorDim(outputTensor, 1))
+                if detected > 0 { embeddingDimension = detected }
+            }
+        }
+
+        interpreter = interp
     }
-    
+
     /// Generate embeddings for input text (equivalent to Android's generateEmbedding)
-    /// - Parameter text: Input text to embed
-    /// - Returns: 768-dimensional embedding vector
     func generateEmbedding(for text: String) throws -> [Float] {
-        guard let interpreter = interpreter,
-              let tokenizer = tokenizer else {
-            throw EmbeddingError.modelNotLoaded("Model not loaded. Call loadModel() first.")
-        }
-
-        // Tokenize full string in one call (not prefix + text separately)
-        // This matches Android behavior where SentencePiece encodes the complete string
-        let fullText = taskPrefix + text
-        var tokens = tokenizer.encode(fullText)
-
-        // Add BOS at beginning and EOS at end - ONCE for entire sequence
-        // BOS token ID = 2, EOS token ID = 1 (from Gemma vocabulary)
-        tokens.insert(2, at: 0)  // Add BOS
-        tokens.append(1)         // Add EOS
-
-        // Prepare and copy input tensor
-        let inputTensor = try prepareInputTensor(tokens: tokens)
-        try interpreter.copy(inputTensor, toInputAt: 0)
-
-        // Run inference
-        try interpreter.invoke()
-
-        // Extract embeddings from output
-        let outputTensor = try interpreter.output(at: 0)
-        let embeddings = try extractEmbeddings(from: outputTensor)
-
-        return embeddings
+        return try runInference(fullText: taskPrefix + text)
     }
-    
-    /// Generate embeddings for input text using document prefix (for RAG indexing)
+
+    /// Generate embeddings using document prefix (for RAG indexing)
     func generateDocumentEmbedding(for text: String) throws -> [Float] {
-        guard let interpreter = interpreter,
-              let tokenizer = tokenizer else {
-            throw EmbeddingError.modelNotLoaded("Model not loaded. Call loadModel() first.")
-        }
-
-        let fullText = docPrefix + text
-        var tokens = tokenizer.encode(fullText)
-        tokens.insert(2, at: 0)  // BOS
-        tokens.append(1)         // EOS
-
-        let inputTensor = try prepareInputTensor(tokens: tokens)
-        try interpreter.copy(inputTensor, toInputAt: 0)
-        try interpreter.invoke()
-
-        let outputTensor = try interpreter.output(at: 0)
-        return try extractEmbeddings(from: outputTensor)
+        return try runInference(fullText: docPrefix + text)
     }
 
     /// Close model and release resources
     func close() {
-        interpreter = nil
+        if let interp = interpreter {
+            TfLiteInterpreterDelete(interp)
+            interpreter = nil
+        }
         tokenizer = nil
-
-        // Clear reusable buffers to free memory
-        inputBuffer = nil
         paddedTokensBuffer.removeAll()
         outputBuffer.removeAll()
     }
-    
+
     // MARK: - Private Methods
 
-    /// Load tokenizer by auto-detecting type from tokenizer.json
+    private func runInference(fullText: String) throws -> [Float] {
+        guard let interp = interpreter, let tokenizer = tokenizer else {
+            throw EmbeddingError.modelNotLoaded("Model not loaded. Call loadModel() first.")
+        }
+
+        var tokens = tokenizer.encode(fullText)
+        tokens.insert(2, at: 0)  // BOS (Gemma vocabulary)
+        tokens.append(1)         // EOS
+
+        // Pad/truncate to maxSequenceLength into Int32 buffer
+        let seqLen = maxSequenceLength
+        if paddedTokensBuffer.count != seqLen {
+            paddedTokensBuffer = [Int32](repeating: 0, count: seqLen)
+        }
+        let copyCount = min(tokens.count, seqLen)
+        for i in 0..<copyCount { paddedTokensBuffer[i] = Int32(tokens[i]) }
+        for i in copyCount..<seqLen { paddedTokensBuffer[i] = 0 }
+
+        // Copy into input tensor
+        guard let inputTensor = TfLiteInterpreterGetInputTensor(interp, 0) else {
+            throw EmbeddingError.inferenceFailed("Cannot get input tensor")
+        }
+        let byteCount = seqLen * MemoryLayout<Int32>.size
+        let status = paddedTokensBuffer.withUnsafeBytes { ptr in
+            TfLiteTensorCopyFromBuffer(inputTensor, ptr.baseAddress!, byteCount)
+        }
+        guard status == kTfLiteOk else {
+            throw EmbeddingError.inferenceFailed("TfLiteTensorCopyFromBuffer failed")
+        }
+
+        // Run inference
+        guard TfLiteInterpreterInvoke(interp) == kTfLiteOk else {
+            throw EmbeddingError.inferenceFailed("TfLiteInterpreterInvoke failed")
+        }
+
+        // Extract output
+        guard let outputTensor = TfLiteInterpreterGetOutputTensor(interp, 0) else {
+            throw EmbeddingError.inferenceFailed("Cannot get output tensor")
+        }
+        let outputByteCount = TfLiteTensorByteSize(outputTensor)
+        let floatCount = outputByteCount / MemoryLayout<Float>.size
+        if outputBuffer.count != floatCount {
+            outputBuffer = [Float](repeating: 0.0, count: floatCount)
+        }
+        outputBuffer.withUnsafeMutableBytes { ptr in
+            TfLiteTensorCopyToBuffer(outputTensor, ptr.baseAddress!, outputByteCount)
+        }
+
+        guard outputBuffer.count >= embeddingDimension else {
+            throw EmbeddingError.invalidOutput("Unexpected embedding dimension: \(outputBuffer.count)")
+        }
+        return Array(outputBuffer.prefix(embeddingDimension))
+    }
+
     private static func loadTokenizer(jsonPath: String) throws -> TokenizerProtocol {
         let data = try Data(contentsOf: URL(fileURLWithPath: jsonPath))
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -165,94 +174,14 @@ class EmbeddingModel {
             throw NSError(domain: "EmbeddingModel", code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "Cannot detect tokenizer type from JSON"])
         }
-
         switch type {
-        case "BPE":
-            return try BPETokenizer(jsonPath: jsonPath)
-        case "Unigram":
-            return try UnigramTokenizer(jsonPath: jsonPath)
+        case "BPE":    return try BPETokenizer(jsonPath: jsonPath)
+        case "Unigram": return try UnigramTokenizer(jsonPath: jsonPath)
         default:
             throw NSError(domain: "EmbeddingModel", code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "Unknown tokenizer type: \(type)"])
         }
     }
-
-    private func prepareInputTensor(tokens: [Int]) throws -> Data {
-        // Pad or truncate to maxSequenceLength (reusing buffer)
-        padTokens(tokens, toLength: maxSequenceLength, intoBuffer: &paddedTokensBuffer)
-
-        // Reuse input buffer if possible
-        let requiredSize = paddedTokensBuffer.count * MemoryLayout<Int32>.size
-        if inputBuffer == nil || inputBuffer!.count != requiredSize {
-            inputBuffer = Data(count: requiredSize)
-        }
-
-        // Copy Int tokens to Int32 buffer efficiently
-        inputBuffer!.withUnsafeMutableBytes { bytes in
-            let int32Pointer = bytes.bindMemory(to: Int32.self)
-            for i in 0..<paddedTokensBuffer.count {
-                int32Pointer[i] = Int32(paddedTokensBuffer[i])
-            }
-        }
-
-        return inputBuffer!
-    }
-    
-    private func padTokens(_ tokens: [Int], toLength length: Int, intoBuffer buffer: inout [Int]) {
-        // Resize buffer if needed
-        if buffer.count != length {
-            buffer = Array(repeating: 0, count: length)
-        }
-
-        // Copy tokens and handle truncation/padding
-        let copyCount = min(tokens.count, length)
-
-        // Copy input tokens
-        for i in 0..<copyCount {
-            buffer[i] = tokens[i]
-        }
-
-        // Fill remaining with PAD token (0)
-        // PAD=0 is standard for Gemma vocabulary
-        let padToken = 0
-        for i in copyCount..<length {
-            buffer[i] = padToken
-        }
-    }
-    
-    private func extractEmbeddings(from tensor: Tensor) throws -> [Float] {
-        // Extract embeddings from output tensor
-        let outputData = tensor.data
-
-        // Convert bytes to Float32 array (reusing buffer)
-        let floatCount = outputData.count / MemoryLayout<Float>.size
-
-        // Resize output buffer if needed
-        if outputBuffer.count != floatCount {
-            outputBuffer = [Float](repeating: 0.0, count: floatCount)
-        }
-
-        outputData.withUnsafeBytes { bytes in
-            let floatPointer = bytes.bindMemory(to: Float.self)
-            for i in 0..<floatCount {
-                outputBuffer[i] = floatPointer[i]
-            }
-        }
-
-        // Model returns [1, 768] - just take the 768 values directly
-        // No mean pooling - model already outputs final embedding
-        if outputBuffer.count >= embeddingDimension {
-            var result = [Float](repeating: 0.0, count: embeddingDimension)
-            for i in 0..<embeddingDimension {
-                result[i] = outputBuffer[i]
-            }
-
-            return result
-        } else {
-            throw EmbeddingError.invalidOutput("Unexpected embedding dimension: \(outputBuffer.count)")
-        }
-    }
-    
 }
 
 // MARK: - Error Types
@@ -283,40 +212,29 @@ enum EmbeddingError: Error, LocalizedError {
 // MARK: - Extensions for debugging
 
 extension EmbeddingModel {
-    
-    /// Get model information for debugging
+
     var modelInfo: [String: Any] {
-        guard let interpreter = interpreter else {
+        guard let interp = interpreter else {
             return ["status": "not_loaded"]
         }
-        
         var info: [String: Any] = [
             "status": "loaded",
-            "use_gpu": useGPU,
             "max_sequence_length": maxSequenceLength,
             "embedding_dimension": embeddingDimension,
-            "input_tensor_count": interpreter.inputTensorCount,
-            "output_tensor_count": interpreter.outputTensorCount
+            "input_tensor_count": TfLiteInterpreterGetInputTensorCount(interp),
+            "output_tensor_count": TfLiteInterpreterGetOutputTensorCount(interp),
         ]
-        
-        // Add tensor shapes if available
-        if let inputTensor = try? interpreter.input(at: 0) {
-            info["input_shape"] = inputTensor.shape.dimensions
-            info["input_type"] = "\(inputTensor.dataType)"
+        if let t = TfLiteInterpreterGetInputTensor(interp, 0) {
+            info["input_dims"] = TfLiteTensorNumDims(t)
         }
-        
-        if let outputTensor = try? interpreter.output(at: 0) {
-            info["output_shape"] = outputTensor.shape.dimensions
-            info["output_type"] = "\(outputTensor.dataType)"
+        if let t = TfLiteInterpreterGetOutputTensor(interp, 0) {
+            info["output_dims"] = TfLiteTensorNumDims(t)
         }
-        
         return info
     }
-    
-    /// Test embedding generation with sample text
+
     func testEmbedding() throws -> [Float] {
-        let testText = "machine learning algorithms"
-        return try generateEmbedding(for: testText)
+        return try generateEmbedding(for: "machine learning algorithms")
     }
 }
 

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -25,7 +25,7 @@ Includes support for Gemma 3 Nano models with optimized MediaPipe GenAI v0.10.33
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64',
     # Conditional force_load: only for device builds (TensorFlowLiteSelectTfOps doesn't have simulator slice)
     'OTHER_LDFLAGS[sdk=iphoneos*]' => '-force_load $(SRCROOT)/Pods/TensorFlowLiteSelectTfOps/Frameworks/TensorFlowLiteSelectTfOps.xcframework/ios-arm64/TensorFlowLiteSelectTfOps.framework/TensorFlowLiteSelectTfOps',
     'OTHER_LDFLAGS[sdk=iphonesimulator*]' => ''

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -19,7 +19,6 @@ Includes support for Gemma 3 Nano models with optimized MediaPipe GenAI v0.10.33
   s.dependency 'MediaPipeTasksGenAI', '= 0.10.33'
   s.dependency 'MediaPipeTasksGenAIC', '= 0.10.33'
   s.dependency 'TensorFlowLiteC', '0.0.1-nightly.20250619'
-  s.dependency 'TensorFlowLiteSwift', '0.0.1-nightly.20250619'
   s.dependency 'TensorFlowLiteSelectTfOps', '0.0.1-nightly.20250619'
   s.platform = :ios, '16.0'
 

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.13.2'
+  s.version          = '0.13.3'
   s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
   s.description      = <<-DESC
 The plugin allows running the Gemma AI model locally on a device from a Flutter application.

--- a/linux/scripts/setup_desktop.sh
+++ b/linux/scripts/setup_desktop.sh
@@ -59,9 +59,9 @@ JRE_URL="https://cdn.azul.com/zulu/bin/${JRE_ARCHIVE}"
 
 # JAR settings
 JAR_NAME="litertlm-server.jar"
-JAR_VERSION="0.13.1"
+JAR_VERSION="0.13.3"
 JAR_URL="https://github.com/DenisovAV/flutter_gemma/releases/download/v${JAR_VERSION}/${JAR_NAME}"
-JAR_CHECKSUM="97e01020f921c098f7cfc0a9509e4b207b8bc326703ae2f26bbce3c11b957430"
+JAR_CHECKSUM="6cb0ac8aa0b89c542bb9acd265c8881eb70e11e7aeab9f15d78197536b207e77"
 
 # Plugin root (parent of linux/)
 PLUGIN_ROOT=$(dirname "$PLUGIN_DIR")

--- a/litertlm-server/build.gradle.kts
+++ b/litertlm-server/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "dev.flutterberlin"
-version = "0.13.1"
+version = "0.13.3"
 
 repositories {
     mavenCentral()

--- a/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
+++ b/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
@@ -4,12 +4,15 @@ import com.google.ai.edge.litertlm.*
 import com.google.ai.edge.litertlm.Content
 import com.google.ai.edge.litertlm.Contents
 import dev.flutterberlin.litertlm.proto.*
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -215,6 +218,8 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             return@callbackFlow
         }
 
+        val done = CompletableDeferred<Unit>()
+
         try {
             logger.info("=== CHAT REQUEST ===")
             logger.info("conversationId: '${request.conversationId}'")
@@ -244,6 +249,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
+                    done.complete(Unit)
                     close()
                     logger.debug("Chat completed for ${request.conversationId}")
                 }
@@ -256,6 +262,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
+                    done.complete(Unit)
                     close(throwable)
                 }
             }
@@ -277,7 +284,19 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close(e)
         }
 
-        awaitClose { }
+        // Wait for native sendMessageAsync to finish before allowing the coroutine
+        // to exit. Without this, a client disconnect (gRPC cancel / model.close())
+        // causes the coroutine to exit immediately while the native thread still
+        // holds a reference to messageCallback → SIGSEGV in jni_CallVoidMethodV.
+        // See: https://github.com/DenisovAV/flutter_gemma/issues/219
+        awaitClose {
+            try {
+                conversation.cancelProcess()
+            } catch (_: Exception) { /* conversation may already be closed */ }
+            runBlocking {
+                withTimeoutOrNull(5_000) { done.await() }
+            }
+        }
     }
 
     override suspend fun chatWithImageSync(request: ChatWithImageRequest): ChatResponse {
@@ -333,6 +352,8 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             return@callbackFlow
         }
 
+        val done = CompletableDeferred<Unit>()
+
         try {
             val imageBytes = request.image.toByteArray()
             logger.info("Chat with image request: text='${request.text.take(50)}', imageBytes=${imageBytes.size}, visionEnabled=$visionEnabled")
@@ -385,6 +406,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
+                    done.complete(Unit)
                     close()
                 }
 
@@ -396,6 +418,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
+                    done.complete(Unit)
                     close(throwable)
                 }
             }
@@ -417,7 +440,15 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close(e)
         }
 
-        awaitClose { }
+        // See chat() awaitClose comment — same race condition applies here.
+        awaitClose {
+            try {
+                conversation.cancelProcess()
+            } catch (_: Exception) { /* conversation may already be closed */ }
+            runBlocking {
+                withTimeoutOrNull(5_000) { done.await() }
+            }
+        }
     }
 
     override fun chatWithAudio(request: ChatWithAudioRequest): Flow<ChatResponse> = callbackFlow {
@@ -432,6 +463,8 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close()
             return@callbackFlow
         }
+
+        val done = CompletableDeferred<Unit>()
 
         try {
             val audioBytes = request.audio.toByteArray()
@@ -485,6 +518,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
+                    done.complete(Unit)
                     close()
                 }
 
@@ -496,6 +530,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
+                    done.complete(Unit)
                     close(throwable)
                 }
             }
@@ -517,7 +552,15 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close(e)
         }
 
-        awaitClose { }
+        // See chat() awaitClose comment — same race condition applies here.
+        awaitClose {
+            try {
+                conversation.cancelProcess()
+            } catch (_: Exception) { /* conversation may already be closed */ }
+            runBlocking {
+                withTimeoutOrNull(5_000) { done.await() }
+            }
+        }
     }
 
     override suspend fun cancelGeneration(request: CancelGenerationRequest): CancelGenerationResponse {

--- a/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
+++ b/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
@@ -298,7 +298,9 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             // Hold the per-conversation mutex for the entire duration of sendMessageAsync.
             // closeConversation also acquires this mutex, so conversation.close() cannot
             // be called while native decode is running → prevents use-after-free SIGSEGV.
-            val convMutex = conversationMutexes.getOrPut(request.conversationId) { Mutex() }
+            // computeIfAbsent is used (not getOrPut) because it is atomic on ConcurrentHashMap:
+            // guarantees a single Mutex instance per conversationId under concurrent calls.
+            val convMutex = conversationMutexes.computeIfAbsent(request.conversationId) { Mutex() }
             convMutex.withLock {
                 if (extraContext.isNotEmpty()) {
                     conversation.sendMessageAsync(message, messageCallback, extraContext)
@@ -461,11 +463,17 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 }
             }
 
-            // Use callback-based API (like Android does)
-            if (extraContext.isNotEmpty()) {
-                conversation.sendMessageAsync(message, messageCallback, extraContext)
-            } else {
-                conversation.sendMessageAsync(message, messageCallback)
+            // Hold per-conversation mutex (same pattern as chat()) to prevent
+            // closeConversation() from calling conversation.close() while native
+            // image decode is running → prevents use-after-free SIGSEGV.
+            val convMutex = conversationMutexes.computeIfAbsent(request.conversationId) { Mutex() }
+            convMutex.withLock {
+                if (extraContext.isNotEmpty()) {
+                    conversation.sendMessageAsync(message, messageCallback, extraContext)
+                } else {
+                    conversation.sendMessageAsync(message, messageCallback)
+                }
+                withTimeoutOrNull(300_000) { done.await() }
             }
         } catch (e: Exception) {
             logger.error("Error starting chat with image", e)
@@ -478,14 +486,10 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close(e)
         }
 
-        // See chat() awaitClose comment — same race condition applies here.
         awaitClose {
-            try {
-                conversation.cancelProcess()
-            } catch (_: Exception) { /* conversation may already be closed */ }
-            runBlocking {
-                withTimeoutOrNull(5_000) { done.await() }
-            }
+            active.set(false)
+            try { conversation.cancelProcess() } catch (_: Exception) { }
+            runBlocking { withTimeoutOrNull(5_000) { done.await() } }
         }
     }
 
@@ -584,11 +588,17 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 }
             }
 
-            // Use callback-based API (like Android does)
-            if (extraContext.isNotEmpty()) {
-                conversation.sendMessageAsync(message, messageCallback, extraContext)
-            } else {
-                conversation.sendMessageAsync(message, messageCallback)
+            // Hold per-conversation mutex (same pattern as chat()) to prevent
+            // closeConversation() from calling conversation.close() while native
+            // audio decode is running → prevents use-after-free SIGSEGV.
+            val convMutex = conversationMutexes.computeIfAbsent(request.conversationId) { Mutex() }
+            convMutex.withLock {
+                if (extraContext.isNotEmpty()) {
+                    conversation.sendMessageAsync(message, messageCallback, extraContext)
+                } else {
+                    conversation.sendMessageAsync(message, messageCallback)
+                }
+                withTimeoutOrNull(300_000) { done.await() }
             }
         } catch (e: Exception) {
             logger.error("Error starting chat with audio", e)
@@ -601,14 +611,10 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close(e)
         }
 
-        // See chat() awaitClose comment — same race condition applies here.
         awaitClose {
-            try {
-                conversation.cancelProcess()
-            } catch (_: Exception) { /* conversation may already be closed */ }
-            runBlocking {
-                withTimeoutOrNull(5_000) { done.await() }
-            }
+            active.set(false)
+            try { conversation.cancelProcess() } catch (_: Exception) { }
+            runBlocking { withTimeoutOrNull(5_000) { done.await() } }
         }
     }
 

--- a/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
+++ b/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
@@ -5,6 +5,7 @@ import com.google.ai.edge.litertlm.Content
 import com.google.ai.edge.litertlm.Contents
 import dev.flutterberlin.litertlm.proto.*
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -31,6 +32,10 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
     private var visionEnabled: Boolean = false  // Track if vision backend was initialized
     private val conversations = ConcurrentHashMap<String, Conversation>()
     private val conversationCounter = AtomicInteger(0)
+    // Per-conversation mutex: held during sendMessageAsync, prevents closeConversation
+    // from calling conversation.close() while native decode is running (use-after-free).
+    // See: https://github.com/DenisovAV/flutter_gemma/issues/219
+    private val conversationMutexes = ConcurrentHashMap<String, Mutex>()
 
     override suspend fun initialize(request: InitializeRequest): InitializeResponse {
         logger.info("Initializing engine with model: ${request.modelPath}")
@@ -219,6 +224,25 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
         }
 
         val done = CompletableDeferred<Unit>()
+        // Guards the MessageCallback JNI methods. Once the gRPC stream is cancelled
+        // (client disconnect / model.close()), native sendMessageAsync may still be
+        // running on a background thread. Setting this flag to false prevents the
+        // callback from touching the (potentially invalid) callbackFlow channel,
+        // avoiding SIGSEGV in jni_CallVoidMethodV.
+        // See: https://github.com/DenisovAV/flutter_gemma/issues/219
+        val active = java.util.concurrent.atomic.AtomicBoolean(true)
+
+        // Register a cancellation handler on the coroutine Job so that active is
+        // deactivated even if the coroutine is cancelled before reaching awaitClose.
+        coroutineContext[kotlinx.coroutines.Job]?.invokeOnCompletion {
+            active.set(false)
+            if (it != null) {
+                // Coroutine was cancelled — signal native code to stop.
+                logger.info("Job cancelled for ${request.conversationId}, cancelling native inference")
+                try { conversation.cancelProcess() } catch (_: Exception) { }
+                done.complete(Unit)
+            }
+        }
 
         try {
             logger.info("=== CHAT REQUEST ===")
@@ -233,6 +257,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
 
             val messageCallback = object : MessageCallback {
                 override fun onMessage(msg: Message) {
+                    if (!active.get()) return
                     val builder = ChatResponse.newBuilder()
                         .setText(msg.toString())
                         .setDone(false)
@@ -244,17 +269,20 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 }
 
                 override fun onDone() {
+                    done.complete(Unit)
+                    if (!active.get()) return
                     trySend(
                         ChatResponse.newBuilder()
                             .setDone(true)
                             .build()
                     )
-                    done.complete(Unit)
                     close()
                     logger.debug("Chat completed for ${request.conversationId}")
                 }
 
                 override fun onError(throwable: Throwable) {
+                    done.complete(Unit)
+                    if (!active.get()) return
                     logger.error("Error during chat", throwable)
                     trySend(
                         ChatResponse.newBuilder()
@@ -262,16 +290,23 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
-                    done.complete(Unit)
                     close(throwable)
                 }
             }
 
-            // Use callback-based API (like Android does)
-            if (extraContext.isNotEmpty()) {
-                conversation.sendMessageAsync(message, messageCallback, extraContext)
-            } else {
-                conversation.sendMessageAsync(message, messageCallback)
+            // Use callback-based API (like Android does).
+            // Hold the per-conversation mutex for the entire duration of sendMessageAsync.
+            // closeConversation also acquires this mutex, so conversation.close() cannot
+            // be called while native decode is running → prevents use-after-free SIGSEGV.
+            val convMutex = conversationMutexes.getOrPut(request.conversationId) { Mutex() }
+            convMutex.withLock {
+                if (extraContext.isNotEmpty()) {
+                    conversation.sendMessageAsync(message, messageCallback, extraContext)
+                } else {
+                    conversation.sendMessageAsync(message, messageCallback)
+                }
+                // Wait for native code to call onDone/onError before releasing the lock.
+                withTimeoutOrNull(300_000) { done.await() }
             }
         } catch (e: Exception) {
             logger.error("Error starting chat", e)
@@ -284,18 +319,10 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             close(e)
         }
 
-        // Wait for native sendMessageAsync to finish before allowing the coroutine
-        // to exit. Without this, a client disconnect (gRPC cancel / model.close())
-        // causes the coroutine to exit immediately while the native thread still
-        // holds a reference to messageCallback → SIGSEGV in jni_CallVoidMethodV.
-        // See: https://github.com/DenisovAV/flutter_gemma/issues/219
         awaitClose {
-            try {
-                conversation.cancelProcess()
-            } catch (_: Exception) { /* conversation may already be closed */ }
-            runBlocking {
-                withTimeoutOrNull(5_000) { done.await() }
-            }
+            active.set(false)
+            try { conversation.cancelProcess() } catch (_: Exception) { }
+            runBlocking { withTimeoutOrNull(5_000) { done.await() } }
         }
     }
 
@@ -353,6 +380,14 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
         }
 
         val done = CompletableDeferred<Unit>()
+        val active = java.util.concurrent.atomic.AtomicBoolean(true)
+        coroutineContext[Job]?.invokeOnCompletion {
+            active.set(false)
+            if (it != null) {
+                try { conversation.cancelProcess() } catch (_: Exception) { }
+                done.complete(Unit)
+            }
+        }
 
         try {
             val imageBytes = request.image.toByteArray()
@@ -385,6 +420,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
 
             val messageCallback = object : MessageCallback {
                 override fun onMessage(msg: Message) {
+                    if (!active.get()) return
                     responseCount++
                     if (responseCount <= 3) {
                         logger.info("Response chunk $responseCount: '${msg.toString().take(100)}'")
@@ -400,17 +436,20 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 }
 
                 override fun onDone() {
+                    done.complete(Unit)
+                    if (!active.get()) return
                     logger.info("Chat with image completed, total chunks: $responseCount")
                     trySend(
                         ChatResponse.newBuilder()
                             .setDone(true)
                             .build()
                     )
-                    done.complete(Unit)
                     close()
                 }
 
                 override fun onError(throwable: Throwable) {
+                    done.complete(Unit)
+                    if (!active.get()) return
                     logger.error("Error during chat with image", throwable)
                     trySend(
                         ChatResponse.newBuilder()
@@ -418,7 +457,6 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
-                    done.complete(Unit)
                     close(throwable)
                 }
             }
@@ -465,6 +503,14 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
         }
 
         val done = CompletableDeferred<Unit>()
+        val active = java.util.concurrent.atomic.AtomicBoolean(true)
+        coroutineContext[Job]?.invokeOnCompletion {
+            active.set(false)
+            if (it != null) {
+                try { conversation.cancelProcess() } catch (_: Exception) { }
+                done.complete(Unit)
+            }
+        }
 
         try {
             val audioBytes = request.audio.toByteArray()
@@ -496,6 +542,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
 
             val messageCallback = object : MessageCallback {
                 override fun onMessage(msg: Message) {
+                    if (!active.get()) return
                     responseCount++
                     val responseText = msg.toString()
                     if (responseCount <= 3) {
@@ -512,17 +559,20 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 }
 
                 override fun onDone() {
+                    done.complete(Unit)
+                    if (!active.get()) return
                     logger.info("Chat with audio completed, total chunks: $responseCount")
                     trySend(
                         ChatResponse.newBuilder()
                             .setDone(true)
                             .build()
                     )
-                    done.complete(Unit)
                     close()
                 }
 
                 override fun onError(throwable: Throwable) {
+                    done.complete(Unit)
+                    if (!active.get()) return
                     logger.error("Error during chat with audio", throwable)
                     trySend(
                         ChatResponse.newBuilder()
@@ -530,7 +580,6 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                             .setDone(true)
                             .build()
                     )
-                    done.complete(Unit)
                     close(throwable)
                 }
             }
@@ -590,9 +639,22 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
     override suspend fun closeConversation(request: CloseConversationRequest): CloseConversationResponse {
         val conversation = conversations.remove(request.conversationId)
         if (conversation != null) {
+            // Acquire the per-conversation mutex before closing. This waits for any
+            // ongoing sendMessageAsync to finish (or be cancelled) before calling
+            // conversation.close(), preventing use-after-free in native decode.
+            val convMutex = conversationMutexes.remove(request.conversationId)
             try {
-                conversation.close()
-                logger.info("Closed conversation: ${request.conversationId}")
+                if (convMutex != null) {
+                    // Signal native to stop, then wait for the lock.
+                    try { conversation.cancelProcess() } catch (_: Exception) { }
+                    convMutex.withLock {
+                        conversation.close()
+                        logger.info("Closed conversation (waited for inference): ${request.conversationId}")
+                    }
+                } else {
+                    conversation.close()
+                    logger.info("Closed conversation: ${request.conversationId}")
+                }
             } catch (e: Exception) {
                 logger.warn("Error closing conversation", e)
             }

--- a/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
+++ b/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
@@ -49,6 +49,22 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 .build()
         }
 
+        // Windows workaround: litertlm_jni.dll uses 32-bit stat() which overflows for files > 2 GiB.
+        // See: https://github.com/google-ai-edge/LiteRT-LM/issues/1494
+        if (System.getProperty("os.name")?.lowercase()?.contains("windows") == true
+            && modelFile.length() > 2L * 1024 * 1024 * 1024) {
+            val sizeGb = modelFile.length().toDouble() / (1024.0 * 1024.0 * 1024.0)
+            return InitializeResponse.newBuilder()
+                .setSuccess(false)
+                .setError(
+                    "Model file (%.1f GB) exceeds the 2 GB Windows limit. ".format(sizeGb) +
+                    "Known upstream bug in litertlm_jni.dll (google-ai-edge/LiteRT-LM#1494): " +
+                    "32-bit stat() overflows for files > 2 GB. " +
+                    "Use a smaller model (< 2 GB) until Google fixes this upstream."
+                )
+                .build()
+        }
+
         // Use mutex to protect engine state
         return engineMutex.withLock {
             try {

--- a/macos/scripts/setup_desktop.sh
+++ b/macos/scripts/setup_desktop.sh
@@ -58,9 +58,9 @@ JRE_CHECKSUM_X64="4a36280b411db58952bc97a26f96b184222b23d36ea5008a6ee34744989ff9
 
 # JAR settings
 JAR_NAME="litertlm-server.jar"
-JAR_VERSION="0.13.1"
+JAR_VERSION="0.13.3"
 JAR_URL="https://github.com/DenisovAV/flutter_gemma/releases/download/v${JAR_VERSION}/${JAR_NAME}"
-JAR_CHECKSUM="97e01020f921c098f7cfc0a9509e4b207b8bc326703ae2f26bbce3c11b957430"
+JAR_CHECKSUM="6cb0ac8aa0b89c542bb9acd265c8881eb70e11e7aeab9f15d78197536b207e77"
 JAR_CACHE_DIR="$HOME/Library/Caches/flutter_gemma/jar"
 
 echo "Plugin root: $PLUGIN_ROOT"

--- a/macos/scripts/setup_desktop.sh
+++ b/macos/scripts/setup_desktop.sh
@@ -480,6 +480,60 @@ ENTITLEMENTS
     echo "JRE signed with sandbox inheritance"
 }
 
+# === Download and install LiteRT Metal accelerator (GPU inference) ===
+# libLiteRtMetalAccelerator.dylib provides the Metal-based GPU sampler for LiteRT-LM.
+# Without it, inference falls back to the statically linked C API sampler, which
+# can crash with certain models (see: https://github.com/DenisovAV/flutter_gemma/issues/219).
+setup_litert_gpu() {
+    local NATIVES_DIR="$FRAMEWORKS_DIR/litertlm"
+    local METAL_DYLIB="$NATIVES_DIR/libLiteRtMetalAccelerator.dylib"
+
+    if [[ -f "$METAL_DYLIB" ]]; then
+        echo "LiteRT Metal accelerator already installed"
+        return 0
+    fi
+
+    if [[ "$ARCH" != "arm64" ]]; then
+        echo "WARNING: LiteRT Metal accelerator only available for arm64 macOS"
+        return 0
+    fi
+
+    local METAL_VERSION="0.13.1"
+    local METAL_URL="https://github.com/DenisovAV/flutter_gemma/releases/download/v${METAL_VERSION}/libLiteRtMetalAccelerator.dylib"
+    local METAL_CHECKSUM="2a1ec5b062f509451d0377283c752e0dde7231b9e5cbb6eee927757f7c10fa65"
+    local CACHE_DIR="$HOME/Library/Caches/flutter_gemma/litert_gpu"
+    local CACHED="$CACHE_DIR/libLiteRtMetalAccelerator.dylib"
+
+    echo "Setting up LiteRT Metal accelerator (GPU inference)..."
+    mkdir -p "$CACHE_DIR" "$NATIVES_DIR"
+
+    if [[ ! -f "$CACHED" ]]; then
+        echo "Downloading from $METAL_URL..."
+        if ! curl -L -o "$CACHED" "$METAL_URL" --fail --retry 3 --progress-bar; then
+            echo "WARNING: Failed to download Metal accelerator — GPU inference may crash on some models"
+            echo "  See: https://github.com/DenisovAV/flutter_gemma/issues/219"
+            rm -f "$CACHED"
+            return 0
+        fi
+
+        local actual_checksum
+        actual_checksum=$(shasum -a 256 "$CACHED" | awk '{print $1}')
+        if [[ "$actual_checksum" != "$METAL_CHECKSUM" ]]; then
+            rm -f "$CACHED"
+            echo "WARNING: Metal accelerator checksum mismatch (expected $METAL_CHECKSUM, got $actual_checksum)"
+            return 0
+        fi
+        echo "Checksum verified"
+    else
+        echo "Using cached Metal accelerator"
+    fi
+
+    cp "$CACHED" "$METAL_DYLIB"
+    xattr -r -d com.apple.quarantine "$METAL_DYLIB" 2>/dev/null || true
+    codesign --force --sign - "$METAL_DYLIB"
+    echo "LiteRT Metal accelerator installed ($(du -h "$METAL_DYLIB" | cut -f1))"
+}
+
 # === Download and install TFLite C library (for desktop embeddings) ===
 setup_tflite() {
     local tflite_dest="$RESOURCES_DIR/tflite"
@@ -553,6 +607,7 @@ setup_tflite() {
 download_jre
 setup_jar
 extract_natives
+setup_litert_gpu
 setup_tflite
 remove_quarantine
 sign_jre

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.13.2
+version: 0.13.3
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 

--- a/windows/scripts/setup_desktop.ps1
+++ b/windows/scripts/setup_desktop.ps1
@@ -87,9 +87,9 @@ $JreChecksums = @{
 
 # JAR settings
 $JarName = "litertlm-server.jar"
-$JarVersion = "0.13.1"
+$JarVersion = "0.13.3"
 $JarUrl = "https://github.com/DenisovAV/flutter_gemma/releases/download/v$JarVersion/$JarName"
-$JarChecksum = "97e01020f921c098f7cfc0a9509e4b207b8bc326703ae2f26bbce3c11b957430"
+$JarChecksum = "6cb0ac8aa0b89c542bb9acd265c8881eb70e11e7aeab9f15d78197536b207e77"
 $JarCacheDir = "$env:LOCALAPPDATA\flutter_gemma\jar"
 $PluginRoot = Split-Path -Parent $PluginDir
 


### PR DESCRIPTION
## Summary

- **Fix macOS SIGSEGV (#219)**: Per-conversation mutex in gRPC server serializes `sendMessageAsync` with `conversation.close()` — eliminates use-after-free crash in native C++ decode. Regression test C3 (prefill-disconnect with Qwen 2.5 1.5B) confirmed SIGSEGV before fix, clean after.
- **Fix macOS Metal accelerator**: `setup_desktop.sh` downloads `libLiteRtMetalAccelerator.dylib` so GPU inference uses Metal delegate instead of falling back to static C API sampler.
- **Fix iOS pod install hanging (#220)**: `TensorFlowLiteSwift` was a source pod that triggered a full clone of the TensorFlow repository. Replaced with direct `TensorFlowLiteC` C API in `EmbeddingModel.swift`. Both simulator and device builds verified clean.
- **Fix Windows >2 GB model error (#212)**: Clear error message for known upstream 32-bit stat() overflow in litertlm_jni.dll (google-ai-edge/LiteRT-LM#1494).
- **Fix iOS arm64 simulator build (#216)**: Excluded arm64 from iphonesimulator archs.
- **Download reliability tests (#192)**: Integration tests + DOWNLOAD_TESTING.md documenting the 9-min WorkManager timeout and HuggingFace weak ETag limitation.