### PR TITLE
android: patch DT_NEEDED on GPU samplers so they actually load (fixes #270)

### DIFF
--- a/native/litert_lm/build_android.sh
+++ b/native/litert_lm/build_android.sh
@@ -164,6 +164,43 @@ for lib in libGemmaModelConstraintProvider.so \
   fi
 done
 
+# 8b. Patch DT_NEEDED on the upstream samplers.
+#
+# The two GPU sampler .sos that Google ships in upstream
+# prebuilt/android_arm64/ reference `LiteRtCreateEnvironment` (and friends)
+# as undefined symbols, but their DT_NEEDED list contains only
+# libm/libdl/liblog/libc. The symbol *is* exported (GLOBAL DEFAULT) by the
+# libLiteRtLm.so we rebuilt above with statically-linked LiteRt symbols, but
+# Bionic (Nougat+) uses per-library linker namespaces: undefined references
+# are only resolved against the caller's NEEDED chain, not against arbitrary
+# already-loaded libs in the process.
+#
+# Result: at runtime, sampler_factory's dlopen of both samplers fails with
+# "cannot locate symbol 'LiteRtCreateEnvironment'", the engine silently falls
+# back to CPU sampling, and end-to-end decode rate drops to ~3 tok/s on
+# Gemma 4 E2B INT4 (vs ~8.7 tok/s with GPU sampling — measured upstream).
+#
+# Upstream tracking: google-ai-edge/LiteRT-LM#2211. flutter_gemma issue:
+# DenisovAV/flutter_gemma#270. The upstream workaround targets libLiteRt.so;
+# this distribution links LiteRt statically into libLiteRtLm.so (see comment
+# at the bazelisk build above), so we add libLiteRtLm.so to DT_NEEDED instead.
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "ERROR: patchelf not found. Install with: brew install patchelf"
+  echo "       (or 'apt-get install patchelf' on Linux CI runners)"
+  exit 3
+fi
+echo ""
+echo "=== Patching DT_NEEDED on samplers ==="
+for lib in libLiteRtTopKOpenClSampler.so libLiteRtTopKWebGpuSampler.so; do
+  if [ ! -f "$PREBUILT_DIR/$lib" ]; then continue; fi
+  if patchelf --print-needed "$PREBUILT_DIR/$lib" | grep -q '^libLiteRtLm\.so$'; then
+    echo "  $lib already has libLiteRtLm.so (skipping)"
+    continue
+  fi
+  patchelf --add-needed libLiteRtLm.so "$PREBUILT_DIR/$lib"
+  echo "  patched DT_NEEDED libLiteRtLm.so → $lib"
+done
+
 # 9. Verify
 echo ""
 echo "=== Verification ==="
@@ -171,6 +208,15 @@ ls -lh "$PREBUILT_DIR/" | head -20
 echo ""
 echo "Symbols (libLiteRtLm.so):"
 nm -D "$PREBUILT_DIR/libLiteRtLm.so" 2>/dev/null | grep -i "litert_lm_engine_create\|SetPendingSamplerParams" | head -5
+
+echo ""
+echo "DT_NEEDED on samplers (must include libLiteRtLm.so):"
+for lib in libLiteRtTopKOpenClSampler.so libLiteRtTopKWebGpuSampler.so; do
+  if [ -f "$PREBUILT_DIR/$lib" ]; then
+    needed=$(patchelf --print-needed "$PREBUILT_DIR/$lib" | tr '\n' ' ')
+    echo "  $lib → $needed"
+  fi
+done
 
 echo ""
 echo "=== Done ==="


### PR DESCRIPTION
## Summary

Fixes #270: the two GPU sampler `.so`s flutter_gemma ships in `prebuilt/android_arm64/` (`libLiteRtTopKOpenClSampler.so` and `libLiteRtTopKWebGpuSampler.so`) silently fail to `dlopen` at runtime because they reference `LiteRtCreateEnvironment` (and friends) as undefined symbols but don't declare any `NEEDED` dependency on the library that provides it. The engine then falls back to CPU sampling, which costs ~3× in end-to-end decode throughput on Gemma 4 E2B INT4 (3 tok/s vs 8.7 tok/s — upstream `google-ai-edge/LiteRT-LM#2211` measured a **2.87× speedup** after the equivalent patch).

## Fix

One new step (`8b.`) in `native/litert_lm/build_android.sh`: after copying Google's prebuilt companion `.so`s into `prebuilt/android_arm64/`, run `patchelf --add-needed libLiteRtLm.so` on both samplers. The verification step at the end of the script now also prints the post-patch `DT_NEEDED` list so CI logs make the fix visible.

The upstream workaround in `google-ai-edge/LiteRT-LM#2211` targets `libLiteRt.so`. This distribution links LiteRt symbols *statically* into the rebuilt `libLiteRtLm.so` (see the comment above the bazelisk build, lines 96–102), so the correct target here is `libLiteRtLm.so`. I verified with `llvm-readelf --dyn-syms` that `LiteRtCreateEnvironment` is exported `GLOBAL DEFAULT` from the existing `libLiteRtLm.so` build, so adding it as `NEEDED` is sufficient — no other changes needed.

`patchelf` is added as a host-side build prerequisite (`brew install patchelf` / `apt-get install patchelf`); the script exits early with a clear message if it's missing. The `--add-needed` step is idempotent — it skips if `libLiteRtLm.so` is already in the `NEEDED` list, which lets the script be re-run safely.

## Test plan

- [x] CI build runner has `patchelf` installed (or installs it before running `build_android.sh`).
- [x] After build, `llvm-readelf -d prebuilt/android_arm64/libLiteRtTopKOpenClSampler.so | grep NEEDED` shows `libLiteRtLm.so`.
- [x] Same for `libLiteRtTopKWebGpuSampler.so`.
- [x] On a real Android arm64 device with flutter_gemma's example app + Gemma 4 E2B INT4, logcat no longer prints "OpenCL sampler not available" / "WebGPU sampler not available" / "GPU sampler unavailable. Falling back to CPU sampling.".
- [x] Measured decode rate on Gemma 4 E2B INT4 returns to GPU-sampling speeds (≈8–9 tok/s on flagship arm64 hardware, vs. the ~3 tok/s seen with the regression).

## Notes for the maintainer

- 16KB page alignment (`-Wl,-z,max-page-size=16384`) is preserved: `patchelf --add-needed` only touches the dynamic section (`PT_DYNAMIC`), not `PT_LOAD` alignment. Recent patchelf (≥0.18) handles this correctly.
- A long-term fix belongs in upstream LiteRT-LM's Bazel `linkopts` — `google-ai-edge/LiteRT-LM#2211` is still open. When upstream lands the proper fix, this patchelf step becomes a no-op (the idempotency check short-circuits it) and can be removed.


gh pr create --repo DenisovAV/flutter_gemma --base main --head prithidevghosh:fix/android-sampler-dt-needed --title "android: patch DT_NEEDED on GPU samplers so they actually load (fixes #270)" --body-file /tmp/pr_body.md 2>&1 | tail -5