### PR TITLE
Fix Qwen3 thinking mode (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13.5
+- **Fix Qwen3 thinking mode (#224)**: Qwen3 `<think>` tags now stripped automatically
+
 ## 0.13.4
 - **Fix iOS compile error (#222)**: XNNPack delegate type mismatch in `EmbeddingModel.swift`
 - **Fix iOS arm64 simulator (#216)**: Removed `TensorFlowLiteSelectTfOps` — simulator builds work on Apple Silicon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,12 @@
 | Llama 3.2 1B | ❌ | ❌ | ❌ | Android, iOS, Web |
 | Hammer 2.1 0.5B | ✅ | ❌ | ❌ | Android, iOS, Web |
 | DeepSeek | ✅ | ✅ | ❌ | Android, iOS, Web |
+| Qwen3 | ✅ | ✅ ² | ❌ | Android, iOS, Web, Desktop |
 | Qwen2.5 | ✅ | ❌ | ❌ | Android, iOS, Web |
 | Phi-4 | ❌ | ❌ | ❌ | Android, iOS, Web |
 
 > ¹ Thinking Mode for Gemma 4: Android, iOS, Desktop only. Web (MediaPipe) does not support `extraContext`.
+> ² Qwen3 generates thinking by default; tags are stripped when `isThinking: false`.
 
 ### Platform Limitations
 
@@ -108,7 +110,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM Android**: `com.google.ai.edge.litertlm:litertlm-android:0.10.0`
-- **Current Version**: 0.13.4
+- **Current Version**: 0.13.5
 
 ## Platform-Specific Setup
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The example app offers a curated list of models, each suited for different tasks
 | **FastVLM 0.5B** | Fast vision-language inference | ❌ | ❌ | ✅ | Multilingual | 0.5GB |
 | **Phi-4 Mini** | Advanced reasoning and instruction following | ✅ | ❌ | ❌ | Multilingual | 3.9GB |
 | **DeepSeek R1** | High-performance reasoning and code generation | ✅ | ✅ | ❌ | Multilingual | 1.7GB |
-| **Qwen3 0.6B** | Compact multilingual chat with function calling | ✅ | ❌ | ❌ | Multilingual | 586MB |
+| **Qwen3 0.6B** | Compact multilingual chat with function calling | ✅ | ✅ | ❌ | Multilingual | 586MB |
 | **Qwen 2.5** | Strong multilingual chat and instruction following | ✅ | ❌ | ❌ | Multilingual | 0.5-1.6GB |
 | **Gemma 3 1B** | Balanced and efficient text generation | ❌ | ❌ | ❌ | Multilingual | 0.5GB |
 | **Gemma 3 270M** | Ideal for fine-tuning (LoRA) for specific tasks | ❌ | ❌ | ❌ | Multilingual | 0.3GB |
@@ -1535,9 +1535,11 @@ FunctionGemma uses a special format (different from JSON-based function calling)
 
 The `flutter_gemma` plugin handles this format automatically via `FunctionCallParser`.
 
-9. **🧠 Thinking Mode (DeepSeek & Gemma 4 Models)**
+9. **🧠 Thinking Mode (DeepSeek, Qwen3 & Gemma 4 Models)**
 
-DeepSeek and Gemma 4 (E2B/E4B) models support "thinking mode" where you can see the model's reasoning process before it generates the final response. This provides transparency into how the model approaches problems.
+DeepSeek, Qwen3, and Gemma 4 (E2B/E4B) models support "thinking mode" where you can see the model's reasoning process before it generates the final response. This provides transparency into how the model approaches problems.
+
+> **Note:** Qwen3 generates thinking blocks by default. When `isThinking: false`, thinking content is automatically stripped from the response. Set `isThinking: true` to see the reasoning process.
 
 **Enable Thinking Mode (DeepSeek):**
 

--- a/example/integration_test/desktop_thinking_all_models_test.dart
+++ b/example/integration_test/desktop_thinking_all_models_test.dart
@@ -1,0 +1,179 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+/// Comprehensive thinking mode test for all available models.
+/// Verifies that <think> tags are handled correctly for every ModelType.
+///
+/// Run: flutter test integration_test/desktop_thinking_all_models_test.dart -d macos
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // Models available in the sandbox container
+  final sandboxDir = '${Platform.environment['HOME']}/Documents';
+
+  final models = <String, _TestModel>{
+    'Qwen3-0.6B': _TestModel(
+      path: '$sandboxDir/Qwen3-0.6B.litertlm',
+      modelType: ModelType.qwen,
+      fileType: ModelFileType.litertlm,
+      generatesThinking: true,
+    ),
+    'Qwen2.5-1.5B': _TestModel(
+      path:
+          '$sandboxDir/Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv4096.litertlm',
+      modelType: ModelType.qwen,
+      fileType: ModelFileType.litertlm,
+      generatesThinking: false,
+    ),
+    'Gemma4-E2B': _TestModel(
+      path: '$sandboxDir/gemma-4-E2B-it.litertlm',
+      modelType: ModelType.gemmaIt,
+      fileType: ModelFileType.litertlm,
+      generatesThinking: false, // only with extraContext
+    ),
+    'Gemma3-1B': _TestModel(
+      path: '$sandboxDir/Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm',
+      modelType: ModelType.gemmaIt,
+      fileType: ModelFileType.litertlm,
+      generatesThinking: false,
+    ),
+    'Gemma-3n-E2B': _TestModel(
+      path: '$sandboxDir/gemma-3n-E2B-it-int4.litertlm',
+      modelType: ModelType.gemmaIt,
+      fileType: ModelFileType.litertlm,
+      generatesThinking: false,
+    ),
+    'FunctionGemma-270M': _TestModel(
+      path: '$sandboxDir/functiongemma-270M-it.litertlm',
+      modelType: ModelType.functionGemma,
+      fileType: ModelFileType.litertlm,
+      generatesThinking: false,
+    ),
+  };
+
+  for (final entry in models.entries) {
+    final name = entry.key;
+    final config = entry.value;
+
+    testWidgets('$name: isThinking=false — no think tags in output',
+        (tester) async {
+      if (!File(config.path).existsSync()) {
+        debugPrint('SKIP: $name not found at ${config.path}');
+        return;
+      }
+
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: config.modelType,
+        fileType: config.fileType,
+      ).fromFile(config.path).install();
+
+      final model = await FlutterGemma.getActiveModel(maxTokens: 256);
+      try {
+        final chat = await model.createChat(
+          modelType: config.modelType,
+          isThinking: false,
+        );
+
+        await chat.addQuery(
+            const Message(text: 'What is 2+2? Answer briefly.', isUser: true));
+        final response = await chat.generateChatResponse();
+        final text =
+            response is TextResponse ? response.token : response.toString();
+        debugPrint('[$name isThinking=false] Response: $text');
+
+        expect(text.trim(), isNotEmpty,
+            reason: '$name: response should not be empty');
+        expect(text, isNot(contains('<think>')),
+            reason: '$name: <think> tags should be stripped');
+        expect(text, isNot(contains('</think>')),
+            reason: '$name: </think> tags should be stripped');
+
+        await chat.close();
+      } finally {
+        await model.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 5)));
+
+    testWidgets('$name: isThinking=true — response not empty, no raw tags',
+        (tester) async {
+      if (!File(config.path).existsSync()) {
+        debugPrint('SKIP: $name not found at ${config.path}');
+        return;
+      }
+
+      await FlutterGemma.initialize();
+
+      await FlutterGemma.installModel(
+        modelType: config.modelType,
+        fileType: config.fileType,
+      ).fromFile(config.path).install();
+
+      final model = await FlutterGemma.getActiveModel(maxTokens: 256);
+      try {
+        final chat = await model.createChat(
+          modelType: config.modelType,
+          isThinking: true,
+        );
+
+        await chat.addQuery(
+            const Message(text: 'What is 2+2? Answer briefly.', isUser: true));
+
+        final responses = <ModelResponse>[];
+        await for (final response in chat.generateChatResponseAsync()) {
+          responses.add(response);
+        }
+
+        final thinkingCount = responses.whereType<ThinkingResponse>().length;
+        final textCount = responses.whereType<TextResponse>().length;
+
+        debugPrint(
+            '[$name isThinking=true] Thinking: $thinkingCount, Text: $textCount');
+
+        // Models that generate thinking should have ThinkingResponse
+        if (config.generatesThinking) {
+          expect(responses.any((r) => r is ThinkingResponse), isTrue,
+              reason: '$name: should emit ThinkingResponse');
+        }
+
+        // All models should have some text output
+        expect(responses.any((r) => r is TextResponse), isTrue,
+            reason: '$name: should emit TextResponse');
+
+        // TextResponse should never contain raw thinking tags
+        final textContent =
+            responses.whereType<TextResponse>().map((r) => r.token).join();
+        debugPrint('[$name isThinking=true] Text: $textContent');
+        expect(textContent.trim(), isNotEmpty,
+            reason: '$name: text response should not be empty');
+        expect(textContent, isNot(contains('<think>')),
+            reason: '$name: TextResponse should not contain raw <think>');
+        expect(textContent, isNot(contains('</think>')),
+            reason: '$name: TextResponse should not contain raw </think>');
+
+        await chat.close();
+      } finally {
+        await model.close();
+      }
+    }, timeout: const Timeout(Duration(minutes: 5)));
+  }
+}
+
+class _TestModel {
+  final String path;
+  final ModelType modelType;
+  final ModelFileType fileType;
+  final bool generatesThinking;
+
+  const _TestModel({
+    required this.path,
+    required this.modelType,
+    required this.fileType,
+    required this.generatesThinking,
+  });
+}

--- a/example/integration_test/desktop_thinking_qwen3_test.dart
+++ b/example/integration_test/desktop_thinking_qwen3_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+/// Regression test for issue #224: Qwen3-0.6B generates <think> blocks by default
+/// even when isThinking is false. Verify that thinking tags are stripped from output.
+///
+/// Run: flutter test integration_test/desktop_thinking_qwen3_test.dart -d macos
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const modelUrl =
+      'https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/Qwen3-0.6B.litertlm';
+
+  testWidgets('Qwen3: thinking tags stripped when isThinking=false',
+      (tester) async {
+    await FlutterGemma.initialize();
+
+    // Install Qwen3 model
+    await FlutterGemma.installModel(
+      modelType: ModelType.qwen,
+      fileType: ModelFileType.litertlm,
+    ).fromNetwork(modelUrl).install();
+
+    final model = await FlutterGemma.getActiveModel(maxTokens: 512);
+    try {
+      // Create chat WITHOUT thinking mode
+      final chat = await model.createChat(
+        modelType: ModelType.qwen,
+        isThinking: false,
+      );
+
+      await chat.addQuery(const Message(text: 'What is 2+2?', isUser: true));
+
+      // Test sync response
+      final response = await chat.generateChatResponse();
+      final text =
+          response is TextResponse ? response.token : response.toString();
+      debugPrint('Response (isThinking=false): $text');
+
+      expect(text, isNot(contains('<think>')),
+          reason: 'Thinking tags should be stripped when isThinking=false');
+      expect(text, isNot(contains('</think>')),
+          reason:
+              'Thinking close tags should be stripped when isThinking=false');
+      expect(text.trim(), isNotEmpty,
+          reason: 'Response should not be empty after stripping');
+
+      await chat.close();
+    } finally {
+      await model.close();
+    }
+  }, timeout: const Timeout(Duration(minutes: 10)));
+
+  testWidgets('Qwen3: thinking tags present when isThinking=true',
+      (tester) async {
+    await FlutterGemma.initialize();
+
+    final model = await FlutterGemma.getActiveModel(maxTokens: 512);
+    try {
+      // Create chat WITH thinking mode
+      final chat = await model.createChat(
+        modelType: ModelType.qwen,
+        isThinking: true,
+      );
+
+      await chat.addQuery(const Message(text: 'What is 2+2?', isUser: true));
+
+      // Test streaming response — should emit ThinkingResponse events
+      final responses = <ModelResponse>[];
+      await for (final response in chat.generateChatResponseAsync()) {
+        responses.add(response);
+      }
+
+      final hasThinking = responses.any((r) => r is ThinkingResponse);
+      final hasText = responses.any((r) => r is TextResponse);
+
+      debugPrint(
+          'Thinking responses: ${responses.whereType<ThinkingResponse>().length}');
+      debugPrint(
+          'Text responses: ${responses.whereType<TextResponse>().length}');
+
+      expect(hasThinking, isTrue,
+          reason: 'Should emit ThinkingResponse when isThinking=true');
+      expect(hasText, isTrue,
+          reason: 'Should emit TextResponse after thinking');
+
+      // Verify text responses don't contain raw think tags
+      final textContent =
+          responses.whereType<TextResponse>().map((r) => r.token).join();
+      expect(textContent, isNot(contains('<think>')),
+          reason: 'TextResponse tokens should not contain raw think tags');
+
+      await chat.close();
+    } finally {
+      await model.close();
+    }
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}

--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -85,7 +85,8 @@ enum Model implements InferenceModelInterface {
     topK: 64,
     topP: 0.95,
     supportImage: true,
-    supportAudio: false, // .task files don't have TF_LITE_AUDIO_ENCODER - audio only in .litertlm
+    supportAudio:
+        false, // .task files don't have TF_LITE_AUDIO_ENCODER - audio only in .litertlm
     maxTokens: 4096,
     maxNumImages: 1,
     supportsFunctionCalls: false, // Disabled - causes issues with multimodal
@@ -109,7 +110,8 @@ enum Model implements InferenceModelInterface {
     topK: 64,
     topP: 0.95,
     supportImage: true,
-    supportAudio: false, // .task files don't have TF_LITE_AUDIO_ENCODER - need .litertlm
+    supportAudio:
+        false, // .task files don't have TF_LITE_AUDIO_ENCODER - need .litertlm
     maxTokens: 4096,
     maxNumImages: 1,
     supportsFunctionCalls: false, // Disabled - causes issues with multimodal
@@ -178,7 +180,8 @@ enum Model implements InferenceModelInterface {
     temperature: 1.0,
     topK: 64,
     topP: 0.95,
-    supportImage: false, // Disabled: MediaPipe iOS can't find Vision/Audio calculators for .litertlm
+    supportImage:
+        false, // Disabled: MediaPipe iOS can't find Vision/Audio calculators for .litertlm
     supportAudio: false, // Disabled: testing text-only mode first
     maxTokens: 4096,
   ),
@@ -281,6 +284,7 @@ enum Model implements InferenceModelInterface {
     topP: 0.95,
     maxTokens: 4096,
     supportsFunctionCalls: true,
+    isThinking: true,
   ),
 
   deepseek(
@@ -432,7 +436,6 @@ enum Model implements InferenceModelInterface {
     licenseUrl: '',
     needsAuth: false,
     localModel: true,
-
     preferredBackend: PreferredBackend.gpu,
     modelType: ModelType.functionGemma,
     fileType: ModelFileType.litertlm,
@@ -450,7 +453,8 @@ enum Model implements InferenceModelInterface {
     filename: 'functiongemma-flutter_q8_ekv1024.task',
     displayName: 'FunctionGemma Demo (Fine-tuned)',
     size: '284MB',
-    licenseUrl: 'https://huggingface.co/sasha-denisov/functiongemma-flutter-gemma-demo',
+    licenseUrl:
+        'https://huggingface.co/sasha-denisov/functiongemma-flutter-gemma-demo',
     needsAuth: false,
     preferredBackend: PreferredBackend.gpu,
     modelType: ModelType.functionGemma,
@@ -460,6 +464,7 @@ enum Model implements InferenceModelInterface {
     maxTokens: 1024,
     supportsFunctionCalls: true,
   );
+
   // Define fields for the enum
   final String baseUrl;
   final String? webUrl;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.4"
+    version: "0.13.5"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -194,15 +194,24 @@ class InferenceChat {
     final originalStream =
         session.getResponseAsync().map((token) => TextResponse(token));
 
-    // Apply thinking filter if needed using ModelThinkingFilter
-    final Stream<ModelResponse> filteredStream = isThinking
+    // Apply thinking filter — some models (Qwen3, DeepSeek) generate <think> by default
+    final bool modelCanThink = modelType == ModelType.deepSeek ||
+        modelType == ModelType.qwen ||
+        modelType == ModelType.gemmaIt;
+    final Stream<ModelResponse> filteredStream = (isThinking || modelCanThink)
         ? ModelThinkingFilter.filterThinkingStream(originalStream,
             modelType: modelType)
         : originalStream;
 
+    // If user didn't request thinking, discard ThinkingResponse events
+    final Stream<ModelResponse> thinkingHandledStream = isThinking
+        ? filteredStream
+        : filteredStream.where((r) => r is! ThinkingResponse);
+
     // Apply stop token filter for .litertlm on iOS (MediaPipe doesn't handle stop tokens)
     final Stream<ModelResponse> stopFilteredStream =
-        StopTokenFilter.filterStopTokens(filteredStream, fileType: fileType);
+        StopTokenFilter.filterStopTokens(thinkingHandledStream,
+            fileType: fileType);
 
     await for (final response in stopFilteredStream) {
       if (response is TextResponse) {

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -5,7 +5,8 @@ import 'package:flutter_gemma/core/model_response.dart';
 
 const userPrefix = "user";
 const modelPrefix = "model";
-const developerPrefix = "developer"; // FunctionGemma uses developer role for tools
+const developerPrefix =
+    "developer"; // FunctionGemma uses developer role for tools
 const startTurn = "<start_of_turn>";
 const endTurn = "<end_of_turn>";
 
@@ -36,9 +37,11 @@ const functionGemmaEscape = '<escape>';
 
 extension MessageExtension on Message {
   String transformToChatPrompt(
-      {ModelType type = ModelType.general, ModelFileType fileType = ModelFileType.binary}) {
+      {ModelType type = ModelType.general,
+      ModelFileType fileType = ModelFileType.binary}) {
     // DEBUG LOG
-    debugPrint('[transformToChatPrompt] modelType=$type, fileType=$fileType, messageType=${this.type}, isUser=$isUser');
+    debugPrint(
+        '[transformToChatPrompt] modelType=$type, fileType=$fileType, messageType=${this.type}, isUser=$isUser');
 
     // System messages should not be sent to the model
     if (this.type == MessageType.systemInfo) {
@@ -49,7 +52,8 @@ extension MessageExtension on Message {
     // EXCEPT FunctionGemma which needs manual formatting (no prefix/suffix in .task)
     if (fileType == ModelFileType.task && type != ModelType.functionGemma) {
       final result = _formatToolResponseContent();
-      debugPrint('[transformToChatPrompt] Using _formatToolResponseContent, result length=${result.length}');
+      debugPrint(
+          '[transformToChatPrompt] Using _formatToolResponseContent, result length=${result.length}');
       return result;
     }
 
@@ -61,7 +65,8 @@ extension MessageExtension on Message {
         // Fall through to manual formatting below
       } else {
         final result = _formatToolResponseContent();
-        debugPrint('[transformToChatPrompt] litertlm non-iOS, using raw text, result length=${result.length}');
+        debugPrint(
+            '[transformToChatPrompt] litertlm non-iOS, using raw text, result length=${result.length}');
         return result;
       }
     }
@@ -181,8 +186,8 @@ extension MessageExtension on Message {
     // Format tool response in FunctionGemma format
     if (type == MessageType.toolResponse && toolName != null) {
       return '$functionGemmaStartResp'
-             'response:$toolName{result:$functionGemmaEscape$text$functionGemmaEscape}'
-             '$functionGemmaEndResp';
+          'response:$toolName{result:$functionGemmaEscape$text$functionGemmaEscape}'
+          '$functionGemmaEndResp';
     }
     return text;
   }
@@ -192,12 +197,12 @@ extension MessageExtension on Message {
 class ModelThinkingFilter {
   /// Filters ModelResponse stream for models with thinking support.
   /// Supports DeepSeek (`<think>...</think>`) and Gemma 4 (`<|channel>thought\n...<channel|>`) models.
-  static Stream<ModelResponse> filterThinkingStream(Stream<ModelResponse> originalStream,
+  static Stream<ModelResponse> filterThinkingStream(
+      Stream<ModelResponse> originalStream,
       {required ModelType modelType}) async* {
     switch (modelType) {
       case ModelType.deepSeek:
-        // Apply DeepSeek thinking filtration
-        // DeepSeek starts with thinking content, ends with </think>
+        // DeepSeek starts with raw thinking (no opening <think> tag), ends with </think>
         bool insideThinking = true;
         StringBuffer thinkingBuffer = StringBuffer();
 
@@ -206,39 +211,94 @@ class ModelThinkingFilter {
             String token = response.token;
 
             if (insideThinking) {
-              // Check for thinking block end
               if (token.contains('</think>')) {
-                // Add text before </think> to thinking
                 final beforeEnd = token.split('</think>')[0];
                 if (beforeEnd.isNotEmpty) {
                   thinkingBuffer.write(beforeEnd);
                 }
-
-                // Send completed thinking block
                 if (thinkingBuffer.isNotEmpty) {
                   yield ThinkingResponse(thinkingBuffer.toString());
                 }
-
-                // Switch to normal mode
                 insideThinking = false;
-
-                // Process text after </think> - pass as regular text for function call parsing
-                final afterEnd = token.split('</think>').skip(1).join('</think>');
+                final afterEnd =
+                    token.split('</think>').skip(1).join('</think>');
                 if (afterEnd.isNotEmpty) {
                   yield TextResponse(afterEnd);
                 }
               } else {
-                // Accumulate thinking content
                 thinkingBuffer.write(token);
-                // Send intermediate thinking
                 yield ThinkingResponse(token);
               }
             } else {
-              // Normal mode - pass tokens as is for function call parsing
               yield response;
             }
           } else {
-            // For FunctionCallResponse and other types just pass without changes
+            yield response;
+          }
+        }
+        break;
+
+      case ModelType.qwen:
+        // Qwen3 emits <think>...</think>, Qwen2.5 emits nothing.
+        // Start insideThinking=false — only enter thinking when <think> is found.
+        bool qwenInsideThinking = false;
+        StringBuffer qwenThinkingBuffer = StringBuffer();
+
+        await for (final response in originalStream) {
+          if (response is TextResponse) {
+            String token = response.token;
+
+            if (qwenInsideThinking) {
+              if (token.contains('</think>')) {
+                final beforeEnd = token.split('</think>')[0];
+                if (beforeEnd.isNotEmpty) {
+                  qwenThinkingBuffer.write(beforeEnd);
+                  yield ThinkingResponse(beforeEnd);
+                }
+                qwenInsideThinking = false;
+                qwenThinkingBuffer.clear();
+                final afterEnd =
+                    token.split('</think>').skip(1).join('</think>');
+                if (afterEnd.isNotEmpty) {
+                  yield TextResponse(afterEnd);
+                }
+              } else {
+                qwenThinkingBuffer.write(token);
+                yield ThinkingResponse(token);
+              }
+            } else {
+              if (token.contains('<think>')) {
+                final beforeStart = token.split('<think>')[0];
+                if (beforeStart.isNotEmpty) {
+                  yield TextResponse(beforeStart);
+                }
+                qwenInsideThinking = true;
+                qwenThinkingBuffer.clear();
+                final afterStart =
+                    token.split('<think>').skip(1).join('<think>');
+                if (afterStart.isNotEmpty) {
+                  if (afterStart.contains('</think>')) {
+                    final thinking = afterStart.split('</think>')[0];
+                    if (thinking.isNotEmpty) {
+                      yield ThinkingResponse(thinking);
+                    }
+                    qwenInsideThinking = false;
+                    final afterEnd =
+                        afterStart.split('</think>').skip(1).join('</think>');
+                    if (afterEnd.isNotEmpty) {
+                      yield TextResponse(afterEnd);
+                    }
+                  } else {
+                    qwenThinkingBuffer.write(afterStart);
+                    yield ThinkingResponse(afterStart);
+                  }
+                }
+              } else {
+                // No thinking tags — pass through as text (Qwen2.5 path)
+                yield response;
+              }
+            }
+          } else {
             yield response;
           }
         }
@@ -263,16 +323,19 @@ class ModelThinkingFilter {
                   if (thinkingContent.isNotEmpty) {
                     yield ThinkingResponse(thinkingContent);
                   }
-                  gemmaBuffer = gemmaBuffer.substring(endIdx + endMarker.length);
+                  gemmaBuffer =
+                      gemmaBuffer.substring(endIdx + endMarker.length);
                   gemmaInsideThinking = false;
                 } else {
                   // Check for partial end marker at tail
                   final partial = _findPartialSuffix(gemmaBuffer, endMarker);
-                  final safe = gemmaBuffer.substring(0, gemmaBuffer.length - partial);
+                  final safe =
+                      gemmaBuffer.substring(0, gemmaBuffer.length - partial);
                   if (safe.isNotEmpty) {
                     yield ThinkingResponse(safe);
                   }
-                  gemmaBuffer = gemmaBuffer.substring(gemmaBuffer.length - partial);
+                  gemmaBuffer =
+                      gemmaBuffer.substring(gemmaBuffer.length - partial);
                   break;
                 }
               } else {
@@ -282,16 +345,19 @@ class ModelThinkingFilter {
                   if (textBefore.isNotEmpty) {
                     yield TextResponse(textBefore);
                   }
-                  gemmaBuffer = gemmaBuffer.substring(startIdx + startMarker.length);
+                  gemmaBuffer =
+                      gemmaBuffer.substring(startIdx + startMarker.length);
                   gemmaInsideThinking = true;
                 } else {
                   // Check for partial start marker at tail
                   final partial = _findPartialSuffix(gemmaBuffer, startMarker);
-                  final safe = gemmaBuffer.substring(0, gemmaBuffer.length - partial);
+                  final safe =
+                      gemmaBuffer.substring(0, gemmaBuffer.length - partial);
                   if (safe.isNotEmpty) {
                     yield TextResponse(safe);
                   }
-                  gemmaBuffer = gemmaBuffer.substring(gemmaBuffer.length - partial);
+                  gemmaBuffer =
+                      gemmaBuffer.substring(gemmaBuffer.length - partial);
                   break;
                 }
               }
@@ -302,12 +368,13 @@ class ModelThinkingFilter {
         }
         // Flush remaining buffer
         if (gemmaBuffer.isNotEmpty) {
-          yield gemmaInsideThinking ? ThinkingResponse(gemmaBuffer) : TextResponse(gemmaBuffer);
+          yield gemmaInsideThinking
+              ? ThinkingResponse(gemmaBuffer)
+              : TextResponse(gemmaBuffer);
         }
         break;
 
       case ModelType.general:
-      case ModelType.qwen:
       case ModelType.llama:
       case ModelType.hammer:
       case ModelType.functionGemma:
@@ -322,20 +389,23 @@ class ModelThinkingFilter {
   /// Removes thinking blocks from final text.
   /// Supports DeepSeek (`<think>...</think>`) and Gemma 4 (`<|channel>thought\n...<channel|>`) models.
   /// Note: For streaming thinking output, use [filterThinkingStream] with generateChatResponseAsync() instead.
-  static String removeThinkingFromText(String text, {required ModelType modelType}) {
+  static String removeThinkingFromText(String text,
+      {required ModelType modelType}) {
     switch (modelType) {
       case ModelType.deepSeek:
-        // Remove all <think>...</think> blocks (DeepSeek specific)
+      case ModelType.qwen:
+        // Remove all <think>...</think> blocks (DeepSeek/Qwen3 format)
         RegExp thinkingRegex = RegExp(r'<think>.*?</think>', dotAll: true);
         return text.replaceAll(thinkingRegex, '').trim();
 
       case ModelType.gemmaIt:
         // Remove all <|channel>thought\n...<channel|> blocks (Gemma 4 E2B/E4B)
-        return text.replaceAll(
-          RegExp(r'<\|channel>thought\n.*?<channel\|>', dotAll: true), '').trim();
+        return text
+            .replaceAll(
+                RegExp(r'<\|channel>thought\n.*?<channel\|>', dotAll: true), '')
+            .trim();
 
       case ModelType.general:
-      case ModelType.qwen:
       case ModelType.llama:
       case ModelType.hammer:
       case ModelType.functionGemma:
@@ -348,11 +418,16 @@ class ModelThinkingFilter {
 
   /// Cleans model response from service tags and thinking blocks
   static String cleanResponse(String response,
-      {required bool isThinking, required ModelType modelType, required ModelFileType fileType}) {
+      {required bool isThinking,
+      required ModelType modelType,
+      required ModelFileType fileType}) {
     String cleaned = response;
 
-    // Remove <think> blocks if model supports thinking
-    if (isThinking) {
+    // Always strip thinking tags for models that may generate them (Qwen3, DeepSeek, Gemma 4)
+    final bool modelCanThink = modelType == ModelType.deepSeek ||
+        modelType == ModelType.qwen ||
+        modelType == ModelType.gemmaIt;
+    if (isThinking || modelCanThink) {
       cleaned = removeThinkingFromText(cleaned, modelType: modelType);
     }
 

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -196,111 +196,120 @@ extension MessageExtension on Message {
 // Filter class for thinking models
 class ModelThinkingFilter {
   /// Filters ModelResponse stream for models with thinking support.
-  /// Supports DeepSeek (`<think>...</think>`) and Gemma 4 (`<|channel>thought\n...<channel|>`) models.
+  /// Supports DeepSeek/Qwen3 (`<think>...</think>`) and Gemma 4 (`<|channel>thought\n...<channel|>`).
   static Stream<ModelResponse> filterThinkingStream(
       Stream<ModelResponse> originalStream,
       {required ModelType modelType}) async* {
     switch (modelType) {
       case ModelType.deepSeek:
-        // DeepSeek starts with raw thinking (no opening <think> tag), ends with </think>
-        bool insideThinking = true;
-        StringBuffer thinkingBuffer = StringBuffer();
+        // DeepSeek starts in thinking mode (no opening <think> tag).
+        // Uses buffer to handle partial </think> across token boundaries.
+        const endTag = '</think>';
+        bool dsInside = true;
+        String dsBuffer = '';
 
         await for (final response in originalStream) {
           if (response is TextResponse) {
-            String token = response.token;
+            dsBuffer += response.token;
 
-            if (insideThinking) {
-              if (token.contains('</think>')) {
-                final beforeEnd = token.split('</think>')[0];
-                if (beforeEnd.isNotEmpty) {
-                  thinkingBuffer.write(beforeEnd);
-                }
-                if (thinkingBuffer.isNotEmpty) {
-                  yield ThinkingResponse(thinkingBuffer.toString());
-                }
-                insideThinking = false;
-                final afterEnd =
-                    token.split('</think>').skip(1).join('</think>');
-                if (afterEnd.isNotEmpty) {
-                  yield TextResponse(afterEnd);
+            while (dsBuffer.isNotEmpty) {
+              if (dsInside) {
+                final endIdx = dsBuffer.indexOf(endTag);
+                if (endIdx >= 0) {
+                  final thinking = dsBuffer.substring(0, endIdx);
+                  if (thinking.isNotEmpty) {
+                    yield ThinkingResponse(thinking);
+                  }
+                  dsBuffer = dsBuffer.substring(endIdx + endTag.length);
+                  dsInside = false;
+                } else {
+                  final partial = _findPartialSuffix(dsBuffer, endTag);
+                  final safe = dsBuffer.substring(0, dsBuffer.length - partial);
+                  if (safe.isNotEmpty) {
+                    yield ThinkingResponse(safe);
+                  }
+                  dsBuffer = dsBuffer.substring(dsBuffer.length - partial);
+                  break;
                 }
               } else {
-                thinkingBuffer.write(token);
-                yield ThinkingResponse(token);
+                yield TextResponse(dsBuffer);
+                dsBuffer = '';
+                break;
               }
-            } else {
-              yield response;
             }
           } else {
             yield response;
           }
         }
+        if (dsBuffer.isNotEmpty) {
+          yield dsInside ? ThinkingResponse(dsBuffer) : TextResponse(dsBuffer);
+        }
         break;
 
       case ModelType.qwen:
         // Qwen3 emits <think>...</think>, Qwen2.5 emits nothing.
-        // Start insideThinking=false — only enter thinking when <think> is found.
-        bool qwenInsideThinking = false;
-        StringBuffer qwenThinkingBuffer = StringBuffer();
+        // Starts insideThinking=false — safe for non-thinking models.
+        // Uses buffer to handle partial tags across token boundaries.
+        const startTag = '<think>';
+        const endTag = '</think>';
+        bool qwenInside = false;
+        String qwenBuffer = '';
 
         await for (final response in originalStream) {
           if (response is TextResponse) {
-            String token = response.token;
+            qwenBuffer += response.token;
 
-            if (qwenInsideThinking) {
-              if (token.contains('</think>')) {
-                final beforeEnd = token.split('</think>')[0];
-                if (beforeEnd.isNotEmpty) {
-                  qwenThinkingBuffer.write(beforeEnd);
-                  yield ThinkingResponse(beforeEnd);
-                }
-                qwenInsideThinking = false;
-                qwenThinkingBuffer.clear();
-                final afterEnd =
-                    token.split('</think>').skip(1).join('</think>');
-                if (afterEnd.isNotEmpty) {
-                  yield TextResponse(afterEnd);
-                }
-              } else {
-                qwenThinkingBuffer.write(token);
-                yield ThinkingResponse(token);
-              }
-            } else {
-              if (token.contains('<think>')) {
-                final beforeStart = token.split('<think>')[0];
-                if (beforeStart.isNotEmpty) {
-                  yield TextResponse(beforeStart);
-                }
-                qwenInsideThinking = true;
-                qwenThinkingBuffer.clear();
-                final afterStart =
-                    token.split('<think>').skip(1).join('<think>');
-                if (afterStart.isNotEmpty) {
-                  if (afterStart.contains('</think>')) {
-                    final thinking = afterStart.split('</think>')[0];
-                    if (thinking.isNotEmpty) {
-                      yield ThinkingResponse(thinking);
-                    }
-                    qwenInsideThinking = false;
-                    final afterEnd =
-                        afterStart.split('</think>').skip(1).join('</think>');
-                    if (afterEnd.isNotEmpty) {
-                      yield TextResponse(afterEnd);
-                    }
-                  } else {
-                    qwenThinkingBuffer.write(afterStart);
-                    yield ThinkingResponse(afterStart);
+            while (qwenBuffer.isNotEmpty) {
+              if (qwenInside) {
+                final endIdx = qwenBuffer.indexOf(endTag);
+                if (endIdx >= 0) {
+                  final thinking = qwenBuffer.substring(0, endIdx);
+                  if (thinking.isNotEmpty) {
+                    yield ThinkingResponse(thinking);
                   }
+                  qwenBuffer = qwenBuffer.substring(endIdx + endTag.length);
+                  qwenInside = false;
+                } else {
+                  final partial = _findPartialSuffix(qwenBuffer, endTag);
+                  final safe =
+                      qwenBuffer.substring(0, qwenBuffer.length - partial);
+                  if (safe.isNotEmpty) {
+                    yield ThinkingResponse(safe);
+                  }
+                  qwenBuffer =
+                      qwenBuffer.substring(qwenBuffer.length - partial);
+                  break;
                 }
               } else {
-                // No thinking tags — pass through as text (Qwen2.5 path)
-                yield response;
+                final startIdx = qwenBuffer.indexOf(startTag);
+                if (startIdx >= 0) {
+                  final textBefore = qwenBuffer.substring(0, startIdx);
+                  if (textBefore.isNotEmpty) {
+                    yield TextResponse(textBefore);
+                  }
+                  qwenBuffer = qwenBuffer.substring(startIdx + startTag.length);
+                  qwenInside = true;
+                } else {
+                  final partial = _findPartialSuffix(qwenBuffer, startTag);
+                  final safe =
+                      qwenBuffer.substring(0, qwenBuffer.length - partial);
+                  if (safe.isNotEmpty) {
+                    yield TextResponse(safe);
+                  }
+                  qwenBuffer =
+                      qwenBuffer.substring(qwenBuffer.length - partial);
+                  break;
+                }
               }
             }
           } else {
             yield response;
           }
+        }
+        if (qwenBuffer.isNotEmpty) {
+          yield qwenInside
+              ? ThinkingResponse(qwenBuffer)
+              : TextResponse(qwenBuffer);
         }
         break;
 
@@ -387,7 +396,7 @@ class ModelThinkingFilter {
   }
 
   /// Removes thinking blocks from final text.
-  /// Supports DeepSeek (`<think>...</think>`) and Gemma 4 (`<|channel>thought\n...<channel|>`) models.
+  /// Supports DeepSeek/Qwen3 (`<think>...</think>`) and Gemma 4 (`<|channel>thought\n...<channel|>`).
   /// Note: For streaming thinking output, use [filterThinkingStream] with generateChatResponseAsync() instead.
   static String removeThinkingFromText(String text,
       {required ModelType modelType}) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.13.4
+version: 0.13.5
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 

--- a/test/core/gemma4_thinking_test.dart
+++ b/test/core/gemma4_thinking_test.dart
@@ -9,7 +9,9 @@ void main() {
       return Stream.fromIterable(chunks.map((c) => TextResponse(c)));
     }
 
-    test('complete block in single chunk yields ThinkingResponse + TextResponse', () async {
+    test(
+        'complete block in single chunk yields ThinkingResponse + TextResponse',
+        () async {
       final stream = makeStream([
         '<|channel>thought\nI need to think about this.<channel|>The answer is 42.',
       ]);
@@ -38,8 +40,10 @@ void main() {
       ).toList();
 
       // Intermediate thinking chunks are yielded as they arrive
-      final thinkingParts = results.whereType<ThinkingResponse>().map((r) => r.content).join();
-      final textParts = results.whereType<TextResponse>().map((r) => r.token).join();
+      final thinkingParts =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final textParts =
+          results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(thinkingParts, 'I am thinking hard');
       expect(textParts, 'Final answer.');
@@ -71,8 +75,10 @@ void main() {
         modelType: ModelType.gemmaIt,
       ).toList();
 
-      final thinking = results.whereType<ThinkingResponse>().map((r) => r.content).toList();
-      final text = results.whereType<TextResponse>().map((r) => r.token).toList();
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).toList();
+      final text =
+          results.whereType<TextResponse>().map((r) => r.token).toList();
 
       expect(thinking, ['First thought.', 'Second thought.']);
       expect(text, ['Text between.', 'Final text.']);
@@ -102,7 +108,8 @@ void main() {
         modelType: ModelType.gemmaIt,
       ).toList();
 
-      final thinking = results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
       expect(thinking, 'Thinking content<chan');
     });
 
@@ -117,7 +124,8 @@ void main() {
       ).toList();
 
       expect(results.whereType<ThinkingResponse>(), isEmpty);
-      expect(results.whereType<TextResponse>().map((r) => r.token).join(), 'The answer.');
+      expect(results.whereType<TextResponse>().map((r) => r.token).join(),
+          'The answer.');
     });
 
     test('start marker split across chunks', () async {
@@ -131,7 +139,8 @@ void main() {
         modelType: ModelType.gemmaIt,
       ).toList();
 
-      final thinking = results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
       final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(thinking, 'Thinking.');
@@ -141,7 +150,8 @@ void main() {
 
   group('Gemma 4 thinking - removeThinkingFromText', () {
     test('strips thinking blocks from text', () {
-      const input = 'Prefix <|channel>thought\nSome reasoning.<channel|> Suffix';
+      const input =
+          'Prefix <|channel>thought\nSome reasoning.<channel|> Suffix';
       final result = ModelThinkingFilter.removeThinkingFromText(
         input,
         modelType: ModelType.gemmaIt,
@@ -150,7 +160,8 @@ void main() {
     });
 
     test('strips multiple thinking blocks', () {
-      const input = '<|channel>thought\nA<channel|>Text<|channel>thought\nB<channel|>End';
+      const input =
+          '<|channel>thought\nA<channel|>Text<|channel>thought\nB<channel|>End';
       final result = ModelThinkingFilter.removeThinkingFromText(
         input,
         modelType: ModelType.gemmaIt,
@@ -168,7 +179,8 @@ void main() {
     });
 
     test('multiline thinking content is stripped', () {
-      const input = '<|channel>thought\nLine 1\nLine 2\nLine 3<channel|>Answer.';
+      const input =
+          '<|channel>thought\nLine 1\nLine 2\nLine 3<channel|>Answer.';
       final result = ModelThinkingFilter.removeThinkingFromText(
         input,
         modelType: ModelType.gemmaIt,
@@ -177,8 +189,8 @@ void main() {
     });
   });
 
-  group('DeepSeek thinking still works', () {
-    test('filterThinkingStream handles DeepSeek format', () async {
+  group('DeepSeek thinking', () {
+    test('basic DeepSeek format', () async {
       final stream = Stream.fromIterable([
         const TextResponse('I think '),
         const TextResponse('about this</think>'),
@@ -190,11 +202,139 @@ void main() {
         modelType: ModelType.deepSeek,
       ).toList();
 
-      final thinking = results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
       final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(thinking.contains('I think '), isTrue);
       expect(text, 'The answer.');
+    });
+
+    test('partial </think> split across tokens', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('thinking</th'),
+        const TextResponse('ink>answer'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.deepSeek,
+      ).toList();
+
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+
+      expect(thinking, 'thinking');
+      expect(text, 'answer');
+    });
+  });
+
+  group('Qwen thinking', () {
+    test('Qwen3 with <think> tags', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('<think>reasoning</think>answer'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.qwen,
+      ).toList();
+
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+
+      expect(thinking, 'reasoning');
+      expect(text, 'answer');
+    });
+
+    test('Qwen3 tags split across multiple tokens', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('<think>I am '),
+        const TextResponse('thinking</think>'),
+        const TextResponse('The answer.'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.qwen,
+      ).toList();
+
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+
+      expect(thinking, 'I am thinking');
+      expect(text, 'The answer.');
+    });
+
+    test('partial <think> split across tokens', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('<thi'),
+        const TextResponse('nk>reasoning</think>answer'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.qwen,
+      ).toList();
+
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+
+      expect(thinking, 'reasoning');
+      expect(text, 'answer');
+    });
+
+    test('partial </think> split across tokens', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('<think>thinking</th'),
+        const TextResponse('ink>answer'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.qwen,
+      ).toList();
+
+      final thinking =
+          results.whereType<ThinkingResponse>().map((r) => r.content).join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+
+      expect(thinking, 'thinking');
+      expect(text, 'answer');
+    });
+
+    test('Qwen2.5 no thinking tags — passthrough', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('Hello, '),
+        const TextResponse('world!'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.qwen,
+      ).toList();
+
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+      expect(text, 'Hello, world!');
+      expect(results.whereType<ThinkingResponse>(), isEmpty);
+    });
+
+    test('partial <think> at end of stream flushed as text', () async {
+      final stream = Stream.fromIterable([
+        const TextResponse('Some text<thi'),
+      ]);
+
+      final results = await ModelThinkingFilter.filterThinkingStream(
+        stream,
+        modelType: ModelType.qwen,
+      ).toList();
+
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
+      expect(text, 'Some text<thi');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Qwen3 generates `<think>` blocks by default — now stripped when `isThinking: false`
- Separate Qwen filter (starts `insideThinking=false`, detects opening `<think>` tag) — safe for Qwen2.5 which doesn't generate thinking
- Always apply thinking filter for Qwen/DeepSeek/Gemma4, discard `ThinkingResponse` when user didn't request it

Tested on 6 models × 2 modes = 12 tests passed (Qwen3, Qwen2.5, Gemma4 E2B, Gemma3 1B, Gemma3n E2B, FunctionGemma 270M)

Closes #224