### PR TITLE
0.14.5: restore desktop tensorflowlite_c bundling via Native Assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.5
+- **Fix desktop embedding on pub.dev installs** (#250 follow-up): `tensorflowlite_c.{dll,so,dylib}` now bundled via Native Assets — regression from 0.14.0 setup-script removal.
+
 ## 0.14.4
 - **Fix macOS dylib loading on pub.dev installs** (#255).
 - **Fix `fromAsset` install on desktop** (#250 mode 2).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.10.2-b` GitHub Release (built from upstream `google-ai-edge/LiteRT-LM` v0.10.2 + commit 5e0d86b for iOS), bundled via Native Assets — same `.so`/`.dylib`/`.dll` set on all platforms. `-b` rebuild with `-c opt --strip=always` for ~25-60% per-platform size reduction; retains `-a`'s vtool minos patch (26.2 → 16.0) on iOS `libGemmaModelConstraintProvider.dylib` and 16KB page alignment on Android `libLiteRtLm.so`.
-- **Current Version**: 0.14.4
+- **Current Version**: 0.14.5
 
 ## Platform-Specific Setup
 

--- a/example/integration_test/desktop_tflite_load_test.dart
+++ b/example/integration_test/desktop_tflite_load_test.dart
@@ -1,0 +1,34 @@
+// Smoke test: TFLite C library loads via Native Assets on desktop.
+//
+// Regression test for #250 follow-up: verifies that the
+// `tensorflowlite_c.{dll,so,dylib}` registered in `hook/build.dart` is
+// actually placed in the app bundle by the Flutter tool and resolvable
+// via `DynamicLibrary.open('tensorflowlite_c')`. No model file required —
+// just constructs the bindings.
+//
+// Run:
+//   flutter test integration_test/desktop_tflite_load_test.dart -d macos
+//   flutter test integration_test/desktop_tflite_load_test.dart -d windows
+//   flutter test integration_test/desktop_tflite_load_test.dart -d linux
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/desktop/tflite/tflite_bindings.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('TFLite C library loads from Native Assets bundle',
+      (WidgetTester tester) async {
+    // Constructs DynamicLibrary.open('tensorflowlite_c') under the hood.
+    // Throws on platforms where the library is missing (the bug Erik hit
+    // on Windows in #250 follow-up: ArgumentError "module could not be
+    // found").
+    final bindings = TfLiteBindings.load();
+    expect(bindings, isNotNull);
+
+    // Sanity-check one symbol resolved (TfLiteModelCreateFromFile is a
+    // well-known TFLite C entry point).
+    expect(bindings.tfLiteModelCreateFromFile, isNotNull);
+  });
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.14.4"
+    version: "0.14.5"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -39,6 +39,45 @@ const _checksums = <String, String>{
       'c46406d19e52648e364c224dc5d7da5bb28f581cdb428a02b5e746bacb953762',
 };
 
+/// TensorFlow Lite C library (used by `lib/desktop/tflite/tflite_bindings.dart`
+/// for embedding inference on macOS/Linux/Windows). Lives at our own
+/// `v0.12.7` release — built from LiteRT 2.1.3, ABI-compatible with the
+/// LiteRT-LM 0.10.2 series. Fetched separately from the LiteRT-LM tarballs
+/// so versioning stays independent (no need to rebuild `native-v0.10.2-b`
+/// just to bump TFLite C). Restored in 0.14.5 after regression from 0.14.0
+/// setup-script removal — see #250 follow-up.
+const _tfliteVersion = '0.12.7';
+const _tfliteReleaseBase =
+    'https://github.com/DenisovAV/flutter_gemma/releases/download/v$_tfliteVersion';
+
+/// Per-platform TFLite C artifact: source filename in v0.12.7 release +
+/// SHA256. The local cached file is renamed to the canonical bundle name
+/// (`libtensorflowlite_c.{dylib,so}` / `tensorflowlite_c.dll`) so Native
+/// Assets can register it under a stable basename — `tflite_bindings.dart`
+/// loads it via `DynamicLibrary.open('tensorflowlite_c')`.
+const _tfliteAssets = <String, ({String src, String dst, String sha256})>{
+  'macos_arm64': (
+    src: 'libtensorflowlite_c_darwin_arm64.dylib',
+    dst: 'libtensorflowlite_c.dylib',
+    sha256: '13bcd426b62a0b8b12fb10b6c540cd30f4c2858dd0ce42c0ed67090eb7a60ed1',
+  ),
+  'linux_x86_64': (
+    src: 'libtensorflowlite_c_linux_amd64.so',
+    dst: 'libtensorflowlite_c.so',
+    sha256: 'f98dcaa2f8033794725413542625a396744928dc5c0a6fd90ff3c0c5b1209327',
+  ),
+  'linux_arm64': (
+    src: 'libtensorflowlite_c_linux_arm64.so',
+    dst: 'libtensorflowlite_c.so',
+    sha256: '602a0aea312d36697adc042058b3231875b84b7679461214450030f6eace0999',
+  ),
+  'windows_x86_64': (
+    src: 'tensorflowlite_c_windows_amd64.dll',
+    dst: 'tensorflowlite_c.dll',
+    sha256: 'e185a3170109a33e3b29fe64beeff9eaa162fa1f9dc47a618fa708e21d458bcf',
+  ),
+};
+
 /// Resolve prebuilt directory name for the given OS + architecture.
 /// iOS distinguishes device vs simulator via IOSSdk.
 String? _prebuiltDirName(OS os, Architecture arch, {IOSSdk? iOSSdk}) {
@@ -195,6 +234,85 @@ Future<Directory?> _downloadAndExtract(String dirName) async {
   }
 }
 
+/// Download a single file (no archive), verify SHA256, place at [dest].
+/// Used for TFLite C library prebuilts which are shipped as bare .dll/.so/
+/// .dylib files in the v0.12.7 release.
+Future<File?> _downloadFile({
+  required String url,
+  required File dest,
+  required String expectedSha256,
+}) async {
+  // Skip if already cached and checksum matches.
+  if (dest.existsSync()) {
+    final cached = sha256.convert(await dest.readAsBytes()).toString();
+    if (cached == expectedSha256) return dest;
+    dest.deleteSync();
+  }
+
+  final destDir = dest.parent;
+  if (!destDir.existsSync()) destDir.createSync(recursive: true);
+
+  // Download to a `.partial` sibling first, then atomically rename. This
+  // keeps Native Assets' "File modified during build" guard happy:
+  // [dest] only appears (and stops being modified) once the bytes are
+  // fully on disk, instead of growing during the build pass.
+  final partial = File('${dest.path}.partial');
+  if (partial.existsSync()) partial.deleteSync();
+
+  stderr.writeln('flutter_gemma: Downloading $url ...');
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(Uri.parse(url));
+    final response = await request.close();
+    if (response.statusCode != 200) {
+      stderr.writeln(
+          'flutter_gemma: TFLite C download failed (HTTP ${response.statusCode})');
+      return null;
+    }
+    final sink = partial.openWrite();
+    await response.pipe(sink);
+  } finally {
+    client.close();
+  }
+
+  final actual = sha256.convert(await partial.readAsBytes()).toString();
+  if (actual != expectedSha256) {
+    stderr.writeln('flutter_gemma: TFLite C checksum mismatch!');
+    stderr.writeln('  Expected: $expectedSha256');
+    stderr.writeln('  Actual:   $actual');
+    partial.deleteSync();
+    return null;
+  }
+
+  partial.renameSync(dest.path);
+  stderr.writeln('flutter_gemma: TFLite C cached to ${dest.path}');
+  return dest;
+}
+
+/// Resolve the local TFLite C library file for [dirName], downloading from
+/// the v0.12.7 release into the same cache layout used by LiteRT-LM libs
+/// if not already present. Returns null on unsupported platforms (iOS /
+/// Android / web — they don't use TFLite C via FFI).
+Future<File?> _resolveTfliteLib(String dirName) async {
+  final asset = _tfliteAssets[dirName];
+  if (asset == null) return null;
+
+  // Mirror LiteRT-LM `_resolveLibDir` order: in-repo prebuilt → cache → fetch.
+  final cacheBase = _cacheDir();
+  final platformDir = Directory('${cacheBase.path}/$dirName');
+  final cached = File('${platformDir.path}/${asset.dst}');
+  if (cached.existsSync()) {
+    final hash = sha256.convert(await cached.readAsBytes()).toString();
+    if (hash == asset.sha256) return cached;
+  }
+
+  return _downloadFile(
+    url: '$_tfliteReleaseBase/${asset.src}',
+    dest: cached,
+    expectedSha256: asset.sha256,
+  );
+}
+
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (!input.config.buildCodeAssets) return;
@@ -328,6 +446,26 @@ void main(List<String> args) async {
             ),
           );
         }
