### PR TITLE
Release 0.13.6: ModelType.qwen3, Windows paths, removeDocument (#224, #233, #232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.13.6
+- **ModelType.qwen3**: New model type for Qwen3 models with thinking support
 - **Disable Qwen3 thinking at model level**: `/no_think` appended automatically when `isThinking: false` — faster TTFT
-- **Pass `enable_thinking` via extraContext**: LiteRT-LM models receive explicit thinking flag in Jinja template context
+- **Configurable maxFunctionBufferLength** (#229): `createChat(maxFunctionBufferLength: 2048)` for long function call args
+- **Fix Windows path parsing** (#233): `FileSource` now handles backslash paths correctly
+- **removeDocument** (#232): `VectorStoreRepository.removeDocument(id:)` to delete documents from vector store
 
 ## 0.13.5
 - **Fix Qwen3 thinking mode (#224)**: Qwen3 `<think>` tags now stripped automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.6
+- **Disable Qwen3 thinking at model level**: `/no_think` appended automatically when `isThinking: false` — faster TTFT
+- **Pass `enable_thinking` via extraContext**: LiteRT-LM models receive explicit thinking flag in Jinja template context
+
 ## 0.13.5
 - **Fix Qwen3 thinking mode (#224)**: Qwen3 `<think>` tags now stripped automatically
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM Android**: `com.google.ai.edge.litertlm:litertlm-android:0.10.0`
-- **Current Version**: 0.13.5
+- **Current Version**: 0.13.6
 
 ## Platform-Specific Setup
 

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/engines/litertlm/LiteRtLmSession.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/engines/litertlm/LiteRtLmSession.kt
@@ -31,12 +31,9 @@ class LiteRtLmSession(
 
     private val conversation: Conversation
 
-    // Extra context for thinking mode (Gemma 4 via Jinja template variable)
-    private val extraContext: Map<String, Any> = if (config.enableThinking) {
-        mapOf("enable_thinking" to true)
-    } else {
-        emptyMap()
-    }
+    // Extra context for thinking mode (Jinja template variable)
+    // Always pass enable_thinking: Qwen3 needs explicit false to disable thinking
+    private val extraContext: Map<String, Any> = mapOf("enable_thinking" to config.enableThinking)
 
     // Chunk buffering (MediaPipe compatibility) - thread-safe access
     private val pendingPrompt = StringBuilder()

--- a/example/integration_test/desktop_thinking_all_models_test.dart
+++ b/example/integration_test/desktop_thinking_all_models_test.dart
@@ -18,7 +18,7 @@ void main() {
   final models = <String, _TestModel>{
     'Qwen3-0.6B': _TestModel(
       path: '$sandboxDir/Qwen3-0.6B.litertlm',
-      modelType: ModelType.qwen,
+      modelType: ModelType.qwen3,
       fileType: ModelFileType.litertlm,
       generatesThinking: true,
     ),

--- a/example/integration_test/desktop_thinking_qwen3_test.dart
+++ b/example/integration_test/desktop_thinking_qwen3_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     // Install Qwen3 model
     await FlutterGemma.installModel(
-      modelType: ModelType.qwen,
+      modelType: ModelType.qwen3,
       fileType: ModelFileType.litertlm,
     ).fromNetwork(modelUrl).install();
 
@@ -27,7 +27,7 @@ void main() {
     try {
       // Create chat WITHOUT thinking mode
       final chat = await model.createChat(
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
         isThinking: false,
       );
 
@@ -61,7 +61,7 @@ void main() {
     try {
       // Create chat WITH thinking mode
       final chat = await model.createChat(
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
         isThinking: true,
       );
 

--- a/example/integration_test/sequential_litertlm_test.dart
+++ b/example/integration_test/sequential_litertlm_test.dart
@@ -31,7 +31,7 @@ const _models = <({String path, String name, ModelType modelType})>[
   (
     path: '$_deviceDir/Qwen3-0.6B.litertlm',
     name: 'Qwen3 0.6B',
-    modelType: ModelType.qwen,
+    modelType: ModelType.qwen3,
   ),
 ];
 
@@ -71,7 +71,9 @@ void main() {
 
           // First query — should work
           await chat.addQueryChunk(
-            const Message(text: 'What is 2+2? Answer with just the number.', isUser: true),
+            const Message(
+                text: 'What is 2+2? Answer with just the number.',
+                isUser: true),
           );
           final r1 = await chat.generateChatResponse();
           expect(r1, isA<TextResponse>());
@@ -81,7 +83,9 @@ void main() {
 
           // Second query — crashes with SIGSEGV in issue #209
           await chat.addQueryChunk(
-            const Message(text: 'What is 3+3? Answer with just the number.', isUser: true),
+            const Message(
+                text: 'What is 3+3? Answer with just the number.',
+                isUser: true),
           );
           final r2 = await chat.generateChatResponse();
           expect(r2, isA<TextResponse>());
@@ -115,7 +119,8 @@ void main() {
       }, timeout: const Timeout(Duration(minutes: 15)));
 
       // --- Test 3: Streaming sequential queries ---
-      testWidgets('two sequential streaming queries on same chat', (tester) async {
+      testWidgets('two sequential streaming queries on same chat',
+          (tester) async {
         final model = await _installAndLoad(path, modelType);
         try {
           final chat = await model.createChat(modelType: modelType);

--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -277,7 +277,7 @@ enum Model implements InferenceModelInterface {
     licenseUrl: 'https://huggingface.co/litert-community/Qwen3-0.6B',
     needsAuth: false,
     preferredBackend: PreferredBackend.cpu,
-    modelType: ModelType.qwen,
+    modelType: ModelType.qwen3,
     fileType: ModelFileType.litertlm,
     temperature: 0.7,
     topK: 40,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.5"
+    version: "0.13.6"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/core/api/embedding_installation_builder.dart
+++ b/lib/core/api/embedding_installation_builder.dart
@@ -80,7 +80,8 @@ class EmbeddingInstallationBuilder {
   /// [iosPath] optional alternative asset path for iOS platform (same source type: asset).
   /// On iOS, sentencepiece.model tokenizers are not supported due to protobuf conflict.
   /// Pass a tokenizer.json asset path here to use on iOS instead.
-  EmbeddingInstallationBuilder tokenizerFromAsset(String path, {String? iosPath}) {
+  EmbeddingInstallationBuilder tokenizerFromAsset(String path,
+      {String? iosPath}) {
     _tokenizerSource = ModelSource.asset(path);
     if (iosPath != null) {
       _tokenizerIosSource = ModelSource.asset(iosPath);
@@ -93,7 +94,8 @@ class EmbeddingInstallationBuilder {
   /// [iosPath] optional alternative resource name for iOS platform (same source type: bundled).
   /// On iOS, sentencepiece.model tokenizers are not supported due to protobuf conflict.
   /// Pass a tokenizer.json resource name here to use on iOS instead.
-  EmbeddingInstallationBuilder tokenizerFromBundled(String resourceName, {String? iosPath}) {
+  EmbeddingInstallationBuilder tokenizerFromBundled(String resourceName,
+      {String? iosPath}) {
     _tokenizerSource = ModelSource.bundled(resourceName);
     if (iosPath != null) {
       _tokenizerIosSource = ModelSource.bundled(iosPath);
@@ -106,7 +108,8 @@ class EmbeddingInstallationBuilder {
   /// [iosPath] optional alternative file path for iOS platform (same source type: file).
   /// On iOS, sentencepiece.model tokenizers are not supported due to protobuf conflict.
   /// Pass a tokenizer.json file path here to use on iOS instead.
-  EmbeddingInstallationBuilder tokenizerFromFile(String path, {String? iosPath}) {
+  EmbeddingInstallationBuilder tokenizerFromFile(String path,
+      {String? iosPath}) {
     _tokenizerSource = ModelSource.file(path);
     if (iosPath != null) {
       _tokenizerIosSource = ModelSource.file(iosPath);
@@ -117,13 +120,15 @@ class EmbeddingInstallationBuilder {
   // === Progress callbacks ===
 
   /// Add model file progress callback
-  EmbeddingInstallationBuilder withModelProgress(void Function(int progress) onProgress) {
+  EmbeddingInstallationBuilder withModelProgress(
+      void Function(int progress) onProgress) {
     _onModelProgress = onProgress;
     return this;
   }
 
   /// Add tokenizer file progress callback
-  EmbeddingInstallationBuilder withTokenizerProgress(void Function(int progress) onProgress) {
+  EmbeddingInstallationBuilder withTokenizerProgress(
+      void Function(int progress) onProgress) {
     _onTokenizerProgress = onProgress;
     return this;
   }
@@ -196,7 +201,8 @@ class EmbeddingInstallationBuilder {
 
     // Check if both model and tokenizer are already installed
     final isModelInstalled = await repository.isInstalled(modelFilename);
-    final isTokenizerInstalled = await repository.isInstalled(tokenizerFilename);
+    final isTokenizerInstalled =
+        await repository.isInstalled(tokenizerFilename);
 
     if (isModelInstalled && isTokenizerInstalled) {
       debugPrint(
@@ -222,13 +228,15 @@ class EmbeddingInstallationBuilder {
           );
         }
       } else {
-        debugPrint('ℹ️  Embedding model file already installed: $modelFilename');
+        debugPrint(
+            'ℹ️  Embedding model file already installed: $modelFilename');
       }
 
       // Install tokenizer file if not already installed
       if (!isTokenizerInstalled) {
         debugPrint('📥 Installing tokenizer...');
-        final tokenizerHandler = handlerRegistry.getHandler(effectiveTokenizerSource);
+        final tokenizerHandler =
+            handlerRegistry.getHandler(effectiveTokenizerSource);
         if (_onTokenizerProgress != null) {
           await for (final progress in tokenizerHandler!.installWithProgress(
             effectiveTokenizerSource,
@@ -281,9 +289,9 @@ class EmbeddingInstallationBuilder {
   String _extractFilename(ModelSource source) {
     return switch (source) {
       NetworkSource(:final url) => path.basename(Uri.parse(url).path),
-      AssetSource(:final path) => path.split('/').last,
+      AssetSource(:final path) => path.split(RegExp(r'[/\\]')).last,
       BundledSource(:final resourceName) => resourceName,
-      FileSource(:final path) => path.split('/').last,
+      FileSource(:final path) => path.split(RegExp(r'[/\\]')).last,
     };
   }
 }

--- a/lib/core/api/inference_installation_builder.dart
+++ b/lib/core/api/inference_installation_builder.dart
@@ -49,7 +49,8 @@ class InferenceInstallationBuilder {
     String? token,
     bool? foreground,
   }) {
-    _modelSource = ModelSource.network(url, authToken: token, foreground: foreground);
+    _modelSource =
+        ModelSource.network(url, authToken: token, foreground: foreground);
     return this;
   }
 
@@ -89,7 +90,8 @@ class InferenceInstallationBuilder {
   }
 
   /// Convenience: Add LoRA weights from network URL
-  InferenceInstallationBuilder withLoraFromNetwork(String url, {String? token}) {
+  InferenceInstallationBuilder withLoraFromNetwork(String url,
+      {String? token}) {
     _loraSource = ModelSource.network(url, authToken: token);
     return this;
   }
@@ -115,7 +117,8 @@ class InferenceInstallationBuilder {
   /// Add progress callback
   ///
   /// Called periodically during installation with progress percentage (0-100).
-  InferenceInstallationBuilder withProgress(void Function(int progress) onProgress) {
+  InferenceInstallationBuilder withProgress(
+      void Function(int progress) onProgress) {
     _onProgress = onProgress;
     return this;
   }
@@ -220,9 +223,9 @@ class InferenceInstallationBuilder {
   String _extractFilename(ModelSource source) {
     return switch (source) {
       NetworkSource(:final url) => path.basename(Uri.parse(url).path),
-      AssetSource(:final path) => path.split('/').last,
+      AssetSource(:final path) => path.split(RegExp(r'[/\\]')).last,
       BundledSource(:final resourceName) => resourceName,
-      FileSource(:final path) => path.split('/').last,
+      FileSource(:final path) => path.split(RegExp(r'[/\\]')).last,
     };
   }
 }

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -100,6 +100,12 @@ class InferenceChat {
           'WARNING: Model does not support function calls, but tools were provided. Tools will be ignored.');
     }
 
+    // Qwen3: append /no_think to suppress thinking at model level when not requested
+    if (!isThinking && modelType == ModelType.qwen && message.isUser) {
+      messageToSend =
+          messageToSend.copyWith(text: '${messageToSend.text} /no_think');
+    }
+
     // --- DETAILED LOGGING ---
     final historyForLogging = _modelHistory.map((m) => m.text).join('\n');
     debugPrint('--- Sending to Native ---');
@@ -195,7 +201,9 @@ class InferenceChat {
     final originalStream =
         session.getResponseAsync().map((token) => TextResponse(token));
 
-    // Apply thinking filter — some models (Qwen3, DeepSeek) generate <think> by default
+    // Apply thinking filter for models that may generate <think> tags.
+    // enable_thinking=false is passed via extraContext for .litertlm but is not
+    // reliable for all model bundles — keep filter as safety net.
     final bool modelCanThink = modelType == ModelType.deepSeek ||
         modelType == ModelType.qwen ||
         modelType == ModelType.gemmaIt;

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -101,7 +101,7 @@ class InferenceChat {
     }
 
     // Qwen3: append /no_think to suppress thinking at model level when not requested
-    if (!isThinking && modelType == ModelType.qwen && message.isUser) {
+    if (!isThinking && modelType == ModelType.qwen3 && message.isUser) {
       messageToSend =
           messageToSend.copyWith(text: '${messageToSend.text} /no_think');
     }
@@ -206,6 +206,7 @@ class InferenceChat {
     // reliable for all model bundles — keep filter as safety net.
     final bool modelCanThink = modelType == ModelType.deepSeek ||
         modelType == ModelType.qwen ||
+        modelType == ModelType.qwen3 ||
         modelType == ModelType.gemmaIt;
     final Stream<ModelResponse> filteredStream = (isThinking || modelCanThink)
         ? ModelThinkingFilter.filterThinkingStream(originalStream,

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -432,7 +432,7 @@ class ModelThinkingFilter {
       required ModelFileType fileType}) {
     String cleaned = response;
 
-    // Always strip thinking tags for models that may generate them (Qwen3, DeepSeek, Gemma 4)
+    // Strip thinking tags for models that may generate them
     final bool modelCanThink = modelType == ModelType.deepSeek ||
         modelType == ModelType.qwen ||
         modelType == ModelType.gemmaIt;

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -77,6 +77,7 @@ extension MessageExtension on Message {
       ModelType.gemmaIt => _transformGemmaIt(),
       ModelType.deepSeek => _transformDeepSeek(),
       ModelType.qwen => _transformQwen(),
+      ModelType.qwen3 => _transformQwen(),
       ModelType.llama => _transformLlama(),
       ModelType.hammer => _transformHammer(),
       ModelType.functionGemma => _transformFunctionGemma(),
@@ -247,6 +248,7 @@ class ModelThinkingFilter {
         break;
 
       case ModelType.qwen:
+      case ModelType.qwen3:
         // Qwen3 emits <think>...</think>, Qwen2.5 emits nothing.
         // Starts insideThinking=false — safe for non-thinking models.
         // Uses buffer to handle partial tags across token boundaries.
@@ -403,6 +405,7 @@ class ModelThinkingFilter {
     switch (modelType) {
       case ModelType.deepSeek:
       case ModelType.qwen:
+      case ModelType.qwen3:
         // Remove all <think>...</think> blocks (DeepSeek/Qwen3 format)
         RegExp thinkingRegex = RegExp(r'<think>.*?</think>', dotAll: true);
         return text.replaceAll(thinkingRegex, '').trim();
@@ -435,6 +438,7 @@ class ModelThinkingFilter {
     // Strip thinking tags for models that may generate them
     final bool modelCanThink = modelType == ModelType.deepSeek ||
         modelType == ModelType.qwen ||
+        modelType == ModelType.qwen3 ||
         modelType == ModelType.gemmaIt;
     if (isThinking || modelCanThink) {
       cleaned = removeThinkingFromText(cleaned, modelType: modelType);
@@ -465,6 +469,7 @@ class ModelThinkingFilter {
         // Remove trailing <end_of_turn> tags and trim whitespace
         return cleaned.replaceAll(RegExp(r'<end_of_turn>\s*$'), '').trim();
       case ModelType.qwen:
+      case ModelType.qwen3:
         // Remove trailing <|im_end|> tags and trim whitespace
         return cleaned.replaceAll(RegExp(r'<\|im_end\|>\s*$'), '').trim();
       case ModelType.llama:

--- a/lib/core/infrastructure/dart_vector_store_repository.dart
+++ b/lib/core/infrastructure/dart_vector_store_repository.dart
@@ -108,6 +108,15 @@ class DartVectorStoreRepository implements VectorStoreRepository {
   }
 
   @override
+  Future<void> removeDocument({required String id}) async {
+    if (!_isInitialized) {
+      throw StateError('VectorStore not initialized. Call initialize() first.');
+    }
+    _db!.execute('DELETE FROM $_tableName WHERE id = ?', [id]);
+    _hnswIndex.remove(id);
+  }
+
+  @override
   Future<List<RetrievalResult>> searchSimilar({
     required List<double> queryEmbedding,
     required int topK,

--- a/lib/core/infrastructure/dart_vector_store_repository_stub.dart
+++ b/lib/core/infrastructure/dart_vector_store_repository_stub.dart
@@ -12,7 +12,8 @@ class DartVectorStoreRepository implements VectorStoreRepository {
 
   @override
   Future<void> initialize(String databasePath) async =>
-      throw UnimplementedError('DartVectorStoreRepository is not available on web');
+      throw UnimplementedError(
+          'DartVectorStoreRepository is not available on web');
 
   @override
   Future<void> addDocument({
@@ -21,7 +22,13 @@ class DartVectorStoreRepository implements VectorStoreRepository {
     required List<double> embedding,
     String? metadata,
   }) async =>
-      throw UnimplementedError('DartVectorStoreRepository is not available on web');
+      throw UnimplementedError(
+          'DartVectorStoreRepository is not available on web');
+
+  @override
+  Future<void> removeDocument({required String id}) async =>
+      throw UnimplementedError(
+          'DartVectorStoreRepository is not available on web');
 
   @override
   Future<List<RetrievalResult>> searchSimilar({
@@ -29,15 +36,16 @@ class DartVectorStoreRepository implements VectorStoreRepository {
     required int topK,
     double threshold = 0.0,
   }) async =>
-      throw UnimplementedError('DartVectorStoreRepository is not available on web');
+      throw UnimplementedError(
+          'DartVectorStoreRepository is not available on web');
 
   @override
-  Future<VectorStoreStats> getStats() async =>
-      throw UnimplementedError('DartVectorStoreRepository is not available on web');
+  Future<VectorStoreStats> getStats() async => throw UnimplementedError(
+      'DartVectorStoreRepository is not available on web');
 
   @override
-  Future<void> clear() async =>
-      throw UnimplementedError('DartVectorStoreRepository is not available on web');
+  Future<void> clear() async => throw UnimplementedError(
+      'DartVectorStoreRepository is not available on web');
 
   @override
   Future<void> close() async {}

--- a/lib/core/infrastructure/web_vector_store_repository.dart
+++ b/lib/core/infrastructure/web_vector_store_repository.dart
@@ -87,14 +87,17 @@ class WebVectorStoreRepository implements VectorStoreRepository {
       }
 
       // Convert web types to HNSW types
-      final hnswDocs = documents.map((doc) => DocumentEmbedding(
-        id: doc.id,
-        embedding: doc.embedding,
-      )).toList();
+      final hnswDocs = documents
+          .map((doc) => DocumentEmbedding(
+                id: doc.id,
+                embedding: doc.embedding,
+              ))
+          .toList();
 
       _hnswIndex.rebuild(hnswDocs);
 
-      debugPrint('[WebVectorStore] HNSW index rebuilt with ${documents.length} documents');
+      debugPrint(
+          '[WebVectorStore] HNSW index rebuilt with ${documents.length} documents');
     } catch (e) {
       // Log but don't fail - fallback to brute-force search
       debugPrint('[WebVectorStore] Warning: Failed to rebuild HNSW index: $e');
@@ -107,7 +110,7 @@ class WebVectorStoreRepository implements VectorStoreRepository {
   /// ES modules with top-level await load asynchronously.
   /// This polls until window.SQLiteVectorStore is available.
   Future<void> _waitForSQLiteModule() async {
-    const maxAttempts = 50;  // 5 seconds max
+    const maxAttempts = 50; // 5 seconds max
     const delay = Duration(milliseconds: 100);
 
     for (int i = 0; i < maxAttempts; i++) {
@@ -122,9 +125,8 @@ class WebVectorStoreRepository implements VectorStoreRepository {
     }
 
     throw StateError(
-      'SQLiteVectorStore module failed to load after ${maxAttempts * delay.inMilliseconds}ms. '
-      'Add <script type="module" src="sqlite_vector_store.js"></script> to index.html'
-    );
+        'SQLiteVectorStore module failed to load after ${maxAttempts * delay.inMilliseconds}ms. '
+        'Add <script type="module" src="sqlite_vector_store.js"></script> to index.html');
   }
 
   @override
@@ -160,6 +162,15 @@ class WebVectorStoreRepository implements VectorStoreRepository {
   }
 
   @override
+  Future<void> removeDocument({required String id}) async {
+    if (!_isInitialized || _store == null) {
+      throw StateError('VectorStore not initialized. Call initialize() first.');
+    }
+    await _store!.removeDocumentDart(id);
+    _hnswIndex.remove(id);
+  }
+
+  @override
   Future<List<RetrievalResult>> searchSimilar({
     required List<double> queryEmbedding,
     required int topK,
@@ -172,12 +183,14 @@ class WebVectorStoreRepository implements VectorStoreRepository {
     try {
       // Use HNSW if enabled and index has enough documents
       if (enableHnsw && _hnswIndex.count >= _hnswThreshold) {
-        debugPrint('[WebVectorStore] Using HNSW search (${_hnswIndex.count} docs)');
+        debugPrint(
+            '[WebVectorStore] Using HNSW search (${_hnswIndex.count} docs)');
         return await _searchWithHnsw(queryEmbedding, topK, threshold);
       }
 
       // Fallback to brute-force for small datasets or when HNSW disabled
-      debugPrint('[WebVectorStore] Using brute-force search (HNSW enabled: $enableHnsw, count: ${_hnswIndex.count})');
+      debugPrint(
+          '[WebVectorStore] Using brute-force search (HNSW enabled: $enableHnsw, count: ${_hnswIndex.count})');
       return await _store!.searchSimilarDart(queryEmbedding, topK, threshold);
     } catch (e) {
       throw VectorStoreException('Search failed', e);

--- a/lib/core/infrastructure/web_vector_store_repository.dart
+++ b/lib/core/infrastructure/web_vector_store_repository.dart
@@ -166,8 +166,12 @@ class WebVectorStoreRepository implements VectorStoreRepository {
     if (!_isInitialized || _store == null) {
       throw StateError('VectorStore not initialized. Call initialize() first.');
     }
-    await _store!.removeDocumentDart(id);
-    _hnswIndex.remove(id);
+    try {
+      await _store!.removeDocumentDart(id);
+      _hnswIndex.remove(id);
+    } catch (e) {
+      throw VectorStoreException('Failed to remove document', e);
+    }
   }
 
   @override

--- a/lib/core/infrastructure/web_vector_store_repository_stub.dart
+++ b/lib/core/infrastructure/web_vector_store_repository_stub.dart
@@ -25,6 +25,11 @@ class WebVectorStoreRepository implements VectorStoreRepository {
   }
 
   @override
+  Future<void> removeDocument({required String id}) async {
+    throw UnimplementedError('WebVectorStoreRepository is web platform only');
+  }
+
+  @override
   Future<List<RetrievalResult>> searchSimilar({
     required List<double> queryEmbedding,
     required int topK,

--- a/lib/core/model.dart
+++ b/lib/core/model.dart
@@ -3,6 +3,7 @@ enum ModelType {
   gemmaIt,
   deepSeek,
   qwen,
+  qwen3,
   llama,
   hammer,
   functionGemma,

--- a/lib/core/model_management/types/inference_model_spec.dart
+++ b/lib/core/model_management/types/inference_model_spec.dart
@@ -32,9 +32,9 @@ class InferenceModelFile extends ModelFile {
   static String _extractFilenameFromSource(ModelSource source) {
     return switch (source) {
       NetworkSource(:final url) => Uri.parse(url).pathSegments.last,
-      AssetSource(:final path) => path.split('/').last,
+      AssetSource(:final path) => path.split(RegExp(r'[/\\]')).last,
       BundledSource(:final resourceName) => resourceName,
-      FileSource(:final path) => path.split('/').last,
+      FileSource(:final path) => path.split(RegExp(r'[/\\]')).last,
     };
   }
 }
@@ -187,6 +187,7 @@ class InferenceModelSpec extends ModelSpec {
 
   @override
   int get hashCode {
-    return Object.hash(_name, _modelSource, _loraSource, _replacePolicy, _modelType, _fileType);
+    return Object.hash(_name, _modelSource, _loraSource, _replacePolicy,
+        _modelType, _fileType);
   }
 }

--- a/lib/core/multimodal_image_handler.dart
+++ b/lib/core/multimodal_image_handler.dart
@@ -18,12 +18,14 @@ class MultimodalImageHandler {
     bool enableProcessing = true,
   }) async {
     try {
-      debugPrint('MultimodalImageHandler: Starting image processing for $modelType...');
+      debugPrint(
+          'MultimodalImageHandler: Starting image processing for $modelType...');
 
       // Step 1: Validate image for vision encoder compatibility
       ProcessedImage? processedImage;
       if (enableProcessing) {
-        processedImage = await _processImageWithValidation(imageBytes, modelType, originalFormat);
+        processedImage = await _processImageWithValidation(
+            imageBytes, modelType, originalFormat);
       } else {
         // Just validate format if processing is disabled
         final format = ImageProcessor.detectFormat(imageBytes);
@@ -53,7 +55,8 @@ class MultimodalImageHandler {
         }
       }
 
-      debugPrint('MultimodalImageHandler: Image processing completed successfully');
+      debugPrint(
+          'MultimodalImageHandler: Image processing completed successfully');
 
       return MultimodalImageResult(
         success: true,
@@ -108,7 +111,8 @@ class MultimodalImageHandler {
     bool isUser = true,
   }) {
     try {
-      debugPrint('MultimodalImageHandler: Creating multimodal message for $modelType...');
+      debugPrint(
+          'MultimodalImageHandler: Creating multimodal message for $modelType...');
 
       // Validate inputs
       if (text.isEmpty) {
@@ -126,10 +130,12 @@ class MultimodalImageHandler {
         isUser: isUser,
       );
     } catch (e) {
-      debugPrint('MultimodalImageHandler: Failed to create multimodal message - $e');
+      debugPrint(
+          'MultimodalImageHandler: Failed to create multimodal message - $e');
 
       // Try to create a fallback text-only message
-      final fallbackText = '$text\n[Note: Image could not be processed properly]';
+      final fallbackText =
+          '$text\n[Note: Image could not be processed properly]';
       return Message.text(text: fallbackText, isUser: isUser);
     }
   }
@@ -141,7 +147,8 @@ class MultimodalImageHandler {
     required ModelType modelType,
   }) {
     try {
-      debugPrint('MultimodalImageHandler: Creating tokenized prompt for $modelType...');
+      debugPrint(
+          'MultimodalImageHandler: Creating tokenized prompt for $modelType...');
 
       // Use ImageTokenizer to create properly formatted prompt
       final prompt = tokenizer.ImageTokenizer.createImagePrompt(
@@ -151,12 +158,15 @@ class MultimodalImageHandler {
       );
 
       // Validate the prompt contains proper image tokens
-      final hasValidTokens = tokenizer.ImageTokenizer.validateImageTokens(prompt, 1);
+      final hasValidTokens =
+          tokenizer.ImageTokenizer.validateImageTokens(prompt, 1);
       if (!hasValidTokens) {
-        debugPrint('MultimodalImageHandler: Warning - Prompt may have tokenization issues');
+        debugPrint(
+            'MultimodalImageHandler: Warning - Prompt may have tokenization issues');
       }
 
-      debugPrint('MultimodalImageHandler: Tokenized prompt created (${prompt.length} chars)');
+      debugPrint(
+          'MultimodalImageHandler: Tokenized prompt created (${prompt.length} chars)');
 
       return prompt;
     } catch (e) {
@@ -172,7 +182,8 @@ class MultimodalImageHandler {
       );
 
       // Return fallback prompt
-      return tokenizer.ImageTokenizer.createFallbackPrompt(text, errorMessage: errorResult.message);
+      return tokenizer.ImageTokenizer.createFallbackPrompt(text,
+          errorMessage: errorResult.message);
     }
   }
 
@@ -186,7 +197,8 @@ class MultimodalImageHandler {
       debugPrint('MultimodalImageHandler: Validating model response...');
 
       // Detect corruption patterns
-      final corruptionResult = ImageErrorHandler.detectResponseCorruption(response);
+      final corruptionResult =
+          ImageErrorHandler.detectResponseCorruption(response);
 
       if (corruptionResult.isCorrupted) {
         debugPrint(
@@ -201,7 +213,8 @@ class MultimodalImageHandler {
           isCorrupted: true,
           confidence: corruptionResult.confidence,
           analysis: corruptionResult.analysis,
-          suggestedAction: _convertToResponseAction(corruptionResult.suggestedAction),
+          suggestedAction:
+              _convertToResponseAction(corruptionResult.suggestedAction),
           originalResponse: response,
         );
       }
@@ -214,7 +227,8 @@ class MultimodalImageHandler {
         isCorrupted: false, // Not corrupted
         confidence: 0.0, // Low confidence in corruption (none detected)
         analysis: {'status': 'validation_passed', 'length': response.length},
-        suggestedAction: ResponseAction.none, // No action needed - response is good
+        suggestedAction:
+            ResponseAction.none, // No action needed - response is good
         originalResponse: response,
       );
     } catch (e) {
@@ -239,6 +253,7 @@ class MultimodalImageHandler {
       case ModelType.deepSeek:
       case ModelType.general:
       case ModelType.qwen:
+      case ModelType.qwen3:
       case ModelType.llama:
       case ModelType.hammer:
       case ModelType.functionGemma:
@@ -256,6 +271,7 @@ class MultimodalImageHandler {
         return tokenizer.ModelType.deepSeek;
       case ModelType.general:
       case ModelType.qwen:
+      case ModelType.qwen3:
       case ModelType.llama:
       case ModelType.hammer:
       case ModelType.functionGemma:

--- a/lib/core/parsing/function_call_format_factory.dart
+++ b/lib/core/parsing/function_call_format_factory.dart
@@ -14,6 +14,7 @@ class FunctionCallFormatFactory {
     return switch (modelType) {
       ModelType.functionGemma => FunctionGemmaCallFormat(),
       ModelType.qwen => QwenFunctionCallFormat(),
+      ModelType.qwen3 => QwenFunctionCallFormat(),
       ModelType.deepSeek => DeepSeekFunctionCallFormat(),
       ModelType.llama => LlamaFunctionCallFormat(),
       ModelType.phi => PhiFunctionCallFormat(),

--- a/lib/core/services/vector_store_repository.dart
+++ b/lib/core/services/vector_store_repository.dart
@@ -51,6 +51,13 @@ abstract class VectorStoreRepository {
     String? metadata,
   });
 
+  /// Remove a document from the vector store by its ID.
+  ///
+  /// If the document does not exist, this is a no-op (does not throw).
+  ///
+  /// Throws [StateError] if not initialized.
+  Future<void> removeDocument({required String id});
+
   /// Search for similar documents using cosine similarity
   ///
   /// Returns documents sorted by similarity (descending) where:
@@ -133,5 +140,6 @@ class VectorStoreException implements Exception {
   const VectorStoreException(this.message, [this.cause]);
 
   @override
-  String toString() => 'VectorStoreException: $message${cause != null ? '\nCause: $cause' : ''}';
+  String toString() =>
+      'VectorStoreException: $message${cause != null ? '\nCause: $cause' : ''}';
 }

--- a/lib/web/vector_store_web.dart
+++ b/lib/web/vector_store_web.dart
@@ -52,13 +52,16 @@ extension type SQLiteVectorStore._(JSObject _) implements JSObject {
 
   external JSPromise<JSAny?> getStats();
 
+  external JSPromise<JSAny?> removeDocument(String id);
+
   external JSPromise<JSAny?> clear();
 
   external JSPromise<JSAny?> close();
 
   external JSPromise<JSArray<JSObject>> getAllDocumentsWithEmbeddings();
 
-  external JSPromise<JSArray<JSObject>> getDocumentsByIds(JSArray<JSString> ids);
+  external JSPromise<JSArray<JSObject>> getDocumentsByIds(
+      JSArray<JSString> ids);
 
   // ========================================================================
   // Dart Helper Methods (type conversion wrappers)
@@ -81,6 +84,11 @@ extension type SQLiteVectorStore._(JSObject _) implements JSObject {
   ) async {
     final jsEmbedding = embedding.map((e) => e.toJS).toList().toJS;
     await addDocument(id, content, jsEmbedding, metadata).toDart;
+  }
+
+  /// Remove a document by ID (Dart-friendly API)
+  Future<void> removeDocumentDart(String id) async {
+    await removeDocument(id).toDart;
   }
 
   /// Search for similar documents (Dart-friendly API)
@@ -133,7 +141,8 @@ extension type SQLiteVectorStore._(JSObject _) implements JSObject {
   /// Get all documents with embeddings for HNSW rebuild (Dart-friendly API)
   ///
   /// Used during initialize() to rebuild in-memory HNSW index
-  Future<List<DocumentWithEmbedding>> getAllDocumentsWithEmbeddingsDart() async {
+  Future<List<DocumentWithEmbedding>>
+      getAllDocumentsWithEmbeddingsDart() async {
     final jsResults = await getAllDocumentsWithEmbeddings().toDart;
 
     return jsResults.toDart
@@ -200,5 +209,4 @@ extension type SQLiteVectorStore._(JSObject _) implements JSObject {
       metadata: metadata.isNull ? null : (metadata as JSString).toDart,
     );
   }
-
 }

--- a/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
+++ b/litertlm-server/src/main/kotlin/dev/flutterberlin/litertlm/LiteRtLmServiceImpl.kt
@@ -253,7 +253,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             // Use Contents format (like Android does)
             val message = Contents.of(listOf(Content.Text(request.text)))
 
-            val extraContext = if (request.enableThinking) mapOf("enable_thinking" to true) else emptyMap()
+            val extraContext = mapOf("enable_thinking" to request.enableThinking)
 
             val messageCallback = object : MessageCallback {
                 override fun onMessage(msg: Message) {
@@ -302,11 +302,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             // guarantees a single Mutex instance per conversationId under concurrent calls.
             val convMutex = conversationMutexes.computeIfAbsent(request.conversationId) { Mutex() }
             convMutex.withLock {
-                if (extraContext.isNotEmpty()) {
-                    conversation.sendMessageAsync(message, messageCallback, extraContext)
-                } else {
-                    conversation.sendMessageAsync(message, messageCallback)
-                }
+                conversation.sendMessageAsync(message, messageCallback, extraContext)
                 // Wait for native code to call onDone/onError before releasing the lock.
                 withTimeoutOrNull(300_000) { done.await() }
             }
@@ -340,14 +336,10 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             logger.info("ChatWithImageSync: text='${request.text.take(50)}', imageBytes=${imageBytes.size}")
 
             val message = buildContents(request.text, imageBytes = imageBytes)
-            val extraContext = if (request.enableThinking) mapOf("enable_thinking" to true) else emptyMap()
+            val extraContext = mapOf("enable_thinking" to request.enableThinking)
 
             logger.info("Calling SYNC sendMessage...")
-            val response = if (extraContext.isNotEmpty()) {
-                conversation.sendMessage(message, extraContext)
-            } else {
-                conversation.sendMessage(message)
-            }
+            val response = conversation.sendMessage(message, extraContext)
             val responseText = response.toString()
             val thinking = response.channels["thought"]
             logger.info("Sync response (${responseText.length} chars): ${responseText.take(200)}")
@@ -415,7 +407,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
                 logger.info("Image header: $header (JPEG=FFD8, PNG=89504E47)")
             }
             val message = buildContents(request.text, imageBytes = imageBytes)
-            val extraContext = if (request.enableThinking) mapOf("enable_thinking" to true) else emptyMap()
+            val extraContext = mapOf("enable_thinking" to request.enableThinking)
 
             logger.info("Sending message to conversation...")
             var responseCount = 0
@@ -468,11 +460,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             // image decode is running → prevents use-after-free SIGSEGV.
             val convMutex = conversationMutexes.computeIfAbsent(request.conversationId) { Mutex() }
             convMutex.withLock {
-                if (extraContext.isNotEmpty()) {
-                    conversation.sendMessageAsync(message, messageCallback, extraContext)
-                } else {
-                    conversation.sendMessageAsync(message, messageCallback)
-                }
+                conversation.sendMessageAsync(message, messageCallback, extraContext)
                 withTimeoutOrNull(300_000) { done.await() }
             }
         } catch (e: Exception) {
@@ -539,7 +527,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             }
 
             val message = buildContents(request.text, audioBytes = audioBytes)
-            val extraContext = if (request.enableThinking) mapOf("enable_thinking" to true) else emptyMap()
+            val extraContext = mapOf("enable_thinking" to request.enableThinking)
 
             logger.info("Sending message to conversation...")
             var responseCount = 0
@@ -593,11 +581,7 @@ class LiteRtLmServiceImpl : LiteRtLmServiceGrpcKt.LiteRtLmServiceCoroutineImplBa
             // audio decode is running → prevents use-after-free SIGSEGV.
             val convMutex = conversationMutexes.computeIfAbsent(request.conversationId) { Mutex() }
             convMutex.withLock {
-                if (extraContext.isNotEmpty()) {
-                    conversation.sendMessageAsync(message, messageCallback, extraContext)
-                } else {
-                    conversation.sendMessageAsync(message, messageCallback)
-                }
+                conversation.sendMessageAsync(message, messageCallback, extraContext)
                 withTimeoutOrNull(300_000) { done.await() }
             }
         } catch (e: Exception) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.13.5
+version: 0.13.6
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 

--- a/test/core/gemma4_thinking_test.dart
+++ b/test/core/gemma4_thinking_test.dart
@@ -238,7 +238,7 @@ void main() {
 
       final results = await ModelThinkingFilter.filterThinkingStream(
         stream,
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
       ).toList();
 
       final thinking =
@@ -258,7 +258,7 @@ void main() {
 
       final results = await ModelThinkingFilter.filterThinkingStream(
         stream,
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
       ).toList();
 
       final thinking =
@@ -277,7 +277,7 @@ void main() {
 
       final results = await ModelThinkingFilter.filterThinkingStream(
         stream,
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
       ).toList();
 
       final thinking =
@@ -296,7 +296,7 @@ void main() {
 
       final results = await ModelThinkingFilter.filterThinkingStream(
         stream,
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
       ).toList();
 
       final thinking =
@@ -315,7 +315,7 @@ void main() {
 
       final results = await ModelThinkingFilter.filterThinkingStream(
         stream,
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
       ).toList();
 
       final text = results.whereType<TextResponse>().map((r) => r.token).join();
@@ -330,7 +330,7 @@ void main() {
 
       final results = await ModelThinkingFilter.filterThinkingStream(
         stream,
-        modelType: ModelType.qwen,
+        modelType: ModelType.qwen3,
       ).toList();
 
       final text = results.whereType<TextResponse>().map((r) => r.token).join();

--- a/web/rag/sqlite_vector_store.js
+++ b/web/rag/sqlite_vector_store.js
@@ -75,6 +75,13 @@ class SQLiteVectorStore {
     }
 
     /**
+     * Remove a document by ID
+     */
+    async removeDocument(id) {
+        return this._call('removeDocument', [id]);
+    }
+
+    /**
      * Search similar documents using cosine similarity
      */
     async searchSimilar(queryEmbedding, topK, threshold) {

--- a/web/rag/sqlite_vector_store_worker.js
+++ b/web/rag/sqlite_vector_store_worker.js
@@ -174,6 +174,18 @@ async function addDocument(id, content, embedding, metadata) {
     return true;
 }
 
+async function removeDocument(id) {
+    if (!db) {
+        throw new Error('Database not initialized');
+    }
+    const sql = `DELETE FROM ${TABLE_DOCUMENTS} WHERE ${COLUMN_ID} = ?`;
+    for await (const stmt of sqlite3.statements(db, sql)) {
+        sqlite3.bind_collection(stmt, [id]);
+        await sqlite3.step(stmt);
+    }
+    return true;
+}
+
 async function searchSimilar(queryEmbedding, topK, threshold) {
     if (!db) {
         throw new Error('Database not initialized');
@@ -337,6 +349,9 @@ self.onmessage = async (event) => {
                 break;
             case 'addDocument':
                 result = await addDocument(args[0], args[1], args[2], args[3]);
+                break;
+            case 'removeDocument':
+                result = await removeDocument(args[0]);
                 break;
             case 'searchSimilar':
                 result = await searchSimilar(args[0], args[1], args[2]);


### PR DESCRIPTION
## Summary
- **ModelType.qwen3**: New model type for Qwen3 with thinking support. `/no_think` appended only for qwen3 (not Qwen2.5)
- **Fix Windows path parsing** (#233): `FileSource`/`AssetSource` now handle backslash paths
- **removeDocument** (#232): `VectorStoreRepository.removeDocument(id:)` for mobile and web
- **Configurable maxFunctionBufferLength** (#229): merged via PR #230

Closes #224, closes #233, closes #232