### PR TITLE
0.14.4: fix #250 modes 2 and 3 (asset install on desktop + android x86_64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.14.4
 - **Fix macOS dylib loading on pub.dev installs** (#255).
+- **Fix `fromAsset` install on desktop** (#250 mode 2).
+- **Fix Android x86_64 emulator crash on embedding init** (#250 mode 3).
 - **Reduce native lib size**: iOS -63%, macOS -43%, Android -28%, Linux -16-18%.
 
 ## 0.14.3

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,4 +83,8 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.0.0'
     testImplementation 'junit:junit:4.13.2'
+    // junit-vintage-engine lets JUnit 5 platform run JUnit 4 tests (used by
+    // testOptions.unitTests.useJUnitPlatform()). Without this, our
+    // org.junit.Test classes are silently skipped (#250 work).
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.10.2'
 }

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/EmbeddingModel.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/EmbeddingModel.kt
@@ -21,20 +21,36 @@ class EmbeddingModel(
     
     companion object {
         const val EMBEDDING_DIMENSION = 768 // EmbeddingGemma/Gecko output dimension
-    }
-    
-    fun initialize() {
-        // localagents-rag:0.3.0 ships native libs only for arm64-v8a — fail
-        // fast with a typed message rather than the opaque UnsatisfiedLinkError
-        // that GemmaEmbeddingModel's JNI loader would surface on x86_64
-        // emulators or armeabi-v7a devices (#250).
-        if (!Build.SUPPORTED_ABIS.contains("arm64-v8a")) {
-            throw UnsupportedOperationException(
-                "flutter_gemma embedding requires an arm64-v8a Android device " +
-                "(got ${Build.SUPPORTED_ABIS.joinToString()}). " +
-                "Google's localagents-rag library does not ship x86_64 / armeabi-v7a native libs."
-            )
+
+        /**
+         * Throws [UnsupportedOperationException] if the device's primary ABI
+         * is not arm64-v8a — localagents-rag:0.3.0 ships native libs only for
+         * arm64-v8a, so loading on any other ABI surfaces an opaque
+         * [UnsatisfiedLinkError] from the JNI loader (#250).
+         *
+         * Checks the *primary* ABI ([abis] index 0), not [Array.contains]:
+         * x86_64 emulators advertise arm64-v8a as a translation fallback in
+         * [Build.SUPPORTED_ABIS], but JNI still loads native libs only from
+         * the primary ABI, so `contains("arm64-v8a")` is too permissive.
+         *
+         * Pure function over [abis] for unit-testability — production caller
+         * passes [Build.SUPPORTED_ABIS].
+         */
+        @JvmStatic
+        fun assertArm64v8aPrimaryAbi(abis: Array<String>) {
+            if (abis.firstOrNull() != "arm64-v8a") {
+                throw UnsupportedOperationException(
+                    "flutter_gemma embedding requires an arm64-v8a Android device " +
+                    "(got primary ABI ${abis.firstOrNull()}, " +
+                    "full list: ${abis.joinToString()}). " +
+                    "Google's localagents-rag library does not ship x86_64 / armeabi-v7a native libs."
+                )
+            }
         }
+    }
+
+    fun initialize() {
+        assertArm64v8aPrimaryAbi(Build.SUPPORTED_ABIS)
 
         // Verify files exist
         val modelFile = File(modelPath)

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
@@ -368,8 +368,12 @@ private class PlatformServiceImpl(
         embeddingModel = EmbeddingModel(context, modelPath, tokenizerPath, useGPU)
         embeddingModel!!.initialize()
         callback(Result.success(Unit))
-      } catch (e: Exception) {
-        callback(Result.failure(e))
+      } catch (e: Throwable) {
+        // Catch Throwable (not just Exception) so UnsatisfiedLinkError from
+        // GemmaEmbeddingModel's JNI loader on x86_64 / armeabi-v7a — Error
+        // subclass, not Exception — surfaces as a typed failure instead of
+        // killing the process (#250).
+        callback(Result.failure(if (e is Exception) e else RuntimeException(e)))
       }
     }
   }

--- a/android/src/test/kotlin/dev/flutterberlin/flutter_gemma/EmbeddingModelAbiGuardTest.kt
+++ b/android/src/test/kotlin/dev/flutterberlin/flutter_gemma/EmbeddingModelAbiGuardTest.kt
@@ -1,0 +1,78 @@
+package dev.flutterberlin.flutter_gemma
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [EmbeddingModel.assertArm64v8aPrimaryAbi].
+ *
+ * Regression tests for #250 Mode 3: x86_64 Android emulators advertise
+ * arm64-v8a as a translation fallback in Build.SUPPORTED_ABIS, so the old
+ * `Build.SUPPORTED_ABIS.contains("arm64-v8a")` guard was too permissive
+ * and let JNI loading proceed on x86_64, where the arm64-only native lib
+ * fails with [UnsatisfiedLinkError].
+ */
+class EmbeddingModelAbiGuardTest {
+
+    @Test
+    fun `arm64 device passes`() {
+        // Real Pixel 8: SUPPORTED_ABIS=[arm64-v8a]. No throw expected.
+        EmbeddingModel.assertArm64v8aPrimaryAbi(arrayOf("arm64-v8a"))
+    }
+
+    @Test
+    fun `arm64 device with fallbacks passes`() {
+        // Some arm64 devices expose 32-bit fallbacks. Primary still arm64-v8a.
+        EmbeddingModel.assertArm64v8aPrimaryAbi(
+            arrayOf("arm64-v8a", "armeabi-v7a", "armeabi")
+        )
+    }
+
+    @Test
+    fun `x86_64 emulator with arm64 translation fallback throws (reproduces 250 mode 3)`() {
+        // Standard Android x86_64 emulator: primary ABI is x86_64 but
+        // arm64-v8a sits in the list as a Houdini/translation fallback.
+        // The old contains() guard let this through; firstOrNull() catches
+        // it because primary != arm64-v8a.
+        try {
+            EmbeddingModel.assertArm64v8aPrimaryAbi(
+                arrayOf("x86_64", "arm64-v8a")
+            )
+            throw AssertionError("expected UnsupportedOperationException")
+        } catch (e: UnsupportedOperationException) {
+            assertTrue(
+                "error message should mention primary ABI",
+                e.message!!.contains("primary ABI x86_64")
+            )
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun `x86 32-bit emulator throws`() {
+        EmbeddingModel.assertArm64v8aPrimaryAbi(arrayOf("x86", "armeabi-v7a"))
+    }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun `armeabi-v7a only device throws`() {
+        EmbeddingModel.assertArm64v8aPrimaryAbi(arrayOf("armeabi-v7a", "armeabi"))
+    }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun `empty abi list throws`() {
+        EmbeddingModel.assertArm64v8aPrimaryAbi(arrayOf())
+    }
+
+    @Test
+    fun `error message lists full abi list for diagnostics`() {
+        try {
+            EmbeddingModel.assertArm64v8aPrimaryAbi(arrayOf("x86_64", "arm64-v8a"))
+            throw AssertionError("expected throw")
+        } catch (e: UnsupportedOperationException) {
+            assertTrue(
+                "should include full list for support diagnostics",
+                e.message!!.contains("full list: x86_64, arm64-v8a")
+            )
+        }
+    }
+}

--- a/example/integration_test/asset_source_desktop_test.dart
+++ b/example/integration_test/asset_source_desktop_test.dart
@@ -1,0 +1,61 @@
+// Regression test for #250 (Mode 2): AssetSource install on desktop must
+// fall back to in-memory `loadAsset → writeFile` when `large_file_handler`'s
+// native channel call surfaces a `MissingPluginException`.
+//
+// Before 0.14.5, FlutterAssetLoader.copyAssetToFile wrapped *all* exceptions
+// (including MissingPluginException) in a generic `Exception(...)`, so the
+// upstream `on MissingPluginException` catch in AssetSourceHandler matched
+// by type and never fired — the desktop install path threw a wrapped
+// exception instead of falling back.
+//
+// Run: flutter test integration_test/asset_source_desktop_test.dart -d macos
+//
+// On macOS / Windows / Linux there is no large_file_handler plugin
+// implementation, so the channel call throws MissingPluginException —
+// the exact bug Erik reported in #250 on Windows.
+
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/core/api/flutter_gemma.dart';
+import 'package:flutter_gemma/core/model.dart';
+import 'package:path_provider/path_provider.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('AssetSource install falls back to writeFile on desktop',
+      (t) async {
+    await FlutterGemma.initialize();
+
+    // assets/test/test_image.jpg is a 14 KB fixture bundled in the example.
+    // Re-using it as a stand-in "model" file: AssetSourceHandler doesn't
+    // care about contents, only that copy succeeds and it's registered.
+    const fixturePath = 'assets/test/test_image.jpg';
+    const fixtureBasename = 'test_image.jpg';
+
+    // Ensure clean state — uninstall if a prior run left it around.
+    final wasInstalled = await FlutterGemma.isModelInstalled(fixtureBasename);
+    if (wasInstalled) {
+      await FlutterGemma.uninstallModel(fixtureBasename);
+    }
+
+    // The actual probe — installing from an asset on macOS must not throw
+    // "_Exception: Failed to copy asset: ... - MissingPluginException(...)".
+    await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
+        .fromAsset(fixturePath)
+        .install();
+
+    // Verify the file actually landed in app docs dir (the writeFile fallback
+    // wrote it).
+    final docsDir = await getApplicationDocumentsDirectory();
+    final installed = File('${docsDir.path}/$fixtureBasename');
+    expect(installed.existsSync(), isTrue,
+        reason: 'Asset should have been written to app docs dir');
+    expect(installed.lengthSync(), greaterThan(0),
+        reason: 'Written file should be non-empty');
+
+    // Cleanup.
+    await FlutterGemma.uninstallModel(fixtureBasename);
+  });
+}

--- a/lib/core/handlers/asset_source_handler.dart
+++ b/lib/core/handlers/asset_source_handler.dart
@@ -47,16 +47,21 @@ class AssetSourceHandler implements SourceHandler {
     // On platforms where large_file_handler doesn't ship a plugin (desktop:
     // macOS/Windows/Linux, web stub) the channel call throws
     // MissingPluginException — fall back to in-memory loadAsset → writeFile.
+    //
+    // Lookup keys differ between paths:
+    // - `pathForLookupKey` (no `assets/` prefix) for the native channel call
+    // - `normalizedPath` (with `assets/` prefix) for the Flutter rootBundle
+    //   fallback (#250 Mode 2)
     if (assetLoader is FlutterAssetLoader) {
       try {
         await (assetLoader as FlutterAssetLoader)
             .copyAssetToFile(source.pathForLookupKey, filename);
       } on MissingPluginException {
-        final assetData = await assetLoader.loadAsset(source.pathForLookupKey);
+        final assetData = await assetLoader.loadAsset(source.normalizedPath);
         await fileSystem.writeFile(targetPath, assetData);
       }
     } else {
-      final assetData = await assetLoader.loadAsset(source.pathForLookupKey);
+      final assetData = await assetLoader.loadAsset(source.normalizedPath);
       await fileSystem.writeFile(targetPath, assetData);
     }
 
@@ -93,12 +98,12 @@ class AssetSourceHandler implements SourceHandler {
           yield progress;
         }
       } on MissingPluginException {
-        final assetData = await assetLoader.loadAsset(source.pathForLookupKey);
+        final assetData = await assetLoader.loadAsset(source.normalizedPath);
         await fileSystem.writeFile(targetPath, assetData);
         yield 100;
       }
     } else {
-      final assetData = await assetLoader.loadAsset(source.pathForLookupKey);
+      final assetData = await assetLoader.loadAsset(source.normalizedPath);
       await fileSystem.writeFile(targetPath, assetData);
       yield 100;
     }

--- a/lib/core/infrastructure/flutter_asset_loader.dart
+++ b/lib/core/infrastructure/flutter_asset_loader.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_gemma/core/services/asset_loader.dart';
 import 'package:large_file_handler/large_file_handler.dart';
 
@@ -14,30 +15,29 @@ class FlutterAssetLoader implements AssetLoader {
 
   @override
   Future<Uint8List> loadAsset(String path) async {
-    try {
-      // LargeFileHandler doesn't return bytes, it copies files
-      // For the AssetLoader interface, we need to read after copy
-      // But this is still memory-intensive for large files
-      // Better approach: change AssetSourceHandler to use copyAssetToLocalStorage directly
-      throw UnimplementedError(
-          'FlutterAssetLoader.loadAsset() is deprecated for large files. '
-          'Use copyAssetToFile() instead or call LargeFileHandler directly.');
-    } catch (e) {
-      throw Exception('Failed to load asset: $path - $e');
-    }
+    // Used as the desktop fallback in AssetSourceHandler when
+    // large_file_handler has no plugin implementation (#250 Mode 2).
+    // rootBundle.load() works on all platforms including macOS / Windows /
+    // Linux desktop. Loads the whole asset into memory — fine for the small
+    // models that are typically bundled (large models go through
+    // copyAssetToFile which streams via large_file_handler).
+    final byteData = await rootBundle.load(path);
+    return byteData.buffer.asUint8List(
+      byteData.offsetInBytes,
+      byteData.lengthInBytes,
+    );
   }
 
   /// Copies asset file directly to target path using LargeFileHandler
   /// This is the CORRECT way to handle large files
-  Future<void> copyAssetToFile(String assetPath, String targetPath) async {
-    try {
-      await _handler.copyAssetToLocalStorage(
-        assetName: assetPath,
-        targetPath: targetPath,
-      );
-    } catch (e) {
-      throw Exception('Failed to copy asset: $assetPath - $e');
-    }
+  Future<void> copyAssetToFile(String assetPath, String targetPath) {
+    // Do NOT wrap exceptions: callers (e.g. AssetSourceHandler) match by type
+    // — wrapping MissingPluginException in a generic Exception would defeat
+    // the desktop fallback path (#250).
+    return _handler.copyAssetToLocalStorage(
+      assetName: assetPath,
+      targetPath: targetPath,
+    );
   }
 
   /// Copies asset with progress tracking

--- a/test/core/handlers/source_handler_test.dart
+++ b/test/core/handlers/source_handler_test.dart
@@ -199,8 +199,11 @@ void main() {
 
       await handler.install(source);
 
-      // AssetSourceHandler uses pathForLookupKey, not normalizedPath
-      verify(() => mockAssetLoader.loadAsset(source.pathForLookupKey)).called(1);
+      // AssetSourceHandler uses normalizedPath (with assets/ prefix) for the
+      // generic loadAsset path — matches Flutter rootBundle's expected key
+      // format. The native large_file_handler path uses pathForLookupKey
+      // separately (see #250 Mode 2 fix).
+      verify(() => mockAssetLoader.loadAsset(source.normalizedPath)).called(1);
       verify(() => mockFileSystem.writeFile(targetPath, assetData)).called(1);
       verify(() => mockRepository.saveModel(any())).called(1);
     });
@@ -241,9 +244,10 @@ void main() {
       await handler.install(source1);
       await handler.install(source2);
 
-      // Both should use pathForLookupKey which returns 'models/test.bin' (without assets/ prefix)
-      // This is correct for native platform lookupKey
-      verify(() => mockAssetLoader.loadAsset('models/test.bin')).called(2);
+      // Both should normalize to 'assets/models/test.bin' for the loadAsset
+      // (rootBundle) path. The native lookup key (without prefix) is used
+      // separately on the large_file_handler path.
+      verify(() => mockAssetLoader.loadAsset('assets/models/test.bin')).called(2);
     });
   });
 


