### PR TITLE
feat: make maxFunctionBufferLength configurable in createChat()

### DIFF
--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -10,10 +10,9 @@ import 'package:flutter_gemma/flutter_gemma_interface.dart';
 
 import 'model.dart';
 
-// Constants
-/// Maximum length for function call buffer before flushing as text.
+/// Default maximum length for function call buffer before flushing as text.
 /// Must accommodate verbose formats (DeepSeek tags, parallel calls).
-const int _maxFunctionBufferLength = 1024;
+const int defaultMaxFunctionBufferLength = 1024;
 
 class InferenceChat {
   final Future<InferenceModelSession> Function()? sessionCreator;
@@ -22,6 +21,7 @@ class InferenceChat {
   final bool supportImage;
   final bool supportAudio;
   final bool supportsFunctionCalls;
+  final int maxFunctionBufferLength;
   final ModelType modelType; // Add modelType parameter
   final bool isThinking; // Add isThinking flag for thinking models
   final ModelFileType fileType; // Add fileType parameter
@@ -46,6 +46,7 @@ class InferenceChat {
     this.supportImage = false,
     this.supportAudio = false,
     this.supportsFunctionCalls = false,
+    this.maxFunctionBufferLength = defaultMaxFunctionBufferLength,
     this.tools = const [],
     this.modelType =
         ModelType.gemmaIt, // Default to gemmaIt for backward compatibility
@@ -283,7 +284,7 @@ class InferenceChat {
             }
 
             // If buffer gets too long without completing, flush as text
-            if (funcBuffer.length > _maxFunctionBufferLength) {
+            if (funcBuffer.length > maxFunctionBufferLength) {
               debugPrint(
                   'InferenceChat: Buffer too long without completion, flushing as text');
               yield TextResponse(funcBuffer);

--- a/lib/desktop/desktop_inference_model.dart
+++ b/lib/desktop/desktop_inference_model.dart
@@ -97,6 +97,7 @@ class DesktopInferenceModel extends InferenceModel {
     bool isThinking = false,
     ModelType? modelType,
     ToolChoice toolChoice = ToolChoice.auto,
+    int? maxFunctionBufferLength,
     String? systemInstruction,
   }) async {
     chat = InferenceChat(
@@ -116,6 +117,8 @@ class DesktopInferenceModel extends InferenceModel {
       supportImage: supportImage ?? this.supportImage,
       supportAudio: supportAudio ?? this.supportAudio,
       supportsFunctionCalls: supportsFunctionCalls ?? false,
+      maxFunctionBufferLength:
+          maxFunctionBufferLength ?? defaultMaxFunctionBufferLength,
       tools: tools,
       modelType: modelType ?? this.modelType,
       isThinking: isThinking,

--- a/lib/flutter_gemma_interface.dart
+++ b/lib/flutter_gemma_interface.dart
@@ -153,6 +153,7 @@ abstract class InferenceModel {
     bool isThinking = false, // Add isThinking parameter
     ModelType? modelType, // Add modelType parameter
     ToolChoice toolChoice = ToolChoice.auto, // Tool calling mode
+    int? maxFunctionBufferLength,
     String? systemInstruction,
   }) async {
     chat = InferenceChat(
@@ -172,6 +173,8 @@ abstract class InferenceModel {
       supportImage: supportImage ?? false,
       supportAudio: supportAudio ?? false,
       supportsFunctionCalls: supportsFunctionCalls ?? false,
+      maxFunctionBufferLength:
+          maxFunctionBufferLength ?? defaultMaxFunctionBufferLength,
       tools: tools,
       isThinking: isThinking,
       modelType: modelType ?? ModelType.gemmaIt,

--- a/lib/mobile/flutter_gemma_mobile_inference_model.dart
+++ b/lib/mobile/flutter_gemma_mobile_inference_model.dart
@@ -31,6 +31,7 @@ class MobileInferenceModel extends InferenceModel {
     bool isThinking = false,
     ModelType? modelType,
     ToolChoice toolChoice = ToolChoice.auto,
+    int? maxFunctionBufferLength,
     String? systemInstruction,
   }) async {
     chat = InferenceChat(
@@ -50,6 +51,8 @@ class MobileInferenceModel extends InferenceModel {
       supportImage: supportImage ?? false,
       supportAudio: supportAudio ?? this.supportAudio,
       supportsFunctionCalls: supportsFunctionCalls ?? false,
+      maxFunctionBufferLength:
+          maxFunctionBufferLength ?? defaultMaxFunctionBufferLength,
       tools: tools,
       modelType: modelType ?? this.modelType,
       isThinking: isThinking,


### PR DESCRIPTION
## Summary

- Expose `maxFunctionBufferLength` as an optional parameter in `createChat()` (default `1024`, no breaking change)
- Replace the hardcoded `_maxFunctionBufferLength` constant with a per-chat instance field
- Applied to both the base `InferenceModel` and the `DesktopInferenceModel` override

## Problem

The hardcoded `_maxFunctionBufferLength = 1024` in `lib/core/chat.dart` causes function calls with content exceeding 1024 characters to be silently flushed as plain `TextResponse` instead of being parsed as `FunctionCallResponse`.

This breaks real-world use cases like recipe sharing where the model includes formatted content in tool call arguments (easily 1500-2000+ characters).

## Usage

```dart
final chat = await model.createChat(
  tools: myTools,
  supportsFunctionCalls: true,
  maxFunctionBufferLength: 4096, // increase for verbose tool calls
);
```

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)