### PR TITLE
feat: add multi-image support, FFI session metrics, and prefix replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,14 +1091,14 @@ The plugin now supports different types of messages:
 final textMessage = Message.text(text: "Hello!", isUser: true);
 
 // Text + Image
-final multimodalMessage = Message.withImage(
+final multimodalMessage = Message.withImages(
   text: "What's in this image?",
-  imageBytes: imageBytes,
+  imageBytes: [imageBytes],
   isUser: true,
 );
 
 // Image only
-final imageMessage = Message.imageOnly(imageBytes: imageBytes, isUser: true);
+final imageMessage = Message.imagesOnly(imageBytes: [imageBytes], isUser: true);
 
 // Tool response (for function calling)
 final toolMessage = Message.toolResponse(
@@ -1341,7 +1341,7 @@ The full and complete example you can find in `example` folder
 * **LoRA Weights:** They provide efficient customization without the need for full model retraining.
 * **Development vs. Production:** For production apps, do not embed the model or LoRA weights within your assets. Instead, load them once and store them securely on the device or via a network drive.
 * **Web Models:** Currently, Web support is available only for GPU backend models. Multimodal support is fully implemented.
-* **Image Formats:** The plugin automatically handles common image formats (JPEG, PNG, etc.) when using `Message.withImage()`.
+* **Image Formats:** The plugin automatically handles common image formats (JPEG, PNG, etc.) when using `Message.withImages()` or `Message.withImage()`.
 
 ## **🛟 Troubleshooting**
 

--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -38,7 +38,7 @@ enum Model implements InferenceModelInterface {
     supportImage: true,
     supportAudio: true,
     maxTokens: 4096,
-    maxNumImages: 1,
+    maxNumImages: 4,
     isThinking: true,
   ),
   gemma4_E4B(
@@ -62,7 +62,7 @@ enum Model implements InferenceModelInterface {
     supportImage: true,
     supportAudio: true,
     maxTokens: 4096,
-    maxNumImages: 1,
+    maxNumImages: 4,
     isThinking: true,
   ),
 
@@ -88,7 +88,7 @@ enum Model implements InferenceModelInterface {
     supportAudio:
         false, // .task files don't have TF_LITE_AUDIO_ENCODER - audio only in .litertlm
     maxTokens: 4096,
-    maxNumImages: 1,
+    maxNumImages: 4,
     supportsFunctionCalls: false, // Disabled - causes issues with multimodal
     foregroundDownload: true, // Large model - use foreground service on Android
   ),
@@ -113,7 +113,7 @@ enum Model implements InferenceModelInterface {
     supportAudio:
         false, // .task files don't have TF_LITE_AUDIO_ENCODER - need .litertlm
     maxTokens: 4096,
-    maxNumImages: 1,
+    maxNumImages: 4,
     supportsFunctionCalls: false, // Disabled - causes issues with multimodal
     foregroundDownload: true, // Large model - use foreground service on Android
   ),
@@ -206,7 +206,7 @@ enum Model implements InferenceModelInterface {
     supportImage: true,
     supportAudio: true, // .litertlm files have TF_LITE_AUDIO_ENCODER
     maxTokens: 4096,
-    maxNumImages: 1,
+    maxNumImages: 4,
     supportsFunctionCalls: true,
   ),
 
@@ -379,7 +379,7 @@ enum Model implements InferenceModelInterface {
     topP: 0.95,
     maxTokens: 2048,
     supportImage: true,
-    maxNumImages: 1,
+    maxNumImages: 4,
     supportsFunctionCalls: false,
   ),
 

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -62,6 +62,8 @@ class InferenceChat {
 
   List<Message> get fullHistory => List.unmodifiable(_fullHistory);
 
+  int get currentTokens => _currentTokens;
+
   Future<void> initSession() async {
     session = await sessionCreator!();
   }
@@ -524,8 +526,10 @@ class InferenceChat {
       final size = await session.sizeInTokens(removedMessage.text);
       _currentTokens -= size;
 
-      if (removedMessage.hasImage) {
-        _currentTokens -= 257;
+      // Count all images (message.images can have multiple)
+      final imageCount = removedMessage.images.length;
+      if (imageCount > 0) {
+        _currentTokens -= imageCount * 257;
       }
     }
 

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -31,6 +31,7 @@ class InferenceChat {
   final List<Tool> tools;
 
   final List<Message> _fullHistory = [];
+  final List<Message> _prefixes = []; // Prefix messages (tools prompt + context message) for replay across sessions
   final List<Message> _modelHistory = [];
   int _currentTokens = 0;
   bool _toolsInstructionSent =
@@ -70,7 +71,7 @@ class InferenceChat {
     await addQueryChunk(message);
   }
 
-  Future<void> addQueryChunk(Message message, [bool noTool = false]) async {
+  Future<void> addQueryChunk(Message message, [bool noTool = false, bool prefix = false]) async {
     var messageToSend = message;
 
     // Only add tools prompt for the first user text message (not a tool response)
@@ -89,16 +90,17 @@ class InferenceChat {
       _toolsInstructionSent = true;
       final toolsPrompt = createToolsPrompt();
 
-      // For FunctionGemma, manually construct the full prompt with turn markers
-      // because tools prompt already has developer turn markers
-      if (modelType == ModelType.functionGemma) {
-        final newText =
-            '$toolsPrompt$startTurn$userPrefix\n${messageToSend.text}\n$endTurn\n$startTurn$modelPrefix\n';
-        messageToSend = messageToSend.copyWith(text: newText);
-      } else {
-        final newText = '$toolsPrompt\n${messageToSend.text}';
-        messageToSend = messageToSend.copyWith(text: newText);
-      }
+      // Create tools prompt message for both storage and session
+      final toolsPromptMessage = Message(
+        text: toolsPrompt,
+        isUser: true,
+      );
+
+      // Send to session
+      await session.addQueryChunk(toolsPromptMessage);
+
+      // Store in _prefixes for replay
+      _prefixes.add(toolsPromptMessage);
     } else if (!supportsFunctionCalls && tools.isNotEmpty && !noTool) {
       // Log warning if model doesn't support function calls but tools are provided
       debugPrint(
@@ -121,11 +123,18 @@ class InferenceChat {
 
     await session.addQueryChunk(messageToSend);
 
-    // Store original message in _modelHistory (not messageToSend) so that
-    // _recreateSessionWithReducedChunks replay does not double-apply transformations
-    // (e.g. systemInstruction prepend, tools prompt) when the session is recreated.
+    // Store message in history
     _fullHistory.add(messageToSend);
-    _modelHistory.add(message);
+    // If this is a prefix message, add to _prefixes
+    if (prefix) {
+      _prefixes.add(message);
+    } else {
+      _modelHistory.add(message);
+    }
+
+    if (message.hasImage) {
+      _currentTokens += 257;
+    }
   }
 
   Future<ModelResponse> generateChatResponse() async {
@@ -203,6 +212,7 @@ class InferenceChat {
       debugPrint(
           'InferenceChat: Single-turn model detected, clearing model history...');
       _modelHistory.clear();
+      _prefixes.clear();
       _currentTokens = 0;
       _toolsInstructionSent = false;
 
@@ -509,6 +519,7 @@ class InferenceChat {
         debugPrint(
             'InferenceChat: Single-turn model detected (text response), clearing model history...');
         _modelHistory.clear();
+        _prefixes.clear();
         _currentTokens = 0;
         _toolsInstructionSent = false;
 
@@ -545,6 +556,12 @@ class InferenceChat {
     await session.close();
     session = await sessionCreator!();
 
+    // Replay prefixes first (explicit prefix messages)
+    for (final prefix in _prefixes) {
+      await session.addQueryChunk(prefix);
+    }
+
+    // Then replay model history
     for (final message in _modelHistory) {
       await session.addQueryChunk(message);
     }
@@ -552,6 +569,7 @@ class InferenceChat {
 
   Future<void> clearHistory({List<Message>? replayHistory}) async {
     _fullHistory.clear();
+    _prefixes.clear();
     _modelHistory.clear();
     _currentTokens = 0;
     _toolsInstructionSent = false;
@@ -560,7 +578,7 @@ class InferenceChat {
 
     if (replayHistory != null) {
       for (final message in replayHistory) {
-        await addQueryChunk(message, true);
+        await addQueryChunk(message);
       }
     }
   }

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -306,6 +306,12 @@ class InferenceChat {
                     'InferenceChat: Found ${allCalls.length} function call(s) in complete buffer!');
                 emittedFunctionCall = true;
                 lastFuncBuffer = funcBuffer;
+                // Add function call to history IMMEDIATELY (before yielding)
+                // so tool response from caller comes AFTER in history order
+                final toolCallMessage = Message.toolCall(text: funcBuffer);
+                _fullHistory.add(toolCallMessage);
+                _modelHistory.add(toolCallMessage);
+                debugPrint('InferenceChat: Added function call to history before yielding');
                 if (allCalls.length == 1) {
                   yield allCalls.first;
                 } else {
@@ -440,6 +446,11 @@ class InferenceChat {
                 'InferenceChat: ${allCalls.length} function call(s) found at end of stream');
             emittedFunctionCall = true;
             lastFuncBuffer = contentToCheck;
+            // Add function call to history IMMEDIATELY (before yielding)
+            final toolCallMessage = Message.toolCall(text: contentToCheck);
+            _fullHistory.add(toolCallMessage);
+            _modelHistory.add(toolCallMessage);
+            debugPrint('InferenceChat: Added function call to history at end of stream');
             if (allCalls.length == 1) {
               yield allCalls.first;
             } else {
@@ -477,17 +488,19 @@ class InferenceChat {
 
     try {
       debugPrint('InferenceChat: Adding message to history...');
-      // Use toolCall message for function calls, text message otherwise
-      final chatMessage = emittedFunctionCall
-          ? Message.toolCall(
-              text: lastFuncBuffer.isNotEmpty ? lastFuncBuffer : response)
-          : Message(text: response, isUser: false);
-      debugPrint(
-          'InferenceChat: Created message object (toolCall=$emittedFunctionCall): ${chatMessage.text}');
-      _fullHistory.add(chatMessage);
-      debugPrint('InferenceChat: Added to full history');
-      _modelHistory.add(chatMessage);
-      debugPrint('InferenceChat: Added to model history');
+      // For function calls: already added to history when yielded (above)
+      // For text responses: add now since they weren't added during streaming
+      if (!emittedFunctionCall) {
+        final chatMessage = Message(text: response, isUser: false);
+        debugPrint(
+            'InferenceChat: Created text message object: ${chatMessage.text}');
+        _fullHistory.add(chatMessage);
+        debugPrint('InferenceChat: Added to full history');
+        _modelHistory.add(chatMessage);
+        debugPrint('InferenceChat: Added to model history');
+      } else {
+        debugPrint('InferenceChat: Function call was already added to history when yielded');
+      }
       debugPrint('InferenceChat: Message added to history successfully');
 
       // Clear model history for single-turn models (e.g., FunctionGemma)

--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -272,7 +272,7 @@ class FfiInferenceModelSession extends InferenceModelSession
       final textBuffer = StringBuffer();
       await for (final rawChunk in ffiClient.chatRaw(
         text,
-        imageBytes: image,
+        imageBytes: images,
         audioBytes: audio,
         enableThinking: enableThinking,
       )) {
@@ -346,7 +346,7 @@ class FfiInferenceModelSession extends InferenceModelSession
       final rawBuffer = StringBuffer();
       await for (final rawChunk in ffiClient.chatRaw(
         text,
-        imageBytes: image,
+        imageBytes: images,
         audioBytes: audio,
         enableThinking: enableThinking,
       )) {

--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -383,6 +383,11 @@ class FfiInferenceModelSession extends InferenceModelSession
   }
 
   @override
+  SessionMetrics getSessionMetrics() {
+    return ffiClient.getSessionMetrics();
+  }
+
+  @override
   Future<int> sizeInTokens(String text) async {
     return (text.length / 4).ceil();
   }

--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -206,7 +206,7 @@ class FfiInferenceModelSession extends InferenceModelSession
   final VoidCallback onClose;
 
   final StringBuffer _queryBuffer = StringBuffer();
-  Uint8List? _pendingImage;
+  final List<Uint8List> _pendingImages = [];
   Uint8List? _pendingAudio;
   bool _isClosed = false;
 
@@ -234,8 +234,15 @@ class FfiInferenceModelSession extends InferenceModelSession
         message.transformToChatPrompt(type: modelType, fileType: fileType);
     _queryBuffer.write(prompt);
 
-    if (message.hasImage && message.imageBytes != null && supportImage) {
-      _pendingImage = message.imageBytes;
+    if (message.hasImage && supportImage) {
+      if (message.imageBytes != null) {
+        _pendingImages.add(message.imageBytes!);
+      }
+      for (final image in message.images) {
+        if (!_pendingImages.contains(image)) {
+          _pendingImages.add(image);
+        }
+      }
     }
     if (message.hasAudio && message.audioBytes != null && supportAudio) {
       _pendingAudio = message.audioBytes;
@@ -248,9 +255,10 @@ class FfiInferenceModelSession extends InferenceModelSession
     final text = _queryBuffer.toString();
     _queryBuffer.clear();
     final audio = _pendingAudio;
-    final image = _pendingImage;
+    final images =
+        _pendingImages.isNotEmpty ? List<Uint8List>.from(_pendingImages) : null;
     _pendingAudio = null;
-    _pendingImage = null;
+    _pendingImages.clear();
 
     final genSw = Stopwatch()..start();
     int? firstChunkMs;
@@ -286,7 +294,7 @@ class FfiInferenceModelSession extends InferenceModelSession
     final buffer = StringBuffer();
     await for (final chunk in ffiClient.chat(
       text,
-      imageBytes: image,
+      imageBytes: images,
       audioBytes: audio,
       enableThinking: enableThinking,
     )) {
@@ -325,9 +333,10 @@ class FfiInferenceModelSession extends InferenceModelSession
     final text = _queryBuffer.toString();
     _queryBuffer.clear();
     final audio = _pendingAudio;
-    final image = _pendingImage;
+    final images =
+        _pendingImages.isNotEmpty ? List<Uint8List>.from(_pendingImages) : null;
     _pendingAudio = null;
-    _pendingImage = null;
+    _pendingImages.clear();
 
     final genSw = Stopwatch()..start();
     int? firstChunkMs;
@@ -358,7 +367,7 @@ class FfiInferenceModelSession extends InferenceModelSession
     _lastRawResponse = null;
     await for (final chunk in ffiClient.chat(
       text,
-      imageBytes: image,
+      imageBytes: images,
       audioBytes: audio,
       enableThinking: enableThinking,
     )) {
@@ -387,7 +396,7 @@ class FfiInferenceModelSession extends InferenceModelSession
   Future<void> close() async {
     _isClosed = true;
     _queryBuffer.clear();
-    _pendingImage = null;
+    _pendingImages.clear();
     _pendingAudio = null;
     ffiClient.closeConversation();
     onClose();

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -313,6 +313,9 @@ class LiteRtLmFfiClient {
       // Configure settings
       b.litert_lm_engine_settings_set_max_num_tokens(settings, maxTokens);
 
+      // Enable benchmarking for session metrics (token counts, timing)
+      b.litert_lm_engine_settings_enable_benchmark(settings);
+
       if (cacheDir != null) {
         final cacheDirPtr = cacheDir.toNativeUtf8();
         // Sets cache dir on main, vision, and audio executors (C API patched)

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -565,12 +565,12 @@ class LiteRtLmFfiClient {
   /// `tool_calls` field via [extractToolCalls].
   Stream<String> chatRaw(
     String text, {
-    Uint8List? imageBytes,
+    List<Uint8List>? imageBytes,
     Uint8List? audioBytes,
     bool enableThinking = false,
   }) {
     final messageJson =
-        buildMessageJson(text, imageBytes: imageBytes, audioBytes: audioBytes);
+        buildMessageJson(text, imagesBytes: imageBytes, audioBytes: audioBytes);
     final extraContext = enableThinking ? '{"enable_thinking": true}' : null;
     return sendMessageStreamRaw(messageJson, extraContext: extraContext);
   }

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -475,14 +475,17 @@ class LiteRtLmFfiClient {
   /// Build the JSON message for the Conversation API.
   ///
   /// Format: `{"role": "user", "content": [{"type": "text", "text": "..."}]}`
-  static String buildMessageJson(String text,
-      {Uint8List? imageBytes, Uint8List? audioBytes}) {
+  /// Supports multiple images via `imagesBytes` list.
+  static String buildMessageJson(
+    String text, {
+    List<Uint8List>? imagesBytes,
+    Uint8List? audioBytes,
+  }) {
     final content = <Map<String, dynamic>>[];
-    if (imageBytes != null) {
-      content.add({
-        'type': 'image',
-        'blob': base64Encode(imageBytes),
-      });
+    if (imagesBytes != null) {
+      for (final imageBytes in imagesBytes) {
+        content.add({'type': 'image', 'blob': base64Encode(imageBytes)});
+      }
     }
     if (audioBytes != null) {
       content.add({
@@ -536,14 +539,18 @@ class LiteRtLmFfiClient {
   }
 
   /// Send a message and get streaming response as plain text chunks.
+  /// Supports multiple images via `imageBytes` list.
   Stream<String> chat(
     String text, {
-    Uint8List? imageBytes,
+    List<Uint8List>? imageBytes,
     Uint8List? audioBytes,
     bool enableThinking = false,
   }) {
-    final messageJson =
-        buildMessageJson(text, imageBytes: imageBytes, audioBytes: audioBytes);
+    final messageJson = buildMessageJson(
+      text,
+      imagesBytes: imageBytes,
+      audioBytes: audioBytes,
+    );
     final extraContext = enableThinking ? '{"enable_thinking": true}' : null;
     return sendMessageStreamRaw(messageJson, extraContext: extraContext)
         .map(extractTextFromResponse);

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../flutter_gemma_interface.dart';
 import 'litert_lm_bindings.dart';
 
 /// Callback typedef with Uint8 for bool (C _Bool = 1 byte)
@@ -722,6 +723,79 @@ class LiteRtLmFfiClient {
     }
 
     _isInitialized = false;
+  }
+
+  /// Get session metrics from current conversation including token usage.
+  /// Returns empty SessionMetrics if no conversation or benchmark unavailable.
+  SessionMetrics getSessionMetrics() {
+    if (_conversation == null ||
+        _conversation == nullptr ||
+        _bindings == null) {
+      return SessionMetrics();
+    }
+
+    final benchmarkInfo =
+        _bindings!.litert_lm_conversation_get_benchmark_info(_conversation!);
+    if (benchmarkInfo == nullptr) {
+      return SessionMetrics();
+    }
+
+    try {
+      // Get number of turns
+      final numPrefillTurns = _bindings!
+          .litert_lm_benchmark_info_get_num_prefill_turns(benchmarkInfo);
+      final numDecodeTurns = _bindings!
+          .litert_lm_benchmark_info_get_num_decode_turns(benchmarkInfo);
+
+      // Sum up tokens from all turns
+      var inputTokens = 0;
+      var outputTokens = 0;
+
+      for (var i = 0; i < numPrefillTurns; i++) {
+        inputTokens += _bindings!
+            .litert_lm_benchmark_info_get_prefill_token_count_at(
+                benchmarkInfo, i);
+      }
+
+      for (var i = 0; i < numDecodeTurns; i++) {
+        outputTokens += _bindings!
+            .litert_lm_benchmark_info_get_decode_token_count_at(
+                benchmarkInfo, i);
+      }
+
+      // Get timing info if available
+      final timeToFirstToken = _bindings!
+          .litert_lm_benchmark_info_get_time_to_first_token(benchmarkInfo);
+      final initTime = _bindings!
+          .litert_lm_benchmark_info_get_total_init_time_in_second(
+              benchmarkInfo);
+
+      // Calculate average tokens per second from last decode turn if available
+      double? tokensPerSecond;
+      if (numDecodeTurns > 0) {
+        tokensPerSecond = _bindings!
+            .litert_lm_benchmark_info_get_decode_tokens_per_sec_at(
+                benchmarkInfo, numDecodeTurns - 1);
+        if (tokensPerSecond <= 0) tokensPerSecond = null;
+      }
+
+      // Cleanup benchmark info
+      _bindings!.litert_lm_benchmark_info_delete(benchmarkInfo);
+
+      return SessionMetrics(
+        inputTokens: inputTokens,
+        outputTokens: outputTokens,
+        totalTokens: inputTokens + outputTokens,
+        timeToFirstTokenMs:
+            timeToFirstToken > 0 ? timeToFirstToken * 1000 : null,
+        tokensPerSecond: tokensPerSecond,
+        initTimeMs: initTime > 0 ? initTime * 1000 : null,
+      );
+    } catch (e) {
+      debugPrint('[LiteRtLmFfiClient] Error getting metrics: $e');
+      _bindings!.litert_lm_benchmark_info_delete(benchmarkInfo);
+      return SessionMetrics();
+    }
   }
 
   void _assertInitialized() {

--- a/lib/core/message.dart
+++ b/lib/core/message.dart
@@ -14,6 +14,7 @@ class Message {
     required this.text,
     this.isUser = false,
     this.imageBytes,
+    this.images = const [],
     this.audioBytes,
     this.type = MessageType.text,
     this.toolName,
@@ -22,17 +23,19 @@ class Message {
   final String text;
   final bool isUser;
   final Uint8List? imageBytes;
+  final List<Uint8List> images;
   final Uint8List? audioBytes;
   final MessageType type;
   final String? toolName;
 
-  bool get hasImage => imageBytes != null;
+  bool get hasImage => imageBytes != null || images.isNotEmpty;
   bool get hasAudio => audioBytes != null;
 
   Message copyWith({
     String? text,
     bool? isUser,
     Uint8List? imageBytes,
+    List<Uint8List>? images,
     Uint8List? audioBytes,
     MessageType? type,
     String? toolName,
@@ -41,6 +44,7 @@ class Message {
       text: text ?? this.text,
       isUser: isUser ?? this.isUser,
       imageBytes: imageBytes ?? this.imageBytes,
+      images: images ?? this.images,
       audioBytes: audioBytes ?? this.audioBytes,
       type: type ?? this.type,
       toolName: toolName ?? this.toolName,
@@ -65,6 +69,20 @@ class Message {
     return Message(
       text: text,
       imageBytes: imageBytes,
+      images: [imageBytes],
+      isUser: isUser,
+    );
+  }
+
+  factory Message.withImages({
+    required String text,
+    required List<Uint8List> imageBytes,
+    bool isUser = false,
+  }) {
+    return Message(
+      text: text,
+      imageBytes: imageBytes.isNotEmpty ? imageBytes.first : null,
+      images: List<Uint8List>.from(imageBytes),
       isUser: isUser,
     );
   }
@@ -77,6 +95,20 @@ class Message {
     return Message(
       text: text,
       imageBytes: imageBytes,
+      images: [imageBytes],
+      isUser: isUser,
+    );
+  }
+
+  factory Message.imagesOnly({
+    required List<Uint8List> imageBytes,
+    bool isUser = false,
+    String text = '',
+  }) {
+    return Message(
+      text: text,
+      imageBytes: imageBytes.isNotEmpty ? imageBytes.first : null,
+      images: List<Uint8List>.from(imageBytes),
       isUser: isUser,
     );
   }
@@ -153,7 +185,7 @@ class Message {
 
   @override
   String toString() {
-    return 'Message(text: $text, isUser: $isUser, hasImage: $hasImage, hasAudio: $hasAudio, type: $type, toolName: $toolName)';
+    return 'Message(text: $text, isUser: $isUser, imageCount: ${images.isNotEmpty ? images.length : (imageBytes == null ? 0 : 1)}, hasAudio: $hasAudio, type: $type, toolName: $toolName)';
   }
 
   @override
@@ -163,6 +195,7 @@ class Message {
         other.text == text &&
         other.isUser == isUser &&
         _listEquals(other.imageBytes, imageBytes) &&
+        _listEquals(other.images, images) &&
         _listEquals(other.audioBytes, audioBytes) &&
         other.type == type &&
         other.toolName == toolName;
@@ -173,6 +206,7 @@ class Message {
       text.hashCode ^
       isUser.hashCode ^
       imageBytes.hashCode ^
+      Object.hashAll(images) ^
       audioBytes.hashCode ^
       type.hashCode ^
       toolName.hashCode;

--- a/lib/flutter_gemma_interface.dart
+++ b/lib/flutter_gemma_interface.dart
@@ -191,6 +191,43 @@ abstract class InferenceModel {
   Future<void> close();
 }
 
+/// Session metrics containing token usage and performance statistics.
+class SessionMetrics {
+  SessionMetrics({
+    this.inputTokens = 0,
+    this.outputTokens = 0,
+    this.totalTokens = 0,
+    this.timeToFirstTokenMs,
+    this.tokensPerSecond,
+    this.initTimeMs,
+  });
+
+  /// Number of input tokens (prompt tokens).
+  final int inputTokens;
+
+  /// Number of output tokens (generated tokens).
+  final int outputTokens;
+
+  /// Total tokens (input + output).
+  final int totalTokens;
+
+  /// Time to first token in milliseconds (if available).
+  final double? timeToFirstTokenMs;
+
+  /// Average tokens per second generation speed (if available).
+  final double? tokensPerSecond;
+
+  /// Session initialization time in milliseconds (if available).
+  final double? initTimeMs;
+
+  @override
+  String toString() {
+    return 'SessionMetrics(inputTokens: $inputTokens, outputTokens: $outputTokens, '
+        'totalTokens: $totalTokens, ttft: ${timeToFirstTokenMs?.toStringAsFixed(2)}ms, '
+        'tps: ${tokensPerSecond?.toStringAsFixed(2)})';
+  }
+}
+
 /// Session managing response generation from the model.
 abstract class InferenceModelSession {
   Future<String> getResponse();
@@ -202,6 +239,14 @@ abstract class InferenceModelSession {
   Future<void> addQueryChunk(Message message);
 
   Future<void> stopGeneration();
+
+  /// Get session metrics including token usage and performance stats.
+  ///
+  /// **FFI (LiteRT-LM)**: Returns accurate token counts from benchmark info.
+  /// **MediaPipe (Mobile)**: Returns estimated counts (uses internal metrics if available).
+  ///
+  /// Call this after [getResponse] or [getResponseAsync] completes for accurate results.
+  SessionMetrics getSessionMetrics();
 
   Future<void> close();
 }

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -98,6 +98,12 @@ class MobileInferenceModelSession extends InferenceModelSession {
         text: '[System: ${systemInstruction!}]\n\n${message.text}',
       );
     }
+    if (message.hasImage && message.imageBytes != null && supportImage) {
+      await _addImage(message.imageBytes!);
+    }
+    if (message.hasAudio && message.audioBytes != null && supportAudio) {
+      await _addAudio(message.audioBytes!);
+    }
     debugPrint(
         '[MobileSession.addQueryChunk] modelType=$modelType, fileType=$fileType, msgType=${message.type}');
     final finalPrompt = messageToSend.transformToChatPrompt(
@@ -105,12 +111,6 @@ class MobileInferenceModelSession extends InferenceModelSession {
     debugPrint(
         '[MobileSession.addQueryChunk] finalPrompt length=${finalPrompt.length}');
     await _platformService.addQueryChunk(finalPrompt);
-    if (message.hasImage && message.imageBytes != null && supportImage) {
-      await _addImage(message.imageBytes!);
-    }
-    if (message.hasAudio && message.audioBytes != null && supportAudio) {
-      await _addAudio(message.audioBytes!);
-    }
   }
 
   Future<void> _addImage(Uint8List imageBytes) async {

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -215,6 +215,19 @@ class MobileInferenceModelSession extends InferenceModelSession {
   }
 
   @override
+  SessionMetrics getSessionMetrics() {
+    // MediaPipe doesn't expose detailed token metrics via the current platform channel.
+    // To get metrics on mobile, you would need to:
+    // 1. Add a new platform method to fetch metrics from native side
+    // 2. Or track tokens manually using sizeInTokens() before/after generation
+    //
+    // For now, return empty metrics. Users can estimate using:
+    //   final inputTokens = await session.sizeInTokens(prompt);
+    //   final outputTokens = await session.sizeInTokens(responseText);
+    return SessionMetrics();
+  }
+
+  @override
   Future<void> close() async {
     _isClosed = true;
 

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -104,13 +104,18 @@ class MobileInferenceModelSession extends InferenceModelSession {
         type: modelType, fileType: fileType);
     debugPrint(
         '[MobileSession.addQueryChunk] finalPrompt length=${finalPrompt.length}');
-    await _platformService.addQueryChunk(finalPrompt);
-    if (message.hasImage && message.imageBytes != null && supportImage) {
-      await _addImage(message.imageBytes!);
+    if (message.hasImage && supportImage) {
+      final images = message.images.isNotEmpty
+          ? message.images
+          : (message.imageBytes != null ? [message.imageBytes!] : const <Uint8List>[]);
+      for (final image in images) {
+        await _addImage(image);
+      }
     }
     if (message.hasAudio && message.audioBytes != null && supportAudio) {
       await _addAudio(message.audioBytes!);
     }
+    await _platformService.addQueryChunk(finalPrompt);
   }
 
   Future<void> _addImage(Uint8List imageBytes) async {

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -589,30 +589,30 @@ class WebModelSession extends InferenceModelSession {
     final finalPrompt = messageToSend.transformToChatPrompt(
         type: modelType, fileType: fileType);
 
-    // Add text part
-    _promptParts.add(TextPromptPart(finalPrompt));
-    if (kDebugMode) {
-      debugPrint(
-          '🟢 Added text part: ${finalPrompt.substring(0, math.min(100, finalPrompt.length))}...');
-    }
-
-    // Handle image processing for web
-    if (message.hasImage && message.imageBytes != null) {
-      if (kDebugMode) {
-        debugPrint('🟢 Processing image: ${message.imageBytes!.length} bytes');
-      }
+    // Add image parts first, then audio, then text last.
+    if (message.hasImage) {
       if (!supportImage) {
         if (kDebugMode) {
           debugPrint('🔴 Model does not support images - throwing exception');
         }
         throw ArgumentError('This model does not support images');
       }
-      // Add image part
-      final imagePart = ImagePromptPart.fromBytes(message.imageBytes!);
-      _promptParts.add(imagePart);
-      if (kDebugMode) {
-        debugPrint(
-            '🟢 Added image part with dataUrl length: ${imagePart.dataUrl.length}');
+
+      final images = message.images.isNotEmpty
+          ? message.images
+          : (message.imageBytes != null
+              ? [message.imageBytes!]
+              : const <Uint8List>[]);
+      for (final imageBytes in images) {
+        if (kDebugMode) {
+          debugPrint('🟢 Processing image: ${imageBytes.length} bytes');
+        }
+        final imagePart = ImagePromptPart.fromBytes(imageBytes);
+        _promptParts.add(imagePart);
+        if (kDebugMode) {
+          debugPrint(
+              '🟢 Added image part with dataUrl length: ${imagePart.dataUrl.length}');
+        }
       }
     }
 
@@ -634,6 +634,12 @@ class WebModelSession extends InferenceModelSession {
         debugPrint(
             '🎵 Added audio part with ${message.audioBytes!.length} bytes');
       }
+    }
+
+    // Add text part last so multimodal turns keep image/audio context first.
+    _promptParts.add(TextPromptPart(finalPrompt));
+    if (kDebugMode) {
+      debugPrint('🟢 Added text part: ${finalPrompt.substring(0, math.min(100, finalPrompt.length))}...');
     }
 
     if (kDebugMode) {

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -914,6 +914,13 @@ class WebModelSession extends InferenceModelSession {
   }
 
   @override
+  SessionMetrics getSessionMetrics() {
+    // Web MediaPipe implementation doesn't expose detailed token metrics.
+    // Users can estimate using sizeInTokens() before/after generation.
+    return SessionMetrics();
+  }
+
+  @override
   Future<void> close() async {
     // Cleanup MediaPipe LlmInference WASM resources (important for hot restart)
     // This prevents memory leaks and "memory access out of bounds" errors

--- a/test/core/system_instruction_test.dart
+++ b/test/core/system_instruction_test.dart
@@ -42,6 +42,9 @@ class _SessionWithInstruction implements InferenceModelSession {
   Future<void> stopGeneration() async {}
 
   @override
+  SessionMetrics getSessionMetrics() => SessionMetrics();
+
+  @override
   Future<void> close() async {}
 }
 


### PR DESCRIPTION
## Description
This branch adds three related improvements to `flutter_gemma`:

- Multi-image support end-to-end, so `Message`, platform services, and FFI chat/session APIs can accept more than one image per turn.
- LiteRT-LM session metrics in FFI, exposing token and timing statistics from the native backend.
- Persistent prefix messages for session recreation, so injected tool/system context is replayed when a session is rebuilt after history truncation.

This is backward compatible: existing `Message.withImage()` calls continue to work, and the branch adds `Message.withImages()` and `Message.imagesOnly()` for multi-image input.

It also updates the example app and documentation to reflect the new APIs and image limits.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Documentation update
- [x] Test addition

## Testing
- [x] flutter analyze
- [x] flutter test

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings
- [x] Tests added/updated