### PR TITLE
Fix iOS compile error and arm64 simulator build (#222, #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.4
+- **Fix iOS compile error (#222)**: XNNPack delegate type mismatch in `EmbeddingModel.swift`
+- **Fix iOS arm64 simulator (#216)**: Removed `TensorFlowLiteSelectTfOps` — simulator builds work on Apple Silicon
+
 ## 0.13.3
 - **Fix macOS SIGSEGV (#219)**: Per-conversation mutex in gRPC server prevents `conversation.close()` racing with `sendMessageAsync` on a native thread → use-after-free in C++ fixed
 - **Fix macOS desktop Metal accelerator**: `setup_desktop.sh` now downloads `libLiteRtMetalAccelerator.dylib` from GitHub Release so GPU inference uses the Metal delegate instead of falling back to static C API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM Android**: `com.google.ai.edge.litertlm:litertlm-android:0.10.0`
-- **Current Version**: 0.13.3
+- **Current Version**: 0.13.4
 
 ## Platform-Specific Setup
 

--- a/README.md
+++ b/README.md
@@ -192,27 +192,6 @@ platform :ios, '16.0'  # Required for MediaPipe GenAI
 use_frameworks! :linkage => :static
 ```
 
-* **For embedding models**, add force_load to `Podfile`'s post_install hook:
-```ruby
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    flutter_additional_ios_build_settings(target)
-
-    # Required for embedding models (TensorFlow Lite SelectTfOps)
-    if target.name == 'Runner'
-      target.build_configurations.each do |config|
-        sdk = config.build_settings['SDKROOT']
-        if sdk.nil? || !sdk.include?('simulator')
-          config.build_settings['OTHER_LDFLAGS'] ||= ['$(inherited)']
-          config.build_settings['OTHER_LDFLAGS'] << '-force_load'
-          config.build_settings['OTHER_LDFLAGS'] << '$(PODS_ROOT)/TensorFlowLiteSelectTfOps/Frameworks/TensorFlowLiteSelectTfOps.xcframework/ios-arm64/TensorFlowLiteSelectTfOps.framework/TensorFlowLiteSelectTfOps'
-        end
-      end
-    end
-  end
-end
-```
-
 **Android**
 
 * If you want to use a GPU to work with the model, you need to add OpenGL support in the manifest.xml. If you plan to use only the CPU, you can skip this step.
@@ -2213,7 +2192,7 @@ final supported = await FlutterGemma.isStreamingSupported();
 - **Memory entitlements:** Required for large models (see Setup section)
 - **Linking:** Static linking required (`use_frameworks! :linkage => :static`)
 - **Storage:** Local file system in app documents directory
-- **Embedding models:** Require force_load for TensorFlowLiteSelectTfOps in Podfile (see Setup section)
+- **Embedding models:** Supported via TensorFlowLiteC — no extra Podfile configuration needed
 
 The full and complete example you can find in `example` folder
 
@@ -2253,29 +2232,6 @@ The full and complete example you can find in `example` folder
 - Use static linking: `use_frameworks! :linkage => :static`
 - Clean and reinstall pods: `cd ios && pod install --repo-update`
 - Check that all required entitlements are in `Runner.entitlements`
-
-**iOS Embedding Models:**
-For embedding models on iOS, you must add force_load to your Podfile's post_install hook:
-
-```ruby
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    flutter_additional_ios_build_settings(target)
-
-    # Required for embedding models
-    if target.name == 'Runner'
-      target.build_configurations.each do |config|
-        sdk = config.build_settings['SDKROOT']
-        if sdk.nil? || !sdk.include?('simulator')
-          config.build_settings['OTHER_LDFLAGS'] ||= ['$(inherited)']
-          config.build_settings['OTHER_LDFLAGS'] << '-force_load'
-          config.build_settings['OTHER_LDFLAGS'] << '$(PODS_ROOT)/TensorFlowLiteSelectTfOps/Frameworks/TensorFlowLiteSelectTfOps.xcframework/ios-arm64/TensorFlowLiteSelectTfOps.framework/TensorFlowLiteSelectTfOps'
-        end
-      end
-    end
-  end
-end
-```
 
 ## Advanced Usage
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,18 +42,6 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
 
-    # Force load TensorFlowLiteSelectTfOps for embedding models (device only, no simulator slice)
-    if target.name == 'Runner'
-      target.build_configurations.each do |config|
-        sdk = config.build_settings['SDKROOT']
-        if sdk.nil? || !sdk.include?('simulator')
-          config.build_settings['OTHER_LDFLAGS'] ||= ['$(inherited)']
-          config.build_settings['OTHER_LDFLAGS'] << '-force_load'
-          config.build_settings['OTHER_LDFLAGS'] << '$(PODS_ROOT)/TensorFlowLiteSelectTfOps/Frameworks/TensorFlowLiteSelectTfOps.xcframework/ios-arm64/TensorFlowLiteSelectTfOps.framework/TensorFlowLiteSelectTfOps'
-        end
-      end
-    end
-
   end
 
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -9,7 +9,6 @@ PODS:
     - MediaPipeTasksGenAI (= 0.10.33)
     - MediaPipeTasksGenAIC (= 0.10.33)
     - TensorFlowLiteC (= 0.0.1-nightly.20250619)
-    - TensorFlowLiteSelectTfOps (= 0.0.1-nightly.20250619)
   - image_picker_ios (0.0.1):
     - Flutter
   - integration_test (0.0.1):
@@ -35,7 +34,6 @@ PODS:
   - TensorFlowLiteC (0.0.1-nightly.20250619):
     - TensorFlowLiteC/Core (= 0.0.1-nightly.20250619)
   - TensorFlowLiteC/Core (0.0.1-nightly.20250619)
-  - TensorFlowLiteSelectTfOps (0.0.1-nightly.20250619)
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -59,7 +57,6 @@ SPEC REPOS:
     - MediaPipeTasksGenAI
     - MediaPipeTasksGenAIC
     - TensorFlowLiteC
-    - TensorFlowLiteSelectTfOps
 
 EXTERNAL SOURCES:
   audio_session:
@@ -93,7 +90,7 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   background_downloader: 50e91d979067b82081aba359d7d916b3ba5fadad
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_gemma: 285a66dbfff8949e1eeef7dfeb76a5840fb49b16
+  flutter_gemma: 9c2e4bb34f83c0346119291d6a40b89d62dfad09
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
@@ -105,9 +102,8 @@ SPEC CHECKSUMS:
   record_ios: f75fa1d57f840012775c0e93a38a7f3ceea1a374
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   TensorFlowLiteC: 215ef57653dd0fa09a474e7d94d79ae64a870b28
-  TensorFlowLiteSelectTfOps: c71d7dcd063f5d66ae1b9a85cc5aa993f824eff9
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
-PODFILE CHECKSUM: 3efd182c50317a46ac0f4e91a35a38918e286303
+PODFILE CHECKSUM: c61502891ef153f16fe017dcbdbba41944a588fb
 
 COCOAPODS: 1.16.2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.3"
+    version: "0.13.4"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.2"
+    version: "0.13.3"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/Classes/EmbeddingModel.swift
+++ b/ios/Classes/EmbeddingModel.swift
@@ -60,10 +60,11 @@ class EmbeddingModel {
         // NOTE: TfLiteXNNPackDelegateCreate returns a caller-owned pointer.
         // TfLiteInterpreterOptionsAddDelegate does NOT take ownership in the C API.
         // We store it in self.xnnpackDelegate and delete it in close() AFTER the interpreter.
-        if let xDelegate = TfLiteXNNPackDelegateCreate(&xnnpackOptions) {
-            TfLiteInterpreterOptionsAddDelegate(options, xDelegate)
-            xnnpackDelegate = xDelegate
+        guard let xDelegate = TfLiteXNNPackDelegateCreate(&xnnpackOptions) else {
+            throw EmbeddingError.modelLoadFailed("XNNPack delegate creation failed — required for correct mixed-precision inference")
         }
+        TfLiteInterpreterOptionsAddDelegate(options, xDelegate)
+        xnnpackDelegate = xDelegate
 
         guard let interp = TfLiteInterpreterCreate(model, options) else {
             throw EmbeddingError.modelLoadFailed("TfLiteInterpreterCreate failed")

--- a/ios/Classes/EmbeddingModel.swift
+++ b/ios/Classes/EmbeddingModel.swift
@@ -24,7 +24,7 @@ class EmbeddingModel {
     private var outputBuffer: [Float] = []
 
     // XNNPack delegate — caller owns it in TFLiteC API, must be deleted after interpreter
-    private var xnnpackDelegate: OpaquePointer?
+    private var xnnpackDelegate: UnsafeMutablePointer<TfLiteDelegate>?
 
     // MARK: - Initialization
 

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.13.3'
+  s.version          = '0.13.4'
   s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
   s.description      = <<-DESC
 The plugin allows running the Gemma AI model locally on a device from a Flutter application.
@@ -19,15 +19,10 @@ Includes support for Gemma 3 Nano models with optimized MediaPipe GenAI v0.10.33
   s.dependency 'MediaPipeTasksGenAI', '= 0.10.33'
   s.dependency 'MediaPipeTasksGenAIC', '= 0.10.33'
   s.dependency 'TensorFlowLiteC', '0.0.1-nightly.20250619'
-  s.dependency 'TensorFlowLiteSelectTfOps', '0.0.1-nightly.20250619'
   s.platform = :ios, '16.0'
 
   s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64',
-    # Conditional force_load: only for device builds (TensorFlowLiteSelectTfOps doesn't have simulator slice)
-    'OTHER_LDFLAGS[sdk=iphoneos*]' => '-force_load $(SRCROOT)/Pods/TensorFlowLiteSelectTfOps/Frameworks/TensorFlowLiteSelectTfOps.xcframework/ios-arm64/TensorFlowLiteSelectTfOps.framework/TensorFlowLiteSelectTfOps',
-    'OTHER_LDFLAGS[sdk=iphonesimulator*]' => ''
+    'DEFINES_MODULE' => 'YES'
   }
   s.swift_version = '5.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.13.3
+version: 0.13.4
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 


### PR DESCRIPTION
## Summary
- Fix Swift compile error: `OpaquePointer` → `UnsafeMutablePointer<TfLiteDelegate>` in `EmbeddingModel.swift` (#222)
- Remove `TensorFlowLiteSelectTfOps` dependency — not needed for embedding models, was blocking arm64 simulator builds (#216)
- Remove `EXCLUDED_ARCHS` from podspec — arm64 simulators now work on Apple Silicon
- Update README: remove obsolete SelectTfOps Podfile instructions

Closes #222
Closes #216