+      }
+    }
+
+    // TFLite C library — desktop embeddings only (`lib/desktop/tflite/`).
+    // Skipped on iOS / Android / web. Bundled as `tensorflowlite_c` so
+    // `DynamicLibrary.open('tensorflowlite_c')` in tflite_bindings.dart
+    // resolves through Native Assets on each desktop OS. Restored in
+    // 0.14.5 after regression from setup-script removal in 0.14.0
+    // (#250 follow-up: Erik xErik report on Windows).
+    if (os == OS.macOS || os == OS.linux || os == OS.windows) {
+      final tfliteFile = await _resolveTfliteLib(dirName);
+      if (tfliteFile != null) {
+        output.assets.code.add(
+          CodeAsset(
+            package: _packageName,
+            name: 'src/native/tensorflowlite_c',
+            linkMode: DynamicLoadingBundled(),
+            file: tfliteFile.uri,
+          ),
+        );
       }
     }
 

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.14.4'
+  s.version          = '0.14.5'
   s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
   s.description      = <<-DESC
 The plugin allows running the Gemma AI model locally on a device from a Flutter application.

--- a/lib/desktop/tflite/tflite_bindings.dart
+++ b/lib/desktop/tflite/tflite_bindings.dart
@@ -41,39 +41,36 @@ class TfLiteBindings {
 
   static TfLiteBindings? _instance;
 
-  /// Load TFLite C library from the platform-specific location.
+  /// Load TFLite C library bundled by Native Assets (hook/build.dart).
+  ///
+  /// `tensorflowlite_c.{dll,so,dylib}` is registered as a Native Assets
+  /// `CodeAsset` and placed by the Flutter tool — on macOS as a
+  /// `tensorflowlite_c.framework` bundle inside `Contents/Frameworks/`,
+  /// on Windows as a `.dll` next to `<runner>.exe`, on Linux as a `.so`
+  /// in `<runner>/lib/`. `dlopen`/`LoadLibrary` resolves the platform-
+  /// canonical basename via the runtime's library search path (rpath on
+  /// macOS, the exe's directory on Windows, `LD_LIBRARY_PATH` / runpath
+  /// on Linux). [libraryPath] kept for unit tests.
   static TfLiteBindings load({String? libraryPath}) {
     if (_instance != null) return _instance!;
 
-    final path = libraryPath ?? _defaultLibraryPath();
-    final lib = DynamicLibrary.open(path);
+    final lib = libraryPath != null
+        ? DynamicLibrary.open(libraryPath)
+        : DynamicLibrary.open(_platformLibraryName());
     _instance = TfLiteBindings._(lib);
     return _instance!;
   }
 
-  static String _defaultLibraryPath() {
-    final execDir = File(Platform.resolvedExecutable).parent.path;
-
+  static String _platformLibraryName() {
     if (Platform.isMacOS) {
-      // macOS: Contents/Frameworks/libtensorflowlite_c.dylib
-      final frameworksPath = '$execDir/../Frameworks/libtensorflowlite_c.dylib';
-      if (File(frameworksPath).existsSync()) return frameworksPath;
-      // Fallback: Contents/Resources/tflite/
-      final resourcesPath =
-          '$execDir/../Resources/tflite/libtensorflowlite_c.dylib';
-      if (File(resourcesPath).existsSync()) return resourcesPath;
-      throw StateError(
-        'TFLite C library not found. Searched:\n'
-        '  1. $frameworksPath\n'
-        '  2. $resourcesPath\n'
-        'Run macos/scripts/setup_desktop.sh to download it.',
-      );
-    } else if (Platform.isWindows) {
-      return '$execDir\\tflite\\tensorflowlite_c.dll';
-    } else {
-      // Linux
-      return '$execDir/lib/tflite/libtensorflowlite_c.so';
+      // Native Assets wraps macOS dylibs into versioned .framework bundles.
+      // Resolve to the framework's executable name; dyld locates it via
+      // the runner's rpath that Flutter sets up.
+      return 'tensorflowlite_c.framework/tensorflowlite_c';
     }
+    if (Platform.isWindows) return 'tensorflowlite_c.dll';
+    // Linux
+    return 'libtensorflowlite_c.so';
   }
 
   // --- Model ---

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.14.4
+version: 0.14.5
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 


### PR DESCRIPTION
## Summary

Erik (xErik) re-tested 0.14.4 on Windows after we fixed #250 modes 2+3 and found that, once asset install actually works, `getActiveEmbedder()` immediately fails with `Failed to load dynamic library '<exe>\tflite\tensorflowlite_c.dll': The specified module could not be found.`

Root cause: regression from 0.14.0 (#239 desktop FFI rewrite) which removed `scripts/setup_desktop.{ps1,sh}`. Those scripts also fetched `tensorflowlite_c.{dll,so,dylib}` for desktop embedding inference; the TFLite C downloader was deleted alongside the JRE/gRPC setup it lived next to. `lib/desktop/tflite/tflite_bindings.dart` still expected those files to exist.

Same bug latent on macOS + Linux pub.dev installs — only worked locally for the maintainer because of leftover artifacts.

## Fix

- `hook/build.dart`: register `tensorflowlite_c.{dll,so,dylib}` as a Native Assets `CodeAsset`, fetched from existing `v0.12.7` GitHub Release (LiteRT 2.1.3 build, ABI-compatible with our LiteRT-LM 0.10.2 series). SHA256-verified per-platform map. Atomic `.partial` → rename so the file appears at its final path only when the bytes are fully on disk (avoids Native Assets' "File modified during build" guard).
- `lib/desktop/tflite/tflite_bindings.dart`: drop the macOS path-fallback + StateError + Windows hardcoded `\\tflite\\` path. Single platform-aware basename via `DynamicLibrary.open` — `.framework`-relative on macOS, plain `.dll`/`.so` on Windows/Linux. Native Assets places the library so the runtime loader resolves it through the bundle layout.

Separate fetcher from `litertlm-{os}_{arch}.tar.gz` keeps versioning independent (no need to rebuild `native-v0.10.2-b` to bump TFLite C, and vice versa).

## Test plan

- [x] `flutter analyze` — 0 new issues
- [x] `flutter test` — 343/343 unit tests pass
- [x] `dart pub publish --dry-run` — 0 warnings
- [x] **macOS** clean-state simulation (`flutter clean` + cache deleted) → integration test `example/integration_test/desktop_tflite_load_test.dart` passes
- [x] **Windows** GCloud `flutter-gemma-gpu` T4 VM → integration test passes (real Erik repro environment)
- [x] **Linux** GCloud `flutter-gemma-linux` T4 VM → integration test passes