### PR TITLE
Trim 600+ KB of junk from the pub publish archive

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -96,3 +96,30 @@ example/integration_test/
 
 # Working notes (drafts, plans, articles, investigation reports)
 _notes/
+
+# Pigeon spec — build-time input that generates lib/pigeon.g.dart.
+# Consumers ship the already-generated .g.dart, they don't re-run pigeon.
+pigeon.dart
+
+# Native FFI smoke-test — compiled into a standalone binary by maintainers
+# during dev, not loaded at runtime. End users don't need the .c source.
+native/litert_lm/test_ffi_minimal.c
+
+# Stray maintainer scratch files. tables.html is leftover Mac/HTML debug
+# from a much older session; test_audio.txt is a 53-byte text fixture
+# that's only referenced by integration tests (already excluded above).
+tables.html
+test_audio.txt
+
+# Reference clone of google-ai-edge/gallery used during research — this
+# is third-party Apache 2.0 source (Google's), not part of flutter_gemma.
+# Should never be in the pub package.
+ai-edge-gallery/
+
+# CocoaPods lock files — environment-specific, regenerated on every
+# `pod install`. pub.dev's lints flag these.
+example/ios/Podfile.lock
+example/macos/Podfile.lock
+
+# Example web test HTML fixture (used by vector store dev tests).
+example/web/test_vectorstore.html


### PR DESCRIPTION
## Summary

\`flutter pub publish --dry-run\` was bundling several files/directories that shouldn't ship to pub.dev. Adding them to \`.pubignore\` drops the published archive from ~1 MB to 605 KB without changing anything users actually consume.

## Excluded

- **\`ai-edge-gallery/\`** — research clone of [google-ai-edge/gallery](https://github.com/google-ai-edge/gallery) sitting in the working tree. Third-party Apache 2.0, definitely should not redistribute under flutter_gemma's name.
- **\`example/ios/Podfile.lock\`** + **\`example/macos/Podfile.lock\`** — environment-specific, regenerated on every \`pod install\`. pub linter flags these.
- **\`example/web/test_vectorstore.html\`** — dev-only fixture for the SQLite vector store integration tests.
- **\`pigeon.dart\`** — Pigeon spec source. The plugin ships the already-generated \`lib/pigeon.g.dart\`; consumers don't re-run pigeon.
- **\`native/litert_lm/test_ffi_minimal.c\`** — standalone FFI smoke-test binary source compiled by maintainers during dev, not loaded at runtime.
- **\`tables.html\`** — leftover HTML debug snippet from an older session.
- **\`test_audio.txt\`** — 53-byte test fixture only referenced by integration tests (which are already pubignored).

## Kept

- \`native/litert_lm/include/engine.h\` — the LiteRT-LM C API header that ffigen reads and that downstream consumers may need for type-bindings or custom FFI extensions.

## Verification

\`flutter pub publish --dry-run\` reports 0 warnings, archive size **605 KB** (down from ~1 MB).