### PR TITLE
Add CI workflow to build libLiteRtLm for Linux + Windows

### DIFF
--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -1,0 +1,97 @@
+name: Build LiteRT-LM Native Libraries
+
+on:
+  workflow_dispatch:
+    inputs:
+      litertlm_version:
+        description: 'LiteRT-LM version tag'
+        required: true
+        default: 'v0.10.2'
+
+jobs:
+  build-linux-x86_64:
+    name: Linux x86_64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone LiteRT-LM
+        run: |
+          git clone --depth 1 --branch "$LITERTLM_VERSION" \
+            https://github.com/google-ai-edge/LiteRT-LM /tmp/LiteRT-LM
+          cd /tmp/LiteRT-LM && git lfs pull --include="prebuilt/linux_x86_64/*"
+
+      - name: Patch C API
+        run: bash native/litert_lm/patch_c_api.sh /tmp/LiteRT-LM
+
+      - name: Build libLiteRtLm.so
+        run: |
+          cd /tmp/LiteRT-LM
+          bazelisk build '//c:libLiteRtLm.dylib'
+
+      - name: Build libStreamProxy.so
+        run: |
+          gcc -shared -fPIC -o /tmp/libStreamProxy.so \
+            native/litert_lm/stream_proxy.c
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p artifacts
+          cp /tmp/LiteRT-LM/bazel-bin/c/libLiteRtLm.dylib artifacts/libLiteRtLm.so
+          cp /tmp/libStreamProxy.so artifacts/
+          cp /tmp/LiteRT-LM/prebuilt/linux_x86_64/*.so artifacts/ 2>/dev/null || true
+          ls -lh artifacts/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: litertlm-linux-x86_64
+          path: artifacts/
+
+  build-windows-x86_64:
+    name: Windows x86_64
+    runs-on: windows-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone LiteRT-LM
+        run: |
+          git clone --depth 1 --branch "$env:LITERTLM_VERSION" `
+            https://github.com/google-ai-edge/LiteRT-LM C:\LiteRT-LM
+          cd C:\LiteRT-LM
+          git lfs pull --include="prebuilt/windows_x86_64/*"
+
+      - name: Patch C API
+        shell: bash
+        run: bash native/litert_lm/patch_c_api.sh C:/LiteRT-LM
+
+      - name: Build LiteRtLm.dll
+        run: |
+          cd C:\LiteRT-LM
+          bazel build --build_tag_filters='-nowindows' '//c:libLiteRtLm.dylib'
+
+      - name: Build StreamProxy.dll
+        run: |
+          cl /LD /Fe:StreamProxy.dll native\litert_lm\stream_proxy.c
+
+      - name: Collect artifacts
+        run: |
+          New-Item -ItemType Directory -Path artifacts -Force
+          Copy-Item C:\LiteRT-LM\bazel-bin\c\libLiteRtLm.dylib artifacts\LiteRtLm.dll
+          Copy-Item StreamProxy.dll artifacts\
+          Get-ChildItem C:\LiteRT-LM\prebuilt\windows_x86_64\*.dll |
+            Copy-Item -Destination artifacts\ -ErrorAction SilentlyContinue
+          Get-ChildItem artifacts\
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: litertlm-windows-x86_64
+          path: artifacts/

--- a/native/litert_lm/patch_c_api.sh
+++ b/native/litert_lm/patch_c_api.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Patch LiteRT-LM C API source to add:
+# 1. cc_binary(linkshared=True) target for shared library
+# 2. litert_lm_engine_settings_set_max_num_images function
+# 3. set_cache_dir propagation to vision/audio executors
+#
+# Usage: patch_c_api.sh <litert_lm_dir>
+# Example: patch_c_api.sh /tmp/LiteRT-LM
+
+set -euo pipefail
+
+DIR="${1:?Usage: patch_c_api.sh <litert_lm_dir>}"
+
+echo "Patching LiteRT-LM C API in $DIR..."
+
+# ── 1. Add shared library target to c/BUILD ──
+if ! grep -q "linkshared" "$DIR/c/BUILD"; then
+  cat >> "$DIR/c/BUILD" << 'BUILDEOF'
+
+cc_binary(
+    name = "libLiteRtLm.dylib",
+    linkshared = True,
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,-exported_symbol,_LiteRt*", "-Wl,-exported_symbol,_litert_lm_*"],
+        "@platforms//os:ios": ["-Wl,-exported_symbol,_LiteRt*", "-Wl,-exported_symbol,_litert_lm_*"],
+        "@platforms//os:linux": ["-Wl,--export-dynamic-symbol=LiteRt*", "-Wl,--export-dynamic-symbol=litert_lm_*"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":engine"],
+)
+BUILDEOF
+  echo "  ✓ Added cc_binary(linkshared=True) to c/BUILD"
+else
+  echo "  ℹ c/BUILD already has shared lib target"
+fi
+
+# ── 2. Add set_max_num_images to c/engine.h ──
+if ! grep -q "set_max_num_images" "$DIR/c/engine.h"; then
+  # Insert before "Creates a LiteRT LM Engine from the given settings"
+  sed -i.bak '/Creates a LiteRT LM Engine from the given settings/i\
+// Sets the maximum number of images for multimodal vision support.\
+// Required for models with vision capabilities (e.g. Gemma 4, Gemma 3n).\
+LITERT_LM_C_API_EXPORT\
+void litert_lm_engine_settings_set_max_num_images(\
+    LiteRtLmEngineSettings* settings, int max_num_images);\
+' "$DIR/c/engine.h"
+  rm -f "$DIR/c/engine.h.bak"
+  echo "  ✓ Added set_max_num_images to c/engine.h"
+else
+  echo "  ℹ c/engine.h already has set_max_num_images"
+fi
+
+# ── 3. Add set_max_num_images impl + patch set_cache_dir in c/engine.cc ──
+if ! grep -q "set_max_num_images" "$DIR/c/engine.cc"; then
+  # Add set_max_num_images before set_activation_data_type
+  sed -i.bak '/void litert_lm_engine_settings_set_activation_data_type/i\
+void litert_lm_engine_settings_set_max_num_images(\
+    LiteRtLmEngineSettings* settings, int max_num_images) {\
+  if (settings \&\& settings->settings) {\
+    settings->settings->GetMutableMainExecutorSettings().SetMaxNumImages(\
+        max_num_images);\
+  }\
+}\
+' "$DIR/c/engine.cc"
+  rm -f "$DIR/c/engine.cc.bak"
+  echo "  ✓ Added set_max_num_images impl to c/engine.cc"
+else
+  echo "  ℹ c/engine.cc already has set_max_num_images"
+fi
+
+# Patch set_cache_dir to also set on vision/audio executors
+if ! grep -q "GetMutableVisionExecutorSettings.*SetCacheDir" "$DIR/c/engine.cc"; then
+  python3 -c "
+import sys
+with open('$DIR/c/engine.cc', 'r') as f:
+    content = f.read()
+
+old = '''void litert_lm_engine_settings_set_cache_dir(LiteRtLmEngineSettings* settings,
+                                             const char* cache_dir) {
+  if (settings && settings->settings) {
+    settings->settings->GetMutableMainExecutorSettings().SetCacheDir(cache_dir);
+  }
+}'''
+
+new = '''void litert_lm_engine_settings_set_cache_dir(LiteRtLmEngineSettings* settings,
+                                             const char* cache_dir) {
+  if (settings && settings->settings) {
+    settings->settings->GetMutableMainExecutorSettings().SetCacheDir(cache_dir);
+    if (settings->settings->GetVisionExecutorSettings().has_value()) {
+      settings->settings->GetMutableVisionExecutorSettings()->SetCacheDir(cache_dir);
+    }
+    if (settings->settings->GetAudioExecutorSettings().has_value()) {
+      settings->settings->GetMutableAudioExecutorSettings()->SetCacheDir(cache_dir);
+    }
+  }
+}'''
+
+if old in content:
+    content = content.replace(old, new)
+    with open('$DIR/c/engine.cc', 'w') as f:
+        f.write(content)
+    print('  ✓ Patched set_cache_dir to propagate to vision/audio executors')
+else:
+    print('  ℹ set_cache_dir already patched or different format')
+"
+else
+  echo "  ℹ set_cache_dir already propagates to vision/audio"
+fi
+
+echo "Patch complete."

--- a/native/litert_lm/stream_proxy.c
+++ b/native/litert_lm/stream_proxy.c
@@ -1,0 +1,59 @@
+#include <stdlib.h>
+#include <string.h>
+
+// Callback type matching LiteRtLmStreamCallback
+typedef void (*LiteRtLmStreamCallback)(void* callback_data, const char* chunk,
+                                       _Bool is_final, const char* error_msg);
+
+// Proxy callback data: holds the Dart callback and memory to free
+typedef struct {
+  LiteRtLmStreamCallback dart_callback;
+  void* dart_data;
+} ProxyData;
+
+// This is the C callback given to LiteRT-LM.
+// It copies chunk/error strings to heap (strdup) so they survive
+// until Dart's NativeCallable.listener processes them.
+static void stream_proxy_callback(void* callback_data, const char* chunk,
+                                  _Bool is_final, const char* error_msg) {
+  ProxyData* proxy = (ProxyData*)callback_data;
+
+  // Copy strings to heap — Dart callback will free them
+  char* chunk_copy = chunk ? strdup(chunk) : NULL;
+  char* error_copy = error_msg ? strdup(error_msg) : NULL;
+
+  proxy->dart_callback(proxy->dart_data, chunk_copy, is_final, error_copy);
+
+  // If final, free the proxy struct itself
+  if (is_final) {
+    free(proxy);
+  }
+}
+
+// Create a proxy that wraps a Dart callback.
+// Returns: proxy callback function pointer (to pass to LiteRT-LM)
+// Out: proxy_data (to pass as callback_data to LiteRT-LM)
+void* stream_proxy_create(LiteRtLmStreamCallback dart_callback,
+                          void* dart_data,
+                          LiteRtLmStreamCallback* out_proxy_fn) {
+  ProxyData* proxy = (ProxyData*)malloc(sizeof(ProxyData));
+  proxy->dart_callback = dart_callback;
+  proxy->dart_data = dart_data;
+  *out_proxy_fn = stream_proxy_callback;
+  return proxy;
+}
+
+// Free a chunk or error string that was strdup'd by the proxy.
+void stream_proxy_free_string(char* str) {
+  free(str);
+}
+
+// Load a shared library with RTLD_GLOBAL so its symbols are visible
+// to other dlopen'd libraries (e.g. GPU accelerator plugins).
+// Dart's DynamicLibrary.open uses RTLD_LOCAL which hides symbols.
+#ifndef _WIN32
+#include <dlfcn.h>
+void* stream_proxy_load_global(const char* path) {
+  return dlopen(path, RTLD_LAZY | RTLD_GLOBAL);
+}
+#endif


### PR DESCRIPTION
Adds `workflow_dispatch` workflow to build LiteRT-LM shared libraries for Linux x86_64 and Windows x86_64.

Includes:
- `build-litertlm-native.yml` — Bazel build on ubuntu-24.04 + windows-latest
- `patch_c_api.sh` — patches LiteRT-LM source with shared lib target + vision fixes
- `stream_proxy.c` — C helper for FFI streaming callback (strdup workaround)

After merge, run from Actions tab → "Build LiteRT-LM Native Libraries" → select branch & version.