### PR DESCRIPTION
## Summary

Both bugs Erik (xErik) re-confirmed against 0.14.3 in #250, fixed before publishing 0.14.4 to pub.dev.

### Mode 2 — desktop \`installModel().fromAsset()\` was triple-broken
1. \`FlutterAssetLoader.copyAssetToFile\` wrapped \`MissingPluginException\` in a generic \`Exception\` → upstream \`on MissingPluginException\` catch never matched.
2. Even if it had — the fallback \`loadAsset()\` itself threw \`UnimplementedError\` ('deprecated for large files').
3. Fallback used \`pathForLookupKey\` (no \`assets/\` prefix) for what is actually a \`rootBundle.load()\` call (which expects the prefix).

All three fixed. Verified end-to-end on macOS via new \`example/integration_test/asset_source_desktop_test.dart\`.

### Mode 3 — Android x86_64 emulator embedding init crashed the process
1. ABI guard used \`SUPPORTED_ABIS.contains(\"arm64-v8a\")\`, but x86_64 emulators advertise arm64-v8a as a Houdini translation fallback in the list — guard passed, JNI loader then died with \`UnsatisfiedLinkError\`. Now checks \`SUPPORTED_ABIS[0]\` (primary ABI).
2. \`createEmbeddingModel\` coroutine used \`catch (e: Exception)\` — but \`UnsatisfiedLinkError\` is an \`Error\`, not \`Exception\` — so it killed the process. Now \`catch (e: Throwable)\` and surfaces as \`Result.failure\`.

Guard logic refactored into \`EmbeddingModel.assertArm64v8aPrimaryAbi()\` for unit testability. New \`EmbeddingModelAbiGuardTest\` covers seven cases including the exact x86_64+arm64-v8a translation-fallback scenario Erik reported. Also adds \`junit-vintage-engine\` so JUnit5 platform actually picks up our JUnit4 tests (existing \`EngineFactoryTest\` was silently skipped — separate issue).

## Test plan

- [x] \`flutter analyze\` — 0 new issues
- [x] \`flutter test\` — 343/343 unit tests pass
- [x] \`./gradlew :flutter_gemma:testDebugUnitTest --tests *EmbeddingModelAbiGuardTest*\` — 7/7 pass
- [x] \`flutter test integration_test/asset_source_desktop_test.dart -d macos\` — 1/1 pass (Mode 2 verified end-to-end)
- [x] \`dart pub publish --dry-run\` — 0 warnings