### PR TITLE
0.15.0: native LiteRT-LM 0.11.0 + Gemma 4 MTP + restore Android NPU

### DIFF
--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -12,7 +12,7 @@ on:
       litertlm_version:
         description: 'LiteRT-LM ref (tag, branch, or commit SHA)'
         required: true
-        default: 'v0.10.2'
+        default: 'v0.11.0'
       publish_release:
         description: 'Publish to GitHub Release'
         type: boolean
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.10.2' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 60
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.10.2' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +128,7 @@ jobs:
       run:
         shell: pwsh
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.10.2' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
       ANDROID_NDK_HOME: ''
       BAZEL_OUTPUT_BASE: 'D:\b'
     steps:
@@ -233,7 +233,7 @@ jobs:
     permissions:
       contents: write
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.10.2' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -12,7 +12,7 @@ on:
       litertlm_version:
         description: 'LiteRT-LM ref (tag, branch, or commit SHA)'
         required: true
-        default: 'v0.11.0'
+        default: '032334d81ff96431492be272e536fbafe094b1e9'
       publish_release:
         description: 'Publish to GitHub Release'
         type: boolean
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 60
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +128,7 @@ jobs:
       run:
         shell: pwsh
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
       ANDROID_NDK_HOME: ''
       BAZEL_OUTPUT_BASE: 'D:\b'
     steps:
@@ -233,7 +233,7 @@ jobs:
     permissions:
       contents: write
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || 'v0.11.0' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.0
+- **LiteRT-LM 0.11.0**: MTP-capable Gemma 4 + speculative decoding on macOS / iOS / Android / Windows.
+- **`enableSpeculativeDecoding` flag** on `getActiveModel()` (null = model default; true/false to override).
+- **Restore Android NPU support for `.litertlm`** (regression from 0.14.0): `PreferredBackend.npu` on Android `.litertlm` models routes through LiteRT-LM's `Backend::NPU` again — same as 0.13.x's Kotlin path before the FFI migration silently dropped it. Requires a Qualcomm QNN / Google Tensor / MediaTek dispatch lib on the device; without one, `engine_create` fails with a dispatch error. MediaPipe `.task` models still don't support NPU (MediaPipe SDK limitation, unchanged).
+- **`PreferredBackend.npu` on desktop** (#261): macOS / Linux / Windows backend arm wired. Same dispatch-lib requirement as Android.
+- **Linux known limitation**: post-MTP HF Gemma 4 revisions blocked upstream — `libLiteRtWebGpuAccelerator.so` segfaults during graph compile (filed `google-ai-edge/LiteRT-LM#2225`) and multi-signature vision encoder rejected by native (`engine_create` error). Workaround: pin pre-MTP HF revision `7fa1d78473894f7e736a21d920c3aa80f950c0db` for Linux users. Other platforms unaffected.
+- **hook native cache**: marker-file based invalidation (`.flutter_gemma_native_version`) — bumps clean stale companion libs automatically.
+
 ## 0.14.5
 - **Fix desktop embedding on pub.dev installs** (#250 follow-up): `tensorflowlite_c.{dll,so,dylib}` now bundled via Native Assets — regression from 0.14.0 setup-script removal.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@
 - **ModelSource**: Type-safe sealed class (`NetworkSource`, `AssetSource`, `BundledSource`, `FileSource`). See `lib/core/domain/`
 - **Install vs Runtime separation**: Installation stores identity (modelType + fileType), runtime accepts config (maxTokens, backend, etc.)
 - **Engine selection by file extension**: `.task`/`.bin`/`.tflite` → MediaPipe, `.litertlm` → LiteRT-LM
-- **All five platforms (Android/iOS/macOS/Linux/Windows)**: Dart → `dart:ffi` → LiteRT-LM C API. Native prebuilts fetched at build time via `hook/build.dart` (Native Assets) from GitHub release `native-v0.10.2-b`.
+- **All five platforms (Android/iOS/macOS/Linux/Windows)**: Dart → `dart:ffi` → LiteRT-LM C API. Native prebuilts fetched at build time via `hook/build.dart` (Native Assets) from GitHub release `native-v0.11.0-a`.
 
 ### Supported Models
 
@@ -114,8 +114,8 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **Dart SDK**: `>=3.6.0 <4.0.0`
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
-- **LiteRT-LM**: native libs from `native-v0.10.2-b` GitHub Release (built from upstream `google-ai-edge/LiteRT-LM` v0.10.2 + commit 5e0d86b for iOS), bundled via Native Assets — same `.so`/`.dylib`/`.dll` set on all platforms. `-b` rebuild with `-c opt --strip=always` for ~25-60% per-platform size reduction; retains `-a`'s vtool minos patch (26.2 → 16.0) on iOS `libGemmaModelConstraintProvider.dylib` and 16KB page alignment on Android `libLiteRtLm.so`.
-- **Current Version**: 0.14.5
+- **LiteRT-LM**: native libs from `native-v0.11.0-a` GitHub Release (built from upstream `google-ai-edge/LiteRT-LM` commit `032334d` — post-`6571c42` main HEAD with re-synced WORKSPACE LITERT_REF and matching prebuilt accelerators), bundled via Native Assets — same `.so`/`.dylib`/`.dll` set on all platforms. `-c opt --strip=always` build; retains vtool minos patch (26.2 → 16.0) on iOS `libGemmaModelConstraintProvider.dylib` and 16KB page alignment on Android `libLiteRtLm.so`. MTP (speculative decoding) support for Gemma 4.
+- **Current Version**: 0.15.0
 
 ## Platform-Specific Setup
 
@@ -144,7 +144,7 @@ window.LlmInference = LlmInference;
 
 ### Desktop (macOS/Windows/Linux)
 - Architecture: Dart → `dart:ffi` → LiteRT-LM C API (no JVM, no gRPC)
-- Native libs fetched at build time by `hook/build.dart` from `native-v0.10.2-b` GitHub release; SHA256-verified, bundled via Native Assets
+- Native libs fetched at build time by `hook/build.dart` from `native-v0.11.0-a` GitHub release; SHA256-verified, bundled via Native Assets
 - ⚠️ **macOS Vision broken** (#684): SDK bug, use text-only mode
 - Desktop uses `.litertlm` format only (not `.task`)
 - Windows GPU requires `dxil.dll` + `dxcompiler.dll` (DirectXShaderCompiler runtime) — bundled in the Windows native archive

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ There is an example of using:
 - **🔧 Unified Model Management:** Single system for managing both inference and embedding models with automatic validation
 - **💾 Web Persistent Caching:** Models persist across browser restarts using Cache API (Web only)
 
+## What's new in 0.15.0
+
+- ⚡ **MTP / speculative decoding for Gemma 4** — LiteRT-LM 0.11.0 enables Multi-Token Prediction on macOS / iOS / Android / Windows. New `enableSpeculativeDecoding` flag on `getActiveModel()` overrides the model default if needed.
+- 🤖 **Android NPU restored** for `.litertlm` (regression fix from 0.14.0) — `PreferredBackend.npu` again drives Qualcomm QNN / Google Tensor / MediaTek dispatch libs through LiteRT-LM's `Backend::NPU`.
+- 🖥️ **Desktop NPU** — `PreferredBackend.npu` accepted on macOS / Linux / Windows (#261). Same dispatch-lib requirement as Android.
+- 🐧 **Linux note** — pre-MTP Gemma 4 revision required until upstream fixes `google-ai-edge/LiteRT-LM#2225`. See **Linux Setup** for the revision-pinned download.
+
 ## What's new in 0.14.1
 
 - 🛠️ **Gemma 4 native function calling** — `ModelType.gemma4` routes tool definitions through the LiteRT-LM SDK's chat-template path (minja). The SDK renders native `<|tool>declaration:...<tool|>` tokens, the model emits `<|tool_call>...<tool_call|>`, and the SDK parses the response into structured `tool_calls` JSON. flutter_gemma surfaces it as `FunctionCallResponse` — no Dart-side prompt engineering required.
@@ -306,8 +313,10 @@ Since 0.14.0 desktop inference and embeddings both use the LiteRT-LM C API via `
 | macOS | x86_64 (Intel) | - | ❌ Not Supported |
 | Windows | x86_64 | DirectX 12 | ✅ Ready |
 | Windows | arm64 | - | ❌ Not Supported |
-| Linux | x86_64 | Vulkan | ✅ Ready |
-| Linux | arm64 | Vulkan | ✅ Ready |
+| Linux | x86_64 | Vulkan | ⚠️ Pre-MTP Gemma 4 only ¹ |
+| Linux | arm64 | Vulkan | ⚠️ Pre-MTP Gemma 4 only ¹ |
+
+> ¹ The post-MTP Gemma 4 HF revision crashes inside upstream `libLiteRtWebGpuAccelerator.so` on Linux Vulkan ([upstream issue #2225](https://github.com/google-ai-edge/LiteRT-LM/issues/2225)). Pre-MTP revision works. See **Linux: Gemma 4 model revision** below for the workaround. macOS / iOS / Android / Windows are unaffected.
 
 **macOS Setup:**
 
@@ -433,6 +442,18 @@ For GPU acceleration, ensure Vulkan drivers are installed:
 ```bash
 sudo apt install vulkan-tools libvulkan1
 ```
+
+**Linux: Gemma 4 model revision**
+
+The current HuggingFace `main` revision of Gemma 4 E2B/E4B `.litertlm` files (post-MTP) triggers an upstream crash on Linux Vulkan during graph compile (`google-ai-edge/LiteRT-LM#2225`). Until upstream lands a fix, pin the pre-MTP revision when downloading on Linux:
+
+```bash
+# Pre-MTP revision — works on Linux Vulkan
+curl -L -o gemma-4-E2B-it.litertlm \
+  https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/7fa1d78473894f7e736a21d920c3aa80f950c0db/gemma-4-E2B-it.litertlm
+```
+
+macOS / iOS / Android / Windows pick up the post-MTP revision automatically via the model's default URL and benefit from the MTP speedup.
 
 📚 **[Full Desktop Documentation →](DESKTOP_SUPPORT.md)**
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -9,13 +9,12 @@ const _mainLibName = 'LiteRtLm';
 
 /// LiteRT-LM native library version and release info.
 ///
-/// 0.10.2-b is a rebuild of 0.10.2 with `-c opt --strip=always` (and the
-/// MSVC equivalent `/OPT:REF /OPT:ICF` on Windows). Per-platform size
-/// reductions: iOS -63%, macOS -43%, Android -28%, Linux -16-18%, Windows
-/// unchanged. iOS still includes the vtool minos 26.2 → 16.0 patch on
-/// libGemmaModelConstraintProvider.dylib from -a (App Store ITMS-90208,
-/// #245).
-const _nativeVersion = '0.10.2-b';
+/// 0.11.0-a is a fresh build from upstream LiteRT-LM v0.11.0 (Multi-Token
+/// Prediction support). Same optimization flags as 0.10.2-b: `-c opt
+/// --strip=always` (Bazel) + MSVC `/OPT:REF /OPT:ICF` (Windows).
+/// Apple: vtool minos 26.2 → 16.0 patch on libGemmaModelConstraintProvider
+/// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
+const _nativeVersion = '0.11.0-a';
 const _releaseTag = 'native-v$_nativeVersion';
 const _releaseBase =
     'https://github.com/DenisovAV/flutter_gemma/releases/download/$_releaseTag';
@@ -24,19 +23,19 @@ const _releaseBase =
 /// Updated when new native libs are published to GitHub Release.
 const _checksums = <String, String>{
   'litertlm-linux_x86_64.tar.gz':
-      '3a6bd1d3685d8a7df508ebc451223c5f6f991accd51d7972b718437d7b037411',
+      '181326c1a1a8b6ce92111c957e06484334186624a99db2f950aaeb5538fc1214',
   'litertlm-linux_arm64.tar.gz':
-      '86f7e708b4ea966d3cd5c0131425b85bcb2ab8ce9a4cb83710e7e20122954a6a',
+      '2c13727bd8772ec63829eb86977c6df88f26b65b8b4faf7c292622c55acc43c9',
   'litertlm-windows_x86_64.tar.gz':
-      'cb45b35171d959abcef98d8b4ab08879174cc8e36624ddf9c27a0e634f0b5011',
+      'f6966a4687ae826a9d8c5787ea39f5fd3076da23b18ab33813ba13ac7499ba41',
   'litertlm-macos_arm64.tar.gz':
-      'c2b3d42fca0e58659594940efb56f695f76b4ee822aa5ac2d55088149da0bd7e',
+      '961a3b53be35db8b79f827573aa573e09005a2e50f989b3650404a14c5f60e7d',
   'litertlm-ios_arm64.tar.gz':
-      'dd78d25f1b6aa9f5c1bc1f1b26dd440557cb0da2f32a25cb89389718ca4f72ed',
+      'd10d1e55d115ff57fa4eec28b042c984979cbff2e65140a20db67c0709ff5c33',
   'litertlm-ios_sim_arm64.tar.gz':
-      '21a0fdc29e018d55137740c69bd12edf04f1d7e737024e89d758663fc7e5d926',
+      'd6a3f4b278b4f6498169ab665d14edbbc64984aeaa08f7c35d4918b20bd82a5e',
   'litertlm-android_arm64.tar.gz':
-      'c46406d19e52648e364c224dc5d7da5bb28f581cdb428a02b5e746bacb953762',
+      '80d29a6781c9044eca669e6d38801ac6af3e98b06f25653156fabf881e042a49',
 };
 
 /// TensorFlow Lite C library (used by `lib/desktop/tflite/tflite_bindings.dart`

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -138,9 +138,18 @@ Directory _cacheDir() {
 /// if missing or mismatched, delete every platform subdir under `_cacheDir()`
 /// and write the new marker. The next `_resolveLibDir` will fall through to
 /// `_downloadAndExtract` for whatever platform the build is targeting.
+///
+/// The marker is written even on a fresh cache root (created here if needed).
+/// Without that, a second invocation of the build hook (or any other Native
+/// Assets pass) would see the freshly populated platform subdir but a missing
+/// marker, classify the cache as stale, and wipe it — racing with
+/// `install_code_assets` (`Cannot copy file ... libLiteRtLm.so ... No such
+/// file or directory` on a clean CI runner cache).
 void _invalidateCacheIfStale() {
   final cacheBase = _cacheDir();
-  if (!cacheBase.existsSync()) return;
+  if (!cacheBase.existsSync()) {
+    cacheBase.createSync(recursive: true);
+  }
   final marker = File('${cacheBase.path}/.flutter_gemma_native_version');
   final stored = marker.existsSync() ? marker.readAsStringSync().trim() : '';
   if (stored == _nativeVersion) return;

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -23,19 +23,19 @@ const _releaseBase =
 /// Updated when new native libs are published to GitHub Release.
 const _checksums = <String, String>{
   'litertlm-linux_x86_64.tar.gz':
-      '181326c1a1a8b6ce92111c957e06484334186624a99db2f950aaeb5538fc1214',
+      '79583513cbbdda784b1714c1068a1fdd0f8133364868574ec3334af8d0eee056',
   'litertlm-linux_arm64.tar.gz':
-      '2c13727bd8772ec63829eb86977c6df88f26b65b8b4faf7c292622c55acc43c9',
+      'bab26bf420316ef2f4037ffced1470a18cbb6ee6cda069fc0ae8a5f8eb882bfb',
   'litertlm-windows_x86_64.tar.gz':
-      'f6966a4687ae826a9d8c5787ea39f5fd3076da23b18ab33813ba13ac7499ba41',
+      'cde4b0bc871668cb2c91437e213c33e66dc2739394eef9ea7a3da0397f3e3b5c',
   'litertlm-macos_arm64.tar.gz':
-      '961a3b53be35db8b79f827573aa573e09005a2e50f989b3650404a14c5f60e7d',
+      'fa3138c9f97b6ba3c19f620c29439207d38566598fff06cc55ff115ade17f8e8',
   'litertlm-ios_arm64.tar.gz':
-      'd10d1e55d115ff57fa4eec28b042c984979cbff2e65140a20db67c0709ff5c33',
+      'eae0d0ef8b81eeb6e6e0b69a482513f47b371ec2f410f571763538a5d23c7607',
   'litertlm-ios_sim_arm64.tar.gz':
-      'd6a3f4b278b4f6498169ab665d14edbbc64984aeaa08f7c35d4918b20bd82a5e',
+      'f92b8fcb3627c82c9398f39bcf6851a46e97f9565d5341d454390802bf1ffd78',
   'litertlm-android_arm64.tar.gz':
-      '80d29a6781c9044eca669e6d38801ac6af3e98b06f25653156fabf881e042a49',
+      '9712d55d1a248ad8834531f2d937a9bbf2feceaad8a1d352ef5f63a4dedb8f17',
 };
 
 /// TensorFlow Lite C library (used by `lib/desktop/tflite/tflite_bindings.dart`
@@ -108,23 +108,56 @@ String? _prebuiltDirName(OS os, Architecture arch, {IOSSdk? iOSSdk}) {
   return '${osName}_$archName';
 }
 
-/// Platform-appropriate cache directory. Per-version subpath ensures a native
-/// version bump invalidates cached libs from prior versions — without this,
-/// _resolveLibDir would find the old main lib and skip the download, leaving
-/// companion libs (e.g. libStreamProxy) stale.
+/// Platform-appropriate cache directory. Path is NOT versioned because
+/// example/macos/Podfile and example/ios/Podfile read companion dylibs
+/// from this same location (Native Assets cache → app bundle Frameworks/);
+/// keeping a single canonical path means the Podfile doesn't need to know
+/// `_nativeVersion`.
+///
+/// Cache invalidation on a native bump is handled by `_invalidateCacheIfStale`
+/// (called from the build hook) which compares a `.version` marker file in
+/// the cache root against `_nativeVersion`, and wipes the per-platform
+/// subdirs on mismatch so the next `_downloadAndExtract` repopulates them.
 Directory _cacheDir() {
   final home =
       Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'] ?? '';
   if (Platform.isWindows) {
     final localAppData =
         Platform.environment['LOCALAPPDATA'] ?? '$home\\AppData\\Local';
-    return Directory('$localAppData\\flutter_gemma\\native\\$_nativeVersion');
+    return Directory('$localAppData\\flutter_gemma\\native');
   }
   if (Platform.isMacOS) {
-    return Directory('$home/Library/Caches/flutter_gemma/native/$_nativeVersion');
+    return Directory('$home/Library/Caches/flutter_gemma/native');
   }
   // Linux and others
-  return Directory('$home/.cache/flutter_gemma/native/$_nativeVersion');
+  return Directory('$home/.cache/flutter_gemma/native');
+}
+
+/// Wipe stale platform subdirs when `_nativeVersion` changes. The check is
+/// cheap (one file read) and idempotent: if the marker matches, do nothing;
+/// if missing or mismatched, delete every platform subdir under `_cacheDir()`
+/// and write the new marker. The next `_resolveLibDir` will fall through to
+/// `_downloadAndExtract` for whatever platform the build is targeting.
+void _invalidateCacheIfStale() {
+  final cacheBase = _cacheDir();
+  if (!cacheBase.existsSync()) return;
+  final marker = File('${cacheBase.path}/.flutter_gemma_native_version');
+  final stored = marker.existsSync() ? marker.readAsStringSync().trim() : '';
+  if (stored == _nativeVersion) return;
+  for (final entity in cacheBase.listSync()) {
+    if (entity is Directory) {
+      // Wipe per-platform subdirs (linux_x86_64/, macos_arm64/, etc.) but
+      // leave anything else untouched (e.g. cache dirs from other tools
+      // could share this root in the future).
+      final name = entity.uri.pathSegments
+          .where((s) => s.isNotEmpty)
+          .last;
+      if (RegExp(r'^(linux|macos|ios|android|windows)_').hasMatch(name)) {
+        entity.deleteSync(recursive: true);
+      }
+    }
+  }
+  marker.writeAsStringSync(_nativeVersion);
 }
 
 /// Archive name for a given platform directory.
@@ -336,6 +369,12 @@ void main(List<String> args) async {
     final iOSSdk = os == OS.iOS ? codeConfig.iOS.targetSdk : null;
     final dirName = _prebuiltDirName(os, arch, iOSSdk: iOSSdk);
     if (dirName == null) return; // Unsupported arch (e.g. arm32), skip
+
+    // Wipe stale per-platform subdirs if `_nativeVersion` changed since
+    // the cache was last populated. Without this, an upgrade leaves old
+    // companion libs in place because `_resolveLibDir` finds the main lib
+    // and skips the download.
+    _invalidateCacheIfStale();
 
     // Priority: local prebuilt/ → cache → download from GitHub Release
     var libDir = _resolveLibDir(dirName, input.packageRoot);

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -108,20 +108,23 @@ String? _prebuiltDirName(OS os, Architecture arch, {IOSSdk? iOSSdk}) {
   return '${osName}_$archName';
 }
 
-/// Platform-appropriate cache directory.
+/// Platform-appropriate cache directory. Per-version subpath ensures a native
+/// version bump invalidates cached libs from prior versions — without this,
+/// _resolveLibDir would find the old main lib and skip the download, leaving
+/// companion libs (e.g. libStreamProxy) stale.
 Directory _cacheDir() {
   final home =
       Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'] ?? '';
   if (Platform.isWindows) {
     final localAppData =
         Platform.environment['LOCALAPPDATA'] ?? '$home\\AppData\\Local';
-    return Directory('$localAppData\\flutter_gemma\\native');
+    return Directory('$localAppData\\flutter_gemma\\native\\$_nativeVersion');
   }
   if (Platform.isMacOS) {
-    return Directory('$home/Library/Caches/flutter_gemma/native');
+    return Directory('$home/Library/Caches/flutter_gemma/native/$_nativeVersion');
   }
   // Linux and others
-  return Directory('$home/.cache/flutter_gemma/native');
+  return Directory('$home/.cache/flutter_gemma/native/$_nativeVersion');
 }
 
 /// Archive name for a given platform directory.

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.14.5'
+  s.version          = '0.15.0'
   s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
   s.description      = <<-DESC
 The plugin allows running the Gemma AI model locally on a device from a Flutter application.

--- a/lib/core/api/flutter_gemma.dart
+++ b/lib/core/api/flutter_gemma.dart
@@ -236,6 +236,7 @@ class FlutterGemma {
     bool supportImage = false,
     bool supportAudio = false,
     int? maxNumImages,
+    bool? enableSpeculativeDecoding,
   }) async {
     final manager = FlutterGemmaPlugin.instance.modelManager;
     final activeSpec = manager.activeInferenceModel;
@@ -262,6 +263,7 @@ class FlutterGemma {
       supportImage: supportImage,
       supportAudio: supportAudio,
       maxNumImages: maxNumImages,
+      enableSpeculativeDecoding: enableSpeculativeDecoding,
     );
   }
 

--- a/lib/core/ffi/litert_lm_bindings.dart
+++ b/lib/core/ffi/litert_lm_bindings.dart
@@ -365,6 +365,29 @@ class LiteRtLmBindings {
       _litert_lm_engine_settings_set_max_num_imagesPtr.asFunction<
           void Function(ffi.Pointer<LiteRtLmEngineSettings>, int)>();
 
+  /// Toggle Multi-Token Prediction (MTP) / speculative decoding (LiteRT-LM
+  /// v0.11.0+). Only meaningful for models with an `tf_lite_mtp_drafter`
+  /// section in the `.litertlm` binary (Gemma 4 E2B/E4B v2+).
+  void litert_lm_engine_settings_set_enable_speculative_decoding(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    bool enable_speculative_decoding,
+  ) {
+    return _litert_lm_engine_settings_set_enable_speculative_decoding(
+      settings,
+      enable_speculative_decoding,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_enable_speculative_decodingPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
+                      ffi.Bool)>>(
+          'litert_lm_engine_settings_set_enable_speculative_decoding');
+  late final _litert_lm_engine_settings_set_enable_speculative_decoding =
+      _litert_lm_engine_settings_set_enable_speculative_decodingPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)>();
+
   ffi.Pointer<LiteRtLmEngine> litert_lm_engine_create(
     ffi.Pointer<LiteRtLmEngineSettings> settings,
   ) {

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -281,6 +281,7 @@ class LiteRtLmFfiClient {
     bool enableVision = false,
     int maxNumImages = 0,
     bool enableAudio = false,
+    bool? enableSpeculativeDecoding,
   }) async {
     final initSw = Stopwatch()..start();
     _ensureBindings();
@@ -321,6 +322,14 @@ class LiteRtLmFfiClient {
 
       if (maxNumImages > 0) {
         b.litert_lm_engine_settings_set_max_num_images(settings, maxNumImages);
+      }
+
+      // MTP / speculative decoding (LiteRT-LM v0.11.0+). Skip when null so
+      // the SDK uses the model's default; only call when caller explicitly
+      // forces on/off.
+      if (enableSpeculativeDecoding != null) {
+        b.litert_lm_engine_settings_set_enable_speculative_decoding(
+            settings, enableSpeculativeDecoding);
       }
 
       // Create engine in a background isolate to avoid blocking UI.

--- a/lib/desktop/flutter_gemma_desktop.dart
+++ b/lib/desktop/flutter_gemma_desktop.dart
@@ -80,6 +80,7 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
     int? maxNumImages,
     bool supportImage = false,
     bool supportAudio = false,
+    bool? enableSpeculativeDecoding,
   }) async {
     // Check active model
     final activeModel = _modelManager.activeInferenceModel;
@@ -144,13 +145,15 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
 
       // Initialize via dart:ffi → C API (no JRE, no gRPC)
       final ffiClient = LiteRtLmFfiClient();
+      // NPU is supported via LiteRT-LM's `Backend::NPU` enum on macOS / Linux /
+      // Windows (iOS disabled by upstream `LITERT_DISABLE_NPU`). Actual
+      // hardware acceleration requires a Qualcomm QNN / Hexagon NN runtime
+      // dispatch lib on the device; without one, engine_create fails with a
+      // dispatch error from LiteRT-LM. See README for details (#261).
       final backend = switch (preferredBackend) {
         PreferredBackend.cpu => 'cpu',
         PreferredBackend.gpu || null => 'gpu',
-        PreferredBackend.npu => throw UnsupportedError(
-            'PreferredBackend.npu is only supported on Android with .litertlm '
-            'models; not available on desktop.',
-          ),
+        PreferredBackend.npu => 'npu',
       };
       await ffiClient.initialize(
         modelPath: modelPath,
@@ -160,6 +163,7 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
         enableVision: supportImage,
         maxNumImages: supportImage ? (maxNumImages ?? 1) : 0,
         enableAudio: supportAudio,
+        enableSpeculativeDecoding: enableSpeculativeDecoding,
       );
 
       // Create model instance

--- a/lib/flutter_gemma_interface.dart
+++ b/lib/flutter_gemma_interface.dart
@@ -41,6 +41,10 @@ abstract class FlutterGemmaPlugin extends PlatformInterface {
   /// [maxNumImages] — maximum number of images (for multimodal models).
   /// [supportImage] — whether the model supports images.
   /// [supportAudio] — whether the model supports audio (Gemma 3n E4B only).
+  /// [enableSpeculativeDecoding] — Multi-Token Prediction toggle for Gemma 4
+  /// E2B/E4B (LiteRT-LM v0.11.0+). `null` honors the model's default;
+  /// `true`/`false` forces on/off. Older `.litertlm` files without an MTP
+  /// drafter ignore this flag at the SDK level.
   Future<InferenceModel> createModel({
     required ModelType modelType,
     ModelFileType fileType = ModelFileType.task,
@@ -50,6 +54,7 @@ abstract class FlutterGemmaPlugin extends PlatformInterface {
     int? maxNumImages, // Add image support
     bool supportImage = false, // Add image support flag
     bool supportAudio = false, // Add audio support flag (Gemma 3n E4B)
+    bool? enableSpeculativeDecoding,
   });
 
   /// Creates and returns a new [EmbeddingModel] instance.

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -280,6 +280,7 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
     int? maxNumImages,
     bool supportImage = false,
     bool supportAudio = false, // Enabling audio support (Gemma 3n E4B)
+    bool? enableSpeculativeDecoding,
   }) async {
     // Check if model is ready through unified system
     final manager = _unifiedManager;
@@ -384,6 +385,7 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
           enableVision: supportImage,
           maxNumImages: supportImage ? (maxNumImages ?? 1) : 0,
           enableAudio: supportAudio,
+          enableSpeculativeDecoding: enableSpeculativeDecoding,
         );
         debugPrint(
             '[FlutterGemmaMobile/perf] ffiClient.initialize total: ${ffiPathSw.elapsedMilliseconds - beforeInit}ms');

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -368,13 +368,18 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
         debugPrint(
             '[FlutterGemmaMobile/perf] getApplicationSupportDirectory: ${ffiPathSw.elapsedMilliseconds}ms');
         final ffiClient = LiteRtLmFfiClient();
+        // NPU on Android `.litertlm` restored to 0.13.x parity. The Kotlin
+        // LiteRtLmEngine path was dropped in 0.14.0 (commit 81025da); this
+        // routes the same `Backend::NPU` enum value through LiteRT-LM's C
+        // API. A Qualcomm QNN / Google Tensor / MediaTek dispatch lib must
+        // be present on the device — without one, engine_create fails with
+        // a dispatch error from LiteRT-LM. iOS .litertlm: upstream LiteRT-LM
+        // disables NPU via LITERT_DISABLE_NPU at build time; engine_create
+        // returns a clean Backend::NPU not supported error.
         final backend = switch (preferredBackend) {
           PreferredBackend.cpu => 'cpu',
           PreferredBackend.gpu || null => 'gpu',
-          PreferredBackend.npu => throw UnsupportedError(
-              'PreferredBackend.npu is not supported on the .litertlm FFI path. '
-              'Use a MediaPipe .task model on Android for NPU acceleration.',
-            ),
+          PreferredBackend.npu => 'npu',
         };
         final beforeInit = ffiPathSw.elapsedMilliseconds;
         await ffiClient.initialize(

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -124,6 +124,7 @@ class FlutterGemmaWeb extends FlutterGemmaPlugin {
     int? maxNumImages,
     bool supportImage = false, // Enabling image support
     bool supportAudio = false, // Enabling audio support (Gemma 3n E4B)
+    bool? enableSpeculativeDecoding, // Ignored on web (MediaPipe path).
   }) async {
     // TODO: Implement multimodal support for web
     if (supportImage || maxNumImages != null) {

--- a/native/litert_lm/build_android.sh
+++ b/native/litert_lm/build_android.sh
@@ -10,15 +10,20 @@
 #   - Git LFS: brew install git-lfs
 #
 # Usage:
-#   ./build_android.sh [version]
-#   ./build_android.sh 5e0d86b
-#   ./build_android.sh          # uses latest tag
+#   ./build_android.sh [ref]
+#   ./build_android.sh 032334d        # default for 0.15.0 (post-6571c42 main HEAD)
+#   ./build_android.sh v0.11.0        # WARNING: v0.11.0 prebuilt accelerators
+#                                     # are ABI-incompatible with libLiteRtLm
+#                                     # rebuilt from v0.11.0 source. Use 032334d
+#                                     # (post-6571c42 which re-syncs accelerator
+#                                     # binaries with WORKSPACE LITERT_REF).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREBUILT_DIR="$SCRIPT_DIR/prebuilt/android_arm64"
 LITERT_LM_DIR="/tmp/LiteRT-LM"
+DEFAULT_REF="032334d81ff96431492be272e536fbafe094b1e9"
 VERSION="${1:-}"
 
 # Resolve Android NDK — prefer ANDROID_NDK_HOME env, else newest under
@@ -48,7 +53,8 @@ echo "ANDROID_HOME: $ANDROID_HOME"
 if [ -d "$LITERT_LM_DIR" ]; then
   echo "Updating $LITERT_LM_DIR..."
   cd "$LITERT_LM_DIR"
-  git fetch --tags
+  # --force so a tag that moved upstream doesn't abort the fetch.
+  git fetch --tags --force origin
 else
   echo "Cloning LiteRT-LM..."
   git clone https://github.com/google-ai-edge/LiteRT-LM "$LITERT_LM_DIR"
@@ -56,14 +62,9 @@ else
 fi
 
 # 2. Checkout version (-f to discard any patch leftovers)
-if [ -n "$VERSION" ]; then
-  echo "Checking out $VERSION..."
-  git checkout -f "$VERSION"
-else
-  LATEST_TAG=$(git tag -l "v*" | sort -V | tail -1)
-  echo "Checking out latest tag: $LATEST_TAG..."
-  git checkout -f "$LATEST_TAG"
-fi
+TARGET_REF="${VERSION:-$DEFAULT_REF}"
+echo "Checking out $TARGET_REF..."
+git checkout -f "$TARGET_REF"
 echo "Building from: $(git log --oneline -1)"
 
 # 3. Ensure cc_binary(linkshared=True) target exists in c/BUILD

--- a/native/litert_lm/build_ios.sh
+++ b/native/litert_lm/build_ios.sh
@@ -35,12 +35,11 @@ else
 fi
 
 # 2. Checkout version
-# Default to commit 5e0d86b (post-v0.10.2) because it's the first commit that
-# adds libLiteRtMetalAccelerator.dylib for iOS — required for GPU. Building
-# against an earlier ref (e.g. v0.10.2) produces a libLiteRtLm.dylib whose
-# Metal accelerator ABI doesn't match the prebuilt framework, causing
-# EXC_BAD_ACCESS in litert_lm_engine_create at runtime on iPhone GPU.
-DEFAULT_REF="5e0d86b"
+# v0.11.0 ships libLiteRtMetalAccelerator.dylib for iOS in prebuilt/ios_arm64/
+# (verified via `git show v0.11.0 prebuilt/ios_arm64/`), so we can use the
+# tag directly. Earlier we pinned commit 5e0d86b (post-v0.10.2, first commit
+# adding the Metal accelerator dylib) for the same reason.
+DEFAULT_REF="v0.11.0"
 TARGET_REF="${VERSION:-$DEFAULT_REF}"
 echo "Checking out $TARGET_REF..."
 git checkout -f "$TARGET_REF"

--- a/native/litert_lm/build_ios.sh
+++ b/native/litert_lm/build_ios.sh
@@ -33,7 +33,9 @@ echo "=== Building libLiteRtLm.dylib for iOS ==="
 if [ -d "$LITERT_LM_DIR" ]; then
   echo "Updating $LITERT_LM_DIR..."
   cd "$LITERT_LM_DIR"
-  git fetch --tags
+  # --force so a tag that moved upstream (e.g. v0.11.0 itself was retagged
+  # while we waited for accelerator fixes) doesn't abort the fetch.
+  git fetch --tags --force origin
 else
   echo "Cloning LiteRT-LM..."
   git clone https://github.com/google-ai-edge/LiteRT-LM "$LITERT_LM_DIR"

--- a/native/litert_lm/build_ios.sh
+++ b/native/litert_lm/build_ios.sh
@@ -7,9 +7,15 @@
 #   - Git LFS: brew install git-lfs
 #
 # Usage:
-#   ./build_ios.sh [version]
-#   ./build_ios.sh                # default: commit 5e0d86b (required for GPU)
-#   ./build_ios.sh 5e0d86b        # explicit
+#   ./build_ios.sh [ref]
+#   ./build_ios.sh 032334d        # default for 0.15.0 (post-6571c42 main HEAD)
+#   ./build_ios.sh v0.11.0        # WARNING: v0.11.0 prebuilt accelerators
+#                                 # are ABI-incompatible with libLiteRtLm
+#                                 # rebuilt from v0.11.0 source — crashes
+#                                 # in libLiteRtMetalAccelerator on engine
+#                                 # init/teardown. Use 032334d (post-6571c42
+#                                 # which re-syncs accelerator binaries with
+#                                 # WORKSPACE LITERT_REF).
 #   ./build_ios.sh v0.10.2        # WARNING: predates Metal accelerator,
 #                                 # produces libLiteRtLm.dylib that crashes
 #                                 # iPhone GPU with EXC_BAD_ACCESS in
@@ -35,11 +41,13 @@ else
 fi
 
 # 2. Checkout version
-# v0.11.0 ships libLiteRtMetalAccelerator.dylib for iOS in prebuilt/ios_arm64/
-# (verified via `git show v0.11.0 prebuilt/ios_arm64/`), so we can use the
-# tag directly. Earlier we pinned commit 5e0d86b (post-v0.10.2, first commit
-# adding the Metal accelerator dylib) for the same reason.
-DEFAULT_REF="v0.11.0"
+# 032334d (main HEAD on 2026-05-08) is post-6571c42 "Update dependencies of
+# litert_lm" which rebuilt all prebuilt accelerator dylibs (Metal, WebGPU,
+# Gpu, OpenCL, samplers) AND re-synced WORKSPACE LITERT_REF to 5c5b9ce6.
+# This is the first public LiteRT-LM commit where libLiteRtLm rebuilt from
+# source has matching ABI with the prebuilt accelerators. v0.11.0 itself
+# is broken — see the WARNING above and the upstream issue we filed.
+DEFAULT_REF="032334d81ff96431492be272e536fbafe094b1e9"
 TARGET_REF="${VERSION:-$DEFAULT_REF}"
 echo "Checking out $TARGET_REF..."
 git checkout -f "$TARGET_REF"

--- a/native/litert_lm/build_macos.sh
+++ b/native/litert_lm/build_macos.sh
@@ -31,7 +31,9 @@ echo "=== Building libLiteRtLm.dylib for macOS arm64 ==="
 if [ -d "$LITERT_LM_DIR" ]; then
   echo "Updating $LITERT_LM_DIR..."
   cd "$LITERT_LM_DIR"
-  git fetch --tags
+  # --force so a tag that moved upstream (e.g. v0.11.0 itself was retagged
+  # while we waited for accelerator fixes) doesn't abort the fetch.
+  git fetch --tags --force origin
 else
   echo "Cloning LiteRT-LM..."
   git clone https://github.com/google-ai-edge/LiteRT-LM "$LITERT_LM_DIR"

--- a/native/litert_lm/build_macos.sh
+++ b/native/litert_lm/build_macos.sh
@@ -7,15 +7,22 @@
 #   - Git LFS: brew install git-lfs
 #
 # Usage:
-#   ./build_macos.sh [version]
-#   ./build_macos.sh v0.10.1
-#   ./build_macos.sh          # uses latest tag
+#   ./build_macos.sh [ref]
+#   ./build_macos.sh 032334d        # explicit commit (default for 0.15.0)
+#   ./build_macos.sh v0.11.0        # WARNING: v0.11.0 prebuilt accelerators
+#                                   # are ABI-incompatible with libLiteRtLm
+#                                   # rebuilt from v0.11.0 source — crashes
+#                                   # in libLiteRtMetalAccelerator on engine
+#                                   # init/teardown. Use 032334d (post-6571c42
+#                                   # on main, which re-syncs accelerator
+#                                   # binaries with WORKSPACE LITERT_REF).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREBUILT_DIR="$SCRIPT_DIR/prebuilt/macos_arm64"
 LITERT_LM_DIR="/tmp/LiteRT-LM"
+DEFAULT_REF="032334d81ff96431492be272e536fbafe094b1e9"
 VERSION="${1:-}"
 
 echo "=== Building libLiteRtLm.dylib for macOS arm64 ==="
@@ -32,14 +39,9 @@ else
 fi
 
 # 2. Checkout version
-if [ -n "$VERSION" ]; then
-  echo "Checking out $VERSION..."
-  git checkout -f "$VERSION"
-else
-  LATEST_TAG=$(git tag -l "v*" | sort -V | tail -1)
-  echo "Checking out latest tag: $LATEST_TAG..."
-  git checkout -f "$LATEST_TAG"
-fi
+TARGET_REF="${VERSION:-$DEFAULT_REF}"
+echo "Checking out $TARGET_REF..."
+git checkout -f "$TARGET_REF"
 
 echo "Building from: $(git log --oneline -1)"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.14.5
+version: 0.15.0
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 


### PR DESCRIPTION
## Summary

- **LiteRT-LM 0.11.0**: MTP-capable Gemma 4 + speculative decoding on macOS / iOS / Android / Windows.
- **`enableSpeculativeDecoding` flag** on `getActiveModel()` (null = model default; true/false to override).
- **Restore Android NPU support for `.litertlm`** (regression from 0.14.0): `PreferredBackend.npu` on Android `.litertlm` models routes through LiteRT-LM's `Backend::NPU` again — same as 0.13.x's Kotlin path before the FFI migration silently dropped it.
- **`PreferredBackend.npu` on desktop** (#261): macOS / Linux / Windows backend arm wired.
- **Linux known limitation**: post-MTP HF Gemma 4 revisions blocked upstream — `libLiteRtWebGpuAccelerator.so` segfaults during graph compile (filed `google-ai-edge/LiteRT-LM#2225`). Workaround: pre-MTP HF revision `7fa1d78473894f7e736a21d920c3aa80f950c0db` documented in README.
- **hook native cache**: marker-file based invalidation (`.flutter_gemma_native_version`) — bumps clean stale companion libs automatically.

## Test plan

- [x] `flutter analyze` — 0 new issues (370 baseline `info`-level)
- [x] `flutter test` — 343/343 unit tests pass
- [x] `dart pub publish --dry-run` — 621 KB, no warnings (modulo the now-fixed uncommitted-changes warning)
- [x] Full Gemma 4 E2B integration suite (15/15 PASS) on macOS / iOS device / Android Pixel 8 / Windows T4
- [x] Linux: pre-MTP Gemma 4 E2B 15/15 PASS on T4-on-L4-snapshot VM (`flutter-gemma-l4-tmp`)
- [x] Linux: post-MTP confirmed broken upstream — clean repro filed as `google-ai-edge/LiteRT-LM#2225` with full gdb backtrace

## Out of scope / follow-ups

- Awaiting upstream fix on `LiteRT-LM#2225` for Linux post-MTP support; example app URL stays on HF main so other platforms get the MTP speedup.
- iOS NPU disabled by upstream (`LITERT_DISABLE_NPU` build flag).