### PR TITLE
0.15.1: Windows Intel NPU + multi-image + Android sampler + desktop storage

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,6 +24,19 @@ git status                  # all desired changes staged or already committed
 git log --oneline -5
 flutter analyze             # 0 errors
 flutter test                # all pass
+
+# Cross-platform compile sanity — analyze/test run on host VM and skip
+# conditional imports (e.g. `lib/core/ffi/*_stub.dart`). The only thing
+# that catches stub/client signature drift is `flutter build <target>`.
+# Skipping this is how `enableSpeculativeDecoding` web breakage shipped
+# in 0.15.0 — analyze was green, tests passed, web build threw
+# `No named parameter ...` at dart2js time.
+cd example
+flutter build web --no-tree-shake-icons
+flutter build apk --debug
+flutter build macos --debug
+flutter build ios --no-codesign --debug
+cd ..
 ```
 
 ## Step 1: Determine release scope
@@ -188,6 +201,12 @@ or moved to a separate doc.
 ```bash
 flutter analyze
 flutter test
+# Cross-platform compile sanity (also in Pre-flight — rerun here after
+# version bumps in case a setter/getter signature shifted):
+(cd example && flutter build web --no-tree-shake-icons)
+(cd example && flutter build apk --debug)
+(cd example && flutter build macos --debug)
+(cd example && flutter build ios --no-codesign --debug)
 dart pub publish --dry-run     # 0 warnings; check final package size <= 100 KB
 ```
 

--- a/.github/workflows/build-litertlm-native-windows.yml
+++ b/.github/workflows/build-litertlm-native-windows.yml
@@ -1,0 +1,107 @@
+name: Build LiteRT-LM Native — Windows only
+
+# Standalone Windows-only build for fast iteration when iterating on
+# patch_c_api.sh / native bumps that only touch the Windows tarball
+# (e.g. Intel NPU bundle ABI fixes). Use the full
+# `build-litertlm-native.yml` workflow when changing all 3 desktop
+# platforms together.
+#
+# Triggered manually only — never on push. Same Windows job body as
+# build-litertlm-native.yml lines 123-226 (keep in sync when editing).
+
+on:
+  workflow_dispatch:
+    inputs:
+      litertlm_version:
+        description: 'LiteRT-LM ref (tag, branch, or commit SHA)'
+        required: true
+        default: '62f7a8ec3587027a2351ff348bf8bc1648fd59b4'
+
+jobs:
+  build-windows-x86_64:
+    name: Windows x86_64
+    runs-on: windows-latest
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
+      ANDROID_NDK_HOME: ''
+      BAZEL_OUTPUT_BASE: 'D:\b'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable symlinks
+        run: git config --global core.symlinks true
+
+      - name: Clone LiteRT-LM
+        run: |
+          git clone https://github.com/google-ai-edge/LiteRT-LM C:\LiteRT-LM
+          cd C:\LiteRT-LM
+          git checkout "$env:LITERTLM_VERSION"
+          git lfs pull --include="prebuilt/windows_x86_64/*"
+
+      - name: Patch C API
+        shell: bash
+        run: bash native/litert_lm/patch_c_api.sh C:/LiteRT-LM
+
+      - name: Build LiteRtLm.dll
+        run: |
+          cd C:\LiteRT-LM
+          bazel --output_base="$env:BAZEL_OUTPUT_BASE" `
+            build -c opt `
+            --linkopt=/OPT:REF --linkopt=/OPT:ICF `
+            --build_tag_filters='-nowindows' `
+            --features=compiler_param_file `
+            --features=archive_param_file `
+            --spawn_strategy=local `
+            --define=litert_link_capi_so=true `
+            --define=resolve_symbols_in_exec=false `
+            '//c:libLiteRtLm.dylib'
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build StreamProxy.dll
+        run: |
+          cl /LD /Fe:StreamProxy.dll native\litert_lm\stream_proxy.c
+
+      - name: Download DirectXShaderCompiler runtime
+        run: |
+          $dxcVer = 'v1.9.2602'
+          $dxcUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/$dxcVer/dxc_2026_02_20.zip"
+          Invoke-WebRequest -Uri $dxcUrl -OutFile dxc.zip
+          Expand-Archive -Path dxc.zip -DestinationPath dxc -Force
+          Get-ChildItem -Recurse dxc | Where-Object { $_.Name -in 'dxil.dll','dxcompiler.dll' } | Select-Object FullName, Length
+
+      - name: Collect artifacts
+        run: |
+          New-Item -ItemType Directory -Path artifacts -Force
+          Copy-Item C:\LiteRT-LM\bazel-bin\c\libLiteRtLm.dylib artifacts\LiteRtLm.dll
+          Copy-Item StreamProxy.dll artifacts\
+          $prebuilt = 'C:\LiteRT-LM\prebuilt\windows_x86_64'
+          foreach ($base in @('libGemmaModelConstraintProvider','libLiteRt','libLiteRtTopKWebGpuSampler','libLiteRtWebGpuAccelerator')) {
+            $src = "$prebuilt\$base.dll"
+            if (Test-Path $src) {
+              Copy-Item $src "artifacts\$base.dll"
+              $stripped = $base -replace '^lib',''
+              Copy-Item $src "artifacts\$stripped.dll"
+            }
+          }
+          foreach ($dxc in 'dxil.dll', 'dxcompiler.dll') {
+            $src = Get-ChildItem -Recurse -Filter $dxc -Path dxc | Where-Object { $_.FullName -match 'x64' } | Select-Object -First 1
+            if (-not $src) {
+              $src = Get-ChildItem -Recurse -Filter $dxc -Path dxc | Select-Object -First 1
+            }
+            if ($src) {
+              Copy-Item $src.FullName "artifacts\$dxc"
+            } else {
+              throw "DXC runtime missing: $dxc"
+            }
+          }
+          Get-ChildItem artifacts\
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: litertlm-windows_x86_64
+          path: artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.15.1
 - **Fix Android GPU sampler dlopen failure** (#270, thanks @prithidevghosh): `patchelf --add-needed libLiteRtLm.so` on `libLiteRtTopK{OpenCl,WebGpu}Sampler.so`.
 - **Desktop storage** (#179, co-author @ProjectEdge-Jim): use Application Support instead of Documents on Windows/macOS/Linux to avoid cloud-synced paths breaking FFI mmap.
+- **Multi-image, FFI session metrics, prefix replay** (#262, thanks @frdteknikelektro): `Message.withImages([...])` for multi-image input, `chat`/`Conversation` session metrics via FFI, persistent prefix messages replayed on session rebuild after history truncation. Backward-compatible (`Message.withImage(...)` still works).
+- **Skip sampler params on NPU backend**: `temperature`/`topK`/`topP`/`seed` are silently ignored when `PreferredBackend.npu` is selected — LiteRT-LM NPU executor only supports internal greedy sampling.
+- **Windows Intel NPU end-to-end**: native-v0.11.0-b Windows tarball bundles Intel dispatch (`LiteRtDispatch.dll`), OpenVino runtime, TBB (~30 MB); FFI client passes `dispatch_lib_dir` + `use_hw_masking_for_npu=false` at engine_create so `PreferredBackend.npu` works on Intel LunarLake/PantherLake silicon without manual DLL placement.
+- **Fix web build broken by 0.15.0**: `LiteRtLmFfiClient` stub on web was missing the `enableSpeculativeDecoding` parameter — dart2js failed compilation when web target was actually built.
+- **CI**: standalone `build-litertlm-native-windows.yml` workflow for Windows-only rebuilds.
 
 ## 0.15.0
 - **LiteRT-LM 0.11.0**: MTP-capable Gemma 4 + speculative decoding on macOS / iOS / Android / Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.1
+- **Fix Android GPU sampler dlopen failure** (#270, thanks @prithidevghosh): `patchelf --add-needed libLiteRtLm.so` on `libLiteRtTopK{OpenCl,WebGpu}Sampler.so`.
+- **Desktop storage** (#179, co-author @ProjectEdge-Jim): use Application Support instead of Documents on Windows/macOS/Linux to avoid cloud-synced paths breaking FFI mmap.
+
 ## 0.15.0
 - **LiteRT-LM 0.11.0**: MTP-capable Gemma 4 + speculative decoding on macOS / iOS / Android / Windows.
 - **`enableSpeculativeDecoding` flag** on `getActiveModel()` (null = model default; true/false to override).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **Dart SDK**: `>=3.6.0 <4.0.0`
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
-- **LiteRT-LM**: native libs from `native-v0.11.0-a` GitHub Release (built from upstream `google-ai-edge/LiteRT-LM` commit `032334d` — post-`6571c42` main HEAD with re-synced WORKSPACE LITERT_REF and matching prebuilt accelerators), bundled via Native Assets — same `.so`/`.dylib`/`.dll` set on all platforms. `-c opt --strip=always` build; retains vtool minos patch (26.2 → 16.0) on iOS `libGemmaModelConstraintProvider.dylib` and 16KB page alignment on Android `libLiteRtLm.so`. MTP (speculative decoding) support for Gemma 4.
-- **Current Version**: 0.15.0
+- **LiteRT-LM**: native libs from `native-v0.11.0-b` GitHub Release. Windows tarball built from upstream `google-ai-edge/LiteRT-LM` commit `62f7a8e` and bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` on Intel LunarLake/PantherLake silicon. Other 6 platforms unchanged from -a (commit `032334d`). Native Assets bundled — same `.so`/`.dylib`/`.dll` set on all platforms. `-c opt --strip=always` build; retains vtool minos patch (26.2 → 16.0) on iOS `libGemmaModelConstraintProvider.dylib` and 16KB page alignment on Android `libLiteRtLm.so`. MTP (speculative decoding) support for Gemma 4.
+- **Current Version**: 0.15.1
 
 ## Platform-Specific Setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@
 | iOS Device | ✅ | ✅ | ✅ | GPU via Metal delegate (FFI). Setup via Podfile `post_install` (creates `lib*.dylib` symlinks next to bundled frameworks) |
 | iOS Simulator | ❌ GPU | ❌ GPU | ✅ | CPU only — Metal sim has 256 MB single-allocation cap, LLM weights exceed |
 | Web | ✅ | ❌ | ✅ | MediaPipe only |
-| macOS | ⚠️ Broken (#684) | ✅ LiteRT-LM only | ✅ | Vision: SDK bug, model hallucinates |
+| macOS | ✅ | ✅ LiteRT-LM only | ✅ | Vision verified on Metal (Gemma 4 + Gemma 3n) |
 | Windows | ✅ | ✅ LiteRT-LM only | ✅ | Desktop via FFI; GPU via WebGPU/DX12 |
 | Linux | ✅ | ✅ LiteRT-LM only | ✅ | Desktop via FFI; GPU via WebGPU/Vulkan |
 
@@ -144,10 +144,10 @@ window.LlmInference = LlmInference;
 
 ### Desktop (macOS/Windows/Linux)
 - Architecture: Dart → `dart:ffi` → LiteRT-LM C API (no JVM, no gRPC)
-- Native libs fetched at build time by `hook/build.dart` from `native-v0.11.0-a` GitHub release; SHA256-verified, bundled via Native Assets
-- ⚠️ **macOS Vision broken** (#684): SDK bug, use text-only mode
+- Native libs fetched at build time by `hook/build.dart` from `native-v0.11.0-b` GitHub release; SHA256-verified, bundled via Native Assets
 - Desktop uses `.litertlm` format only (not `.task`)
 - Windows GPU requires `dxil.dll` + `dxcompiler.dll` (DirectXShaderCompiler runtime) — bundled in the Windows native archive
+- Windows NPU (`PreferredBackend.npu`) requires Intel LunarLake/PantherLake silicon — `LiteRtDispatch.dll` + OpenVino runtime + TBB bundled in the Windows native archive (0.15.1+)
 
 Entitlements needed: `network.client`, `extended-virtual-addressing`, `increased-memory-limit`
 

--- a/DESKTOP_SUPPORT.md
+++ b/DESKTOP_SUPPORT.md
@@ -66,7 +66,7 @@ loading sequence differs per platform (handled in `litert_lm_client.dart`).
 
 | Platform | Architecture | GPU backend | Vision | Audio | Notes |
 |----------|--------------|-------------|--------|-------|-------|
-| macOS | arm64 (Apple Silicon) | Metal | ⚠️ | ✅ | Vision broken upstream (#684 — model hallucinates) |
+| macOS | arm64 (Apple Silicon) | Metal | ✅ | ✅ | Vision verified on Gemma 4 + Gemma 3n via Metal |
 | macOS | x86_64 | — | — | — | Not supported (Apple Silicon only) |
 | Windows | x86_64 | DirectX 12 (via Dawn/WebGPU) | ✅ | ✅ | Requires VS 2019+ runtime (`vcredist`) for DXC |
 | Windows | arm64 | — | — | — | Not supported |
@@ -414,12 +414,6 @@ push session sampler params see no change.
 - [google-ai-edge/LiteRT-LM #1992](https://github.com/google-ai-edge/LiteRT-LM/issues/1992) (closed) — Python parity, fix didn't reach executor
 - [google-ai-edge/LiteRT-LM #2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080) — bug report we filed (executor + `session_basic.cc:108` together drop GPU/NPU sampler params)
 - [google-ai-edge/LiteRT-LM PR #2081](https://github.com/google-ai-edge/LiteRT-LM/pull/2081) — our proposed fix (Strategy D — `LlmExecutor::SetPendingSamplerParams` virtual + override on `LlmLiteRtCompiledModelExecutorBase` + `session_basic.cc` push). Reproducer: `flutter test integration_test/regression_bugs_test.dart` on any platform, `randomSeed=42` vs `randomSeed=99` at `temperature=1.0` on `PreferredBackend.gpu`.
-
-### macOS vision is broken upstream
-
-Vision input (`supportImage: true`) on macOS produces hallucinated answers
-unrelated to the image content. This is a bug in the upstream MediaPipe /
-LiteRT vision pipeline ([flutter_gemma #684](https://github.com/DenisovAV/flutter_gemma/issues/684)). Use text-only mode on macOS until upstream fixes it.
 
 ### Audio modality requires LiteRT-LM models
 

--- a/README.md
+++ b/README.md
@@ -47,25 +47,11 @@ There is an example of using:
 - **🔧 Unified Model Management:** Single system for managing both inference and embedding models with automatic validation
 - **💾 Web Persistent Caching:** Models persist across browser restarts using Cache API (Web only)
 
-## What's new in 0.15.1
+## What's new in 0.15
 
-- 🪟 **Windows Intel NPU** — `PreferredBackend.npu` on LunarLake / PantherLake silicon. Native bundle ships Intel dispatch (`LiteRtDispatch.dll`) + OpenVino runtime + TBB; no manual DLL placement needed. NPU executor uses internal greedy sampling — `temperature`/`topK`/`topP`/`seed` are silently ignored on this backend.
-- 🖼️ **Multi-image input** (#262, thanks @frdteknikelektro) — `Message.withImages([...])` for chat / inference sessions. Existing `Message.withImage(...)` still works.
-- 📈 **FFI session metrics** (#262) — `chat` / `Conversation` sessions expose token counts and timing via FFI.
-- 🤖 **Android GPU sampler dlopen fix** (#270, thanks @prithidevghosh) — `patchelf --add-needed libLiteRtLm.so` on the sampler `.so`s; +15–30% decode speedup on Pixel-class devices.
-- 💾 **Desktop storage location** (#179, co-author @ProjectEdge-Jim) — uses Application Support (`%LOCALAPPDATA%` on Windows, `~/Library/Application Support` on macOS, `~/.local/share` on Linux) instead of `Documents/` to avoid OneDrive cloud-virtualization breaking FFI mmap on >2 GB models. Existing installs are auto-detected via read-from-both fallback.
-- 🌐 **Web build fix** — `LiteRtLmFfiClient` stub was missing the `enableSpeculativeDecoding` parameter added in 0.15.0; dart2js failed when web was actually built. Resolved.
-
-## What's new in 0.15.0
-
-- ⚡ **MTP / speculative decoding for Gemma 4** — LiteRT-LM 0.11.0 enables Multi-Token Prediction on macOS / iOS / Android / Windows. New `enableSpeculativeDecoding` flag on `getActiveModel()` overrides the model default if needed.
-- 🤖 **Android NPU restored** for `.litertlm` (regression fix from 0.14.0) — `PreferredBackend.npu` again drives Qualcomm QNN / Google Tensor / MediaTek dispatch libs through LiteRT-LM's `Backend::NPU`.
-- 🖥️ **Desktop NPU** — `PreferredBackend.npu` accepted on macOS / Linux / Windows (#261). Same dispatch-lib requirement as Android.
-- 🐧 **Linux note** — pre-MTP Gemma 4 revision required until upstream fixes `google-ai-edge/LiteRT-LM#2225`. See **Linux Setup** for the revision-pinned download.
-
-## What's new in 0.14.1
-
-- 🛠️ **Gemma 4 native function calling** — `ModelType.gemma4` routes tool definitions through the LiteRT-LM SDK's chat-template path (minja). The SDK renders native `<|tool>declaration:...<tool|>` tokens, the model emits `<|tool_call>...<tool_call|>`, and the SDK parses the response into structured `tool_calls` JSON. flutter_gemma surfaces it as `FunctionCallResponse` — no Dart-side prompt engineering required.
+- ⚡ **MTP / speculative decoding for Gemma 4** — Multi-Token Prediction on macOS / iOS / Android / Windows via LiteRT-LM 0.11.0.
+- 🤖 **NPU support** — `PreferredBackend.npu` on Android (Qualcomm QNN / Google Tensor / MediaTek) and Windows (Intel LunarLake / PantherLake).
+- 🖼️ **Multi-image input** — `Message.withImages([...])` for chat / inference sessions.
 
 ## What's new in 0.14.0
 
@@ -1263,11 +1249,11 @@ Function calling is currently supported by the following models:
 | **Text Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All models supported |
 | **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Verified on macOS Metal (Gemma 4 + Gemma 3n) |
 | **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ Full | Gemma3n E2B/E4B; iOS device-only |
-| **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Gemma 4 native (SDK chat template), 0.14.1+ |
+| **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Gemma 4 native (SDK chat template) |
 | **Thinking Mode** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | DeepSeek & Gemma 4 |
 | **Stop Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Cancel mid-process |
 | **GPU Acceleration** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Metal/WebGPU/Vulkan/DX12 |
-| **NPU Acceleration** | ✅ Full | ❌ Not supported | ❌ Not supported | ✅ Windows | Android (.litertlm) + Windows Intel LunarLake/PantherLake (0.15.1+) |
+| **NPU Acceleration** | ✅ Full | ❌ Not supported | ❌ Not supported | ✅ Windows | Android (.litertlm) + Windows Intel LunarLake/PantherLake |
 | **CPU Backend** | ✅ Full | ✅ Full | ❌ Not supported | ✅ Full | MediaPipe limitation |
 | **Streaming Responses** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Real-time generation |
 | **LoRA Support** | ✅ Full | ✅ Full | ✅ Full | ❌ Not supported | LiteRT-LM limitation |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There is an example of using:
 - **Local Execution:** Run Gemma models directly on user devices for enhanced privacy and offline functionality.
 - **Platform Support:** Compatible with iOS, Android, Web, macOS, Windows, and Linux platforms.
 - **🖥️ Desktop Support:** Native desktop apps (macOS, Windows, Linux) with GPU acceleration via LiteRT-LM, called directly from Dart through `dart:ffi` — no JVM/JRE bundling. See [DESKTOP_SUPPORT.md](DESKTOP_SUPPORT.md) for details.
-- **🖼️ Multimodal Support:** Text + Image input with Gemma3n vision models
+- **🖼️ Multimodal Support:** Text + Image input with Gemma 4, Gemma3n, and FastVLM vision models
 - **🎙️ Audio Input:** Record and send audio messages with Gemma3n E2B/E4B models (Android, iOS device, Desktop)
 - **🛠️ Function Calling:** Enable your models to call external functions and integrate with other services (supported by select models)
 - **🧠 Thinking Mode:** View the reasoning process of DeepSeek and Gemma 4 models with thinking blocks
@@ -128,7 +128,7 @@ When installing models, you need to specify the correct `ModelType`. Use this ta
 | **Phi** | `ModelType.phi` | Phi-4 Mini |
 | **General** | `ModelType.general` | FastVLM 0.5B, SmolLM 135M |
 
-> **Note**: Gemma 4 uses `ModelType.gemma4` (introduced in 0.14.1) so its native `<\|tool_call>...<tool_call\|>` tokens are routed through the LiteRT-LM SDK's chat-template path. For Gemma 3 and earlier, keep `ModelType.gemmaIt`.
+> **Note**: Gemma 4 uses `ModelType.gemma4` so its native `<\|tool_call>...<tool_call\|>` tokens are routed through the LiteRT-LM SDK's chat-template path. For Gemma 3 and earlier, keep `ModelType.gemmaIt`.
 
 **Usage Example:**
 ```dart
@@ -247,7 +247,7 @@ platform :ios, '16.0'  # Required for MediaPipe GenAI
 use_frameworks! :linkage => :static
 ```
 
-> Since 0.14.1, no host-side `Podfile` `post_install` is required on iOS — flutter_gemma patches the upstream LiteRT-LM `dlopen` path to use `@executable_path/Frameworks/<X>.framework/<X>` so dyld resolves Metal accelerators directly through the Native-Assets-bundled framework. This also keeps `Runner.app/Frameworks/` App-Store-clean (fixes ITMS-90432, see #245).
+> No host-side `Podfile` `post_install` is required on iOS — flutter_gemma patches the upstream LiteRT-LM `dlopen` path to use `@executable_path/Frameworks/<X>.framework/<X>` so dyld resolves Metal accelerators directly through the Native-Assets-bundled framework. This also keeps `Runner.app/Frameworks/` App-Store-clean (fixes ITMS-90432, see #245).
 
 **Android**
 
@@ -300,7 +300,7 @@ Add to 'AndroidManifest.xml' above tag `</application>`
 > Desktop platforms use **LiteRT-LM format only** (`.litertlm` files).
 > MediaPipe `.task` and `.bin` models used on mobile/web are **NOT compatible** with desktop.
 
-Since 0.14.0 desktop inference and embeddings both use the LiteRT-LM C API via `dart:ffi` directly in the Dart process — no JVM, no gRPC, no separate server. Native libraries are downloaded by `hook/build.dart` (Native Assets) at build time and bundled into the app automatically.
+Desktop inference and embeddings both use the LiteRT-LM C API via `dart:ffi` directly in the Dart process — no JVM, no gRPC, no separate server. Native libraries are downloaded by `hook/build.dart` (Native Assets) at build time and bundled into the app automatically.
 
 | Platform | Architecture | GPU Acceleration | Status |
 |----------|-------------|------------------|--------|
@@ -315,7 +315,7 @@ Since 0.14.0 desktop inference and embeddings both use the LiteRT-LM C API via `
 
 **macOS Setup:**
 
-flutter_gemma 0.14.2+ requires a small `post_install` block in your
+macOS requires a small `post_install` block in your
 `macos/Podfile`. The Apple accelerator dylibs Google ships upstream
 (`libGemmaModelConstraintProvider.dylib`, `libLiteRtMetalAccelerator.dylib`,
 `libLiteRtTopKMetalSampler.dylib`) were linked without
@@ -337,11 +337,11 @@ post_install do |installer|
     flutter_additional_macos_build_settings(target)
   end
 
-  # flutter_gemma 0.14.4: bundle Apple accelerator dylibs as .framework
-  # bundles into Contents/Frameworks/ and re-point LiteRtLm.dylib's
-  # LC_LOAD_DYLIB reference to GemmaModelConstraintProvider's new path.
-  # 3-tier dylib source fallback: Native Assets cache (pub.dev users) →
-  # plugin symlink → in-repo prebuilt/. See README -> macOS Setup and #247/#255.
+  # flutter_gemma: bundle Apple accelerator dylibs as .framework bundles
+  # into Contents/Frameworks/ and re-point LiteRtLm.dylib's LC_LOAD_DYLIB
+  # reference to GemmaModelConstraintProvider's new path. 3-tier dylib
+  # source fallback: Native Assets cache (pub.dev users) → plugin symlink
+  # → in-repo prebuilt/. See README -> macOS Setup and #247/#255.
   installer.aggregate_targets.each do |aggregate_target|
     aggregate_target.user_targets.each do |user_target|
       phase_name = '[flutter_gemma] Setup LiteRT-LM macOS'
@@ -465,7 +465,7 @@ import 'package:flutter_gemma/flutter_gemma.dart';
 await FlutterGemma.installModel(
   modelType: ModelType.gemmaIt,
 ).fromNetwork(
-  'https://huggingface.co/google/gemma-3-2b-it/resolve/main/gemma-3-2b-it-gpu-int8.task',
+  'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4.task',
   token: 'your_hf_token',
 ).withProgress((progress) {
   print('Downloading: ${progress.percentage}%');
@@ -1150,7 +1150,8 @@ chat.generateChatResponseAsync().listen((response) {
     // Use response.token to update your UI incrementally
     
   } else if (response is FunctionCallResponse) {
-    // Model wants to call a function (Gemma3n, DeepSeek, Qwen2.5)
+    // Model wants to call a function (Gemma 4, Gemma3n, Gemma 3 1B,
+    // FunctionGemma, DeepSeek, Qwen3, Qwen 2.5, Phi-4)
     print('Function: ${response.name}');
     print('Arguments: ${response.args}');
     
@@ -1277,7 +1278,7 @@ Function calling is currently supported by the following models:
 - **FileSource:** Only works with HTTP/HTTPS URLs or `assets/` paths
 - **Local file paths:** ❌ Not supported (browser security restriction)
 
-#### Web Storage Modes (v0.12.1+)
+#### Web Storage Modes
 
 **Three Storage Modes:**
 
@@ -1350,8 +1351,8 @@ The full and complete example you can find in `example` folder
 ## **Important Considerations**
 
 * **Model Size:** Larger models (such as 7b and 7b-it) might be too resource-intensive for on-device inference.
-* **Function Calling Support:** Gemma3n and DeepSeek models support function calling. Other models will ignore tools and show a warning.
-* **Thinking Mode:** Only DeepSeek models support thinking mode. Enable with `isThinking: true` and `modelType: ModelType.deepSeek`.
+* **Function Calling Support:** Gemma 4, Gemma3n, Gemma 3 1B, FunctionGemma, DeepSeek, Qwen3, Qwen 2.5, and Phi-4 models support function calling. Other models will ignore tools and show a warning. See [Model Function Calling Support](#%EF%B8%8F-model-function-calling-support).
+* **Thinking Mode:** Gemma 4, DeepSeek, and Qwen3 models support thinking mode. Enable with `isThinking: true` on the matching `ModelType`.
 * **Multimodal Models:** Gemma3n models with vision support require more memory and are recommended for devices with 8GB+ RAM.
 * **iOS Memory Requirements:** Large models require memory entitlements in `Runner.entitlements` and minimum iOS 16.0.
 * **LoRA Weights:** They provide efficient customization without the need for full model retraining.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ There is an example of using:
 - **🔧 Unified Model Management:** Single system for managing both inference and embedding models with automatic validation
 - **💾 Web Persistent Caching:** Models persist across browser restarts using Cache API (Web only)
 
+## What's new in 0.15.1
+
+- 🪟 **Windows Intel NPU** — `PreferredBackend.npu` on LunarLake / PantherLake silicon. Native bundle ships Intel dispatch (`LiteRtDispatch.dll`) + OpenVino runtime + TBB; no manual DLL placement needed. NPU executor uses internal greedy sampling — `temperature`/`topK`/`topP`/`seed` are silently ignored on this backend.
+- 🖼️ **Multi-image input** (#262, thanks @frdteknikelektro) — `Message.withImages([...])` for chat / inference sessions. Existing `Message.withImage(...)` still works.
+- 📈 **FFI session metrics** (#262) — `chat` / `Conversation` sessions expose token counts and timing via FFI.
+- 🤖 **Android GPU sampler dlopen fix** (#270, thanks @prithidevghosh) — `patchelf --add-needed libLiteRtLm.so` on the sampler `.so`s; +15–30% decode speedup on Pixel-class devices.
+- 💾 **Desktop storage location** (#179, co-author @ProjectEdge-Jim) — uses Application Support (`%LOCALAPPDATA%` on Windows, `~/Library/Application Support` on macOS, `~/.local/share` on Linux) instead of `Documents/` to avoid OneDrive cloud-virtualization breaking FFI mmap on >2 GB models. Existing installs are auto-detected via read-from-both fallback.
+- 🌐 **Web build fix** — `LiteRtLmFfiClient` stub was missing the `enableSpeculativeDecoding` parameter added in 0.15.0; dart2js failed when web was actually built. Resolved.
+
 ## What's new in 0.15.0
 
 - ⚡ **MTP / speculative decoding for Gemma 4** — LiteRT-LM 0.11.0 enables Multi-Token Prediction on macOS / iOS / Android / Windows. New `enableSpeculativeDecoding` flag on `getActiveModel()` overrides the model default if needed.
@@ -1252,13 +1261,13 @@ Function calling is currently supported by the following models:
 | Feature | Android | iOS | Web | Desktop | Notes |
 |---------|---------|-----|-----|---------|-------|
 | **Text Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All models supported |
-| **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | ⚠️ Broken (#684) | macOS: model hallucinates |
-| **Audio Input** | ✅ Full | ✅ Full | ❌ Not supported | ✅ Full | Gemma3n E2B/E4B |
-| **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ❌ Not supported | LiteRT-LM limitation |
+| **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Verified on macOS Metal (Gemma 4 + Gemma 3n) |
+| **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ Full | Gemma3n E2B/E4B; iOS device-only |
+| **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Gemma 4 native (SDK chat template), 0.14.1+ |
 | **Thinking Mode** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | DeepSeek & Gemma 4 |
 | **Stop Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Cancel mid-process |
-| **GPU Acceleration** | ✅ Full | ✅ Full | ✅ Full | ⚠️ Partial | macOS GPU broken |
-| **NPU Acceleration** | ✅ Full | ❌ Not supported | ❌ Not supported | ❌ Not supported | Android only (.litertlm) |
+| **GPU Acceleration** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Metal/WebGPU/Vulkan/DX12 |
+| **NPU Acceleration** | ✅ Full | ❌ Not supported | ❌ Not supported | ✅ Windows | Android (.litertlm) + Windows Intel LunarLake/PantherLake (0.15.1+) |
 | **CPU Backend** | ✅ Full | ✅ Full | ❌ Not supported | ✅ Full | MediaPipe limitation |
 | **Streaming Responses** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Real-time generation |
 | **LoRA Support** | ✅ Full | ✅ Full | ✅ Full | ❌ Not supported | LiteRT-LM limitation |

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -457,22 +457,50 @@ void main() {
   group('Gemma4-E2B NPU', () {
     tearDownAll(_closeSharedModel);
 
-    testWidgets('NPU engine_create accepts non-default sampler params',
-        (t) async {
-      // Direct integration: select PreferredBackend.npu. If platform lacks
-      // NPU dispatch the engine_create throws — we catch + SKIP. If it
-      // succeeds, Phase 3 sampler-skip kept engine_create from rejecting
-      // the call.
-      late InferenceModel model;
+    // Real NPU tests need a model precompiled for the target NPU (Intel
+    // LunarLake / PantherLake or Qualcomm QNN). Generic Gemma 4 from HF
+    // doesn't carry NPU executor sections and `engine_create` will reject
+    // it. Pre-arranged LNL artifact lives in the workspace dir; SKIP if
+    // absent (covers CI and dev machines without NPU hardware).
+    String? _findNpuModel() {
+      final candidates = <String>[
+        if (Platform.isWindows)
+          '${Platform.environment['USERPROFILE']}\\dev-gemma4-2b-lnl\\gemma4_2b_lnl.litertlm',
+        if (Platform.isLinux || Platform.isMacOS)
+          '${Platform.environment['HOME']}/dev-gemma4-2b-lnl/gemma4_2b_lnl.litertlm',
+      ];
+      for (final p in candidates) {
+        if (File(p).existsSync()) return p;
+      }
+      return null;
+    }
+
+    Future<InferenceModel?> _installAndGetNpu() async {
+      final npuModelPath = _findNpuModel();
+      if (npuModelPath == null) {
+        print('[Gemma4 NPU] SKIP: no NPU-compiled model found');
+        return null;
+      }
+      await FlutterGemma.installModel(
+        modelType: ModelType.gemma4,
+        fileType: ModelFileType.litertlm,
+      ).fromFile(npuModelPath).install();
+      await _closeSharedModel();
       try {
-        model = await FlutterGemma.getActiveModel(
+        return await FlutterGemma.getActiveModel(
           maxTokens: 4096,
           preferredBackend: PreferredBackend.npu,
         );
       } catch (e) {
-        print('[Gemma4 NPU engine_create] SKIP: $e');
-        return;
+        print('[Gemma4 NPU] SKIP engine_create failed: $e');
+        return null;
       }
+    }
+
+    testWidgets('NPU engine_create accepts non-default sampler params',
+        (t) async {
+      final model = await _installAndGetNpu();
+      if (model == null) return;
       final session = await model.createSession(
         // Non-default sampler params — these MUST be ignored on NPU.
         temperature: 0.5,
@@ -480,37 +508,28 @@ void main() {
         topP: 0.75,
       );
       await session.addQueryChunk(
-          const Message(text: 'Say hello in one word', isUser: true));
+          const Message(text: 'What is the capital of France?', isUser: true));
       final out = await session.getResponse();
       print('[Gemma4 NPU engine_create] $out');
       expect(out, isNotEmpty);
+      // Paris should appear in any sensible answer.
+      expect(out.toLowerCase().contains('paris'), isTrue,
+          reason: 'NPU should produce a coherent answer about France\'s capital');
       await session.close();
       await model.close();
     });
 
     testWidgets('NPU generation is deterministic (greedy ignores seed)',
         (t) async {
-      // Run the same prompt twice with different seeds; on NPU the output
-      // should be byte-identical because seed has no effect — engine uses
-      // internal greedy sampling. On CPU/GPU this assertion would fail
-      // because seed actually changes TopP sampling.
-      late InferenceModel model;
-      try {
-        model = await FlutterGemma.getActiveModel(
-          maxTokens: 4096,
-          preferredBackend: PreferredBackend.npu,
-        );
-      } catch (e) {
-        print('[Gemma4 NPU determinism] SKIP: $e');
-        return;
-      }
-      final s1 = await model.createSession(temperature: 0.8, randomSeed:1);
+      final model = await _installAndGetNpu();
+      if (model == null) return;
+      final s1 = await model.createSession(temperature: 0.8, randomSeed: 1);
       await s1.addQueryChunk(
           const Message(text: 'List three colors', isUser: true));
       final r1 = await s1.getResponse();
       await s1.close();
 
-      final s2 = await model.createSession(temperature: 0.8, randomSeed:99999);
+      final s2 = await model.createSession(temperature: 0.8, randomSeed: 99999);
       await s2.addQueryChunk(
           const Message(text: 'List three colors', isUser: true));
       final r2 = await s2.getResponse();

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -435,4 +435,93 @@ void main() {
       }
     });
   });
+
+  // ── Gemma4 NPU: 0.15.1 sampler-skip behaviour ────────────────────
+  //
+  // LiteRT-LM NPU executor only supports internal greedy sampling. As of
+  // 0.15.1 we skip the sampler-params setter chain when backend == 'npu'
+  // (lib/core/ffi/litert_lm_client.dart::createConversation). These tests
+  // verify the path end-to-end: engine creates successfully with NPU
+  // backend even when caller passes non-default temperature/topK/topP, and
+  // generation is deterministic (same prompt → identical output across
+  // runs, regardless of seed/temperature).
+  //
+  // Platforms covered:
+  //   - Android with .litertlm NPU executor (Pixel 8 / API 31+ with
+  //     NNAPI accelerator that exposes "npu" backend tag)
+  //   - Windows with Intel dispatch DLLs (Lunar Lake / PantherLake — once
+  //     Matt + Intel partner deliver the bundle in 0.15.1 RC)
+  // Other platforms (macOS/iOS/Linux/Web): skipped — no NPU dispatch.
+  group('Gemma4-E2B NPU', () {
+    tearDownAll(_closeSharedModel);
+
+    testWidgets('NPU engine_create accepts non-default sampler params',
+        (t) async {
+      // Direct integration: select PreferredBackend.npu. If platform lacks
+      // NPU dispatch the engine_create throws — we catch + SKIP. If it
+      // succeeds, Phase 3 sampler-skip kept engine_create from rejecting
+      // the call.
+      late InferenceModel model;
+      try {
+        model = await FlutterGemma.getActiveModel(
+          maxTokens: 4096,
+          preferredBackend: PreferredBackend.npu,
+        );
+      } catch (e) {
+        print('[Gemma4 NPU engine_create] SKIP: $e');
+        return;
+      }
+      final session = await model.createSession(
+        // Non-default sampler params — these MUST be ignored on NPU.
+        temperature: 0.5,
+        topK: 20,
+        topP: 0.75,
+      );
+      await session.addQueryChunk(
+          const Message(text: 'Say hello in one word', isUser: true));
+      final out = await session.getResponse();
+      print('[Gemma4 NPU engine_create] $out');
+      expect(out, isNotEmpty);
+      await session.close();
+      await model.close();
+    });
+
+    testWidgets('NPU generation is deterministic (greedy ignores seed)',
+        (t) async {
+      // Run the same prompt twice with different seeds; on NPU the output
+      // should be byte-identical because seed has no effect — engine uses
+      // internal greedy sampling. On CPU/GPU this assertion would fail
+      // because seed actually changes TopP sampling.
+      late InferenceModel model;
+      try {
+        model = await FlutterGemma.getActiveModel(
+          maxTokens: 4096,
+          preferredBackend: PreferredBackend.npu,
+        );
+      } catch (e) {
+        print('[Gemma4 NPU determinism] SKIP: $e');
+        return;
+      }
+      final s1 = await model.createSession(temperature: 0.8, randomSeed:1);
+      await s1.addQueryChunk(
+          const Message(text: 'List three colors', isUser: true));
+      final r1 = await s1.getResponse();
+      await s1.close();
+
+      final s2 = await model.createSession(temperature: 0.8, randomSeed:99999);
+      await s2.addQueryChunk(
+          const Message(text: 'List three colors', isUser: true));
+      final r2 = await s2.getResponse();
+      await s2.close();
+
+      await model.close();
+
+      print('[Gemma4 NPU det run1] $r1');
+      print('[Gemma4 NPU det run2] $r2');
+      expect(r1, isNotEmpty);
+      expect(r2, isNotEmpty);
+      expect(r1, equals(r2),
+          reason: 'NPU should ignore seed and produce deterministic output');
+    });
+  });
 }

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/model.dart';
 
 // ── Model URLs (for iOS download, macOS/Android use local files) ──
@@ -537,55 +538,46 @@ void main() {
   // Mobile (Android, iOS) skips this group entirely — Documents is
   // sandboxed there and never cloud-synced.
   group('Desktop storage path (#179)', () {
-    testWidgets('fromNetwork install lands in Application Support, not Documents',
-        (t) async {
+    testWidgets('getTargetPath resolves into Application Support', (t) async {
       if (Platform.isAndroid || Platform.isIOS) {
         print('[Desktop storage] SKIP: mobile path unchanged');
         return;
       }
 
-      // Use Gemma3-1B (584 MB) — faster than full Gemma 4 for path check.
-      const url =
-          'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm';
-      const filename = 'Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm';
+      // No install required — we just inspect what path the plugin would
+      // hand back for a synthetic filename. This is the exact call site
+      // that NetworkSourceHandler / fromNetwork uses to decide where to
+      // write the downloaded bytes (and that getActiveModel uses to
+      // locate the model file at inference time).
+      //
+      // Routing through ServiceRegistry mirrors the plugin's own
+      // dependency-injection order, so we exercise the production path,
+      // not a hand-rolled instance.
+      final fs = ServiceRegistry.instance.fileSystemService;
+      final filename = 'storage_path_probe_${DateTime.now().millisecondsSinceEpoch}.litertlm';
+      final resolved = await fs.getTargetPath(filename);
 
-      await FlutterGemma.installModel(
-        modelType: ModelType.gemmaIt,
-        fileType: ModelFileType.litertlm,
-      ).fromNetwork(url, token: _token).install();
-
-      // Plugin's getTargetPath now resolves through Application Support
-      // on desktop. Use path_provider directly to compute the expected
-      // root and assert the actual model lives there.
       final supportDir = await getApplicationSupportDirectory();
-      final expectedDir = Directory(
-          '${supportDir.path}${Platform.pathSeparator}flutter_gemma');
-      final expectedPath =
-          '${expectedDir.path}${Platform.pathSeparator}$filename';
-
-      final exists = await File(expectedPath).exists();
-      final size = exists ? await File(expectedPath).length() : 0;
-
-      print('[Desktop storage] Application Support: ${supportDir.path}');
-      print('[Desktop storage] Expected: $expectedPath');
-      print('[Desktop storage] Exists: $exists, size: $size bytes');
-
-      // Also check: file is NOT additionally landing in Documents
-      // (legacy path). It's fine if Documents already has an old copy
-      // (read-from-both fallback), but a fresh install should not be
-      // creating a new one there.
       final docsDir = await getApplicationDocumentsDirectory();
-      final docsPath =
-          '${docsDir.path}${Platform.pathSeparator}$filename';
-      final docsExists = await File(docsPath).exists();
-      print('[Desktop storage] Documents path: $docsPath');
-      print('[Desktop storage] In Documents (legacy): $docsExists');
 
-      expect(exists, isTrue,
-          reason: 'Model should be installed under Application Support, '
-              'not Documents (#179 fix). Expected path: $expectedPath');
-      expect(size, greaterThan(500 * 1024 * 1024),
-          reason: 'Downloaded file should be at least 500 MB (Gemma3-1B is ~584 MB)');
-    }, timeout: const Timeout(Duration(minutes: 30)));
+      print('[Desktop storage] Application Support root: ${supportDir.path}');
+      print('[Desktop storage] Documents root:           ${docsDir.path}');
+      print('[Desktop storage] Resolved target path:     $resolved');
+
+      // Phase 5 contract: write path lives under Application Support
+      // (and namespaced under flutter_gemma/) on Windows/macOS/Linux.
+      expect(resolved.startsWith(supportDir.path), isTrue,
+          reason: 'Phase 5 fix (#179): desktop fromNetwork should write into '
+              'Application Support, got: $resolved');
+      expect(resolved.contains('flutter_gemma'), isTrue,
+          reason: 'Path should be namespaced under flutter_gemma/');
+
+      // And it should NOT land directly under Documents (where 0.15.0
+      // and earlier put it). docsDir + filename would be the legacy
+      // bare-Documents path we explicitly moved away from.
+      final legacyBare = '${docsDir.path}${Platform.pathSeparator}$filename';
+      expect(resolved, isNot(equals(legacyBare)),
+          reason: 'Path must not be the legacy Documents/$filename');
+    });
   });
 }

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -557,24 +557,36 @@ void main() {
       final filename = 'storage_path_probe_${DateTime.now().millisecondsSinceEpoch}.litertlm';
       final resolved = await fs.getTargetPath(filename);
 
-      final supportDir = await getApplicationSupportDirectory();
       final docsDir = await getApplicationDocumentsDirectory();
+      final supportDir = await getApplicationSupportDirectory();
+      final localAppData = Platform.environment['LOCALAPPDATA'];
 
-      print('[Desktop storage] Application Support root: ${supportDir.path}');
       print('[Desktop storage] Documents root:           ${docsDir.path}');
+      print('[Desktop storage] Application Support root: ${supportDir.path}');
+      print('[Desktop storage] LOCALAPPDATA env:         $localAppData');
       print('[Desktop storage] Resolved target path:     $resolved');
 
-      // Phase 5 contract: write path lives under Application Support
-      // (and namespaced under flutter_gemma/) on Windows/macOS/Linux.
-      expect(resolved.startsWith(supportDir.path), isTrue,
-          reason: 'Phase 5 fix (#179): desktop fromNetwork should write into '
-              'Application Support, got: $resolved');
+      // Phase 5 contract:
+      //   - Windows: under %LOCALAPPDATA%\flutter_gemma\ (truly local,
+      //     never OneDrive- or Domain-synced).
+      //   - macOS/Linux: under getApplicationSupportDirectory()/flutter_gemma/.
+      if (Platform.isWindows) {
+        expect(localAppData, isNotNull,
+            reason: 'LOCALAPPDATA env var must be set on Windows');
+        expect(resolved.startsWith(localAppData!), isTrue,
+            reason: 'Phase 5 fix (#179): Windows path must be under '
+                'LOCALAPPDATA ($localAppData), got: $resolved');
+      } else {
+        // macOS, Linux
+        expect(resolved.startsWith(supportDir.path), isTrue,
+            reason: 'Phase 5 fix (#179): macOS/Linux path must be under '
+                'Application Support (${supportDir.path}), got: $resolved');
+      }
       expect(resolved.contains('flutter_gemma'), isTrue,
           reason: 'Path should be namespaced under flutter_gemma/');
 
-      // And it should NOT land directly under Documents (where 0.15.0
-      // and earlier put it). docsDir + filename would be the legacy
-      // bare-Documents path we explicitly moved away from.
+      // It should NOT land directly under Documents (where 0.15.0 and
+      // earlier put it).
       final legacyBare = '${docsDir.path}${Platform.pathSeparator}$filename';
       expect(resolved, isNot(equals(legacyBare)),
           reason: 'Path must not be the legacy Documents/$filename');

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -13,6 +13,7 @@ import 'dart:typed_data';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma/core/model.dart';
 
@@ -523,5 +524,68 @@ void main() {
       expect(r1, equals(r2),
           reason: 'NPU should ignore seed and produce deterministic output');
     });
+  });
+
+  // ── Desktop storage path verification (#179) ─────────────────────
+  //
+  // Verifies Phase 5 of 0.15.1: on Windows / macOS / Linux, fromNetwork
+  // installs land under getApplicationSupportDirectory() (Application
+  // Support / LOCALAPPDATA / XDG_DATA_HOME), NOT in the user's Documents
+  // folder which is commonly cloud-synced (OneDrive, iCloud, Dropbox)
+  // and breaks FFI mmap on large model files.
+  //
+  // Mobile (Android, iOS) skips this group entirely — Documents is
+  // sandboxed there and never cloud-synced.
+  group('Desktop storage path (#179)', () {
+    testWidgets('fromNetwork install lands in Application Support, not Documents',
+        (t) async {
+      if (Platform.isAndroid || Platform.isIOS) {
+        print('[Desktop storage] SKIP: mobile path unchanged');
+        return;
+      }
+
+      // Use Gemma3-1B (584 MB) — faster than full Gemma 4 for path check.
+      const url =
+          'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm';
+      const filename = 'Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm';
+
+      await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromNetwork(url, token: _token).install();
+
+      // Plugin's getTargetPath now resolves through Application Support
+      // on desktop. Use path_provider directly to compute the expected
+      // root and assert the actual model lives there.
+      final supportDir = await getApplicationSupportDirectory();
+      final expectedDir = Directory(
+          '${supportDir.path}${Platform.pathSeparator}flutter_gemma');
+      final expectedPath =
+          '${expectedDir.path}${Platform.pathSeparator}$filename';
+
+      final exists = await File(expectedPath).exists();
+      final size = exists ? await File(expectedPath).length() : 0;
+
+      print('[Desktop storage] Application Support: ${supportDir.path}');
+      print('[Desktop storage] Expected: $expectedPath');
+      print('[Desktop storage] Exists: $exists, size: $size bytes');
+
+      // Also check: file is NOT additionally landing in Documents
+      // (legacy path). It's fine if Documents already has an old copy
+      // (read-from-both fallback), but a fresh install should not be
+      // creating a new one there.
+      final docsDir = await getApplicationDocumentsDirectory();
+      final docsPath =
+          '${docsDir.path}${Platform.pathSeparator}$filename';
+      final docsExists = await File(docsPath).exists();
+      print('[Desktop storage] Documents path: $docsPath');
+      print('[Desktop storage] In Documents (legacy): $docsExists');
+
+      expect(exists, isTrue,
+          reason: 'Model should be installed under Application Support, '
+              'not Documents (#179 fix). Expected path: $expectedPath');
+      expect(size, greaterThan(500 * 1024 * 1024),
+          reason: 'Downloaded file should be at least 500 MB (Gemma3-1B is ~584 MB)');
+    }, timeout: const Timeout(Duration(minutes: 30)));
   });
 }

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -9,12 +9,15 @@ const _mainLibName = 'LiteRtLm';
 
 /// LiteRT-LM native library version and release info.
 ///
-/// 0.11.0-a is a fresh build from upstream LiteRT-LM v0.11.0 (Multi-Token
-/// Prediction support). Same optimization flags as 0.10.2-b: `-c opt
-/// --strip=always` (Bazel) + MSVC `/OPT:REF /OPT:ICF` (Windows).
+/// 0.11.0-b adds Intel NPU dispatch bundling to the Windows tarball
+/// (LiteRtDispatch.dll + OpenVino runtime + TBB, 12 extra DLLs) to enable
+/// `PreferredBackend.npu` on Intel LunarLake-class chips. Windows built
+/// from LiteRT-LM commit 62f7a8e (ABI-compatible with Intel NPU dispatch);
+/// other 6 platforms unchanged from -a (032334d). Same optimization flags:
+/// `-c opt --strip=always` (Bazel) + MSVC `/OPT:REF /OPT:ICF` (Windows).
 /// Apple: vtool minos 26.2 → 16.0 patch on libGemmaModelConstraintProvider
 /// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
-const _nativeVersion = '0.11.0-a';
+const _nativeVersion = '0.11.0-b';
 const _releaseTag = 'native-v$_nativeVersion';
 const _releaseBase =
     'https://github.com/DenisovAV/flutter_gemma/releases/download/$_releaseTag';
@@ -27,7 +30,7 @@ const _checksums = <String, String>{
   'litertlm-linux_arm64.tar.gz':
       'bab26bf420316ef2f4037ffced1470a18cbb6ee6cda069fc0ae8a5f8eb882bfb',
   'litertlm-windows_x86_64.tar.gz':
-      'cde4b0bc871668cb2c91437e213c33e66dc2739394eef9ea7a3da0397f3e3b5c',
+      '6e77c52d2a591f89fb42da517b0d1a4fe9bb8aa07690e2f15d2da6f8e0d1a4d8',
   'litertlm-macos_arm64.tar.gz':
       'fa3138c9f97b6ba3c19f620c29439207d38566598fff06cc55ff115ade17f8e8',
   'litertlm-ios_arm64.tar.gz':
@@ -483,7 +486,31 @@ void main(List<String> args) async {
       // it tries to compile compute shaders for the LLM kernels.
       // Sourced from microsoft/DirectXShaderCompiler GitHub releases.
       const windowsDxc = ['dxil', 'dxcompiler'];
-      for (final name in [...windowsLibPrefixed, ...windowsDxc]) {
+      // Intel NPU dispatch — required for PreferredBackend.npu on
+      // LunarLake / PantherLake-class Intel chips. LiteRtDispatch.dll is
+      // the entry point; OpenVino runtime + TBB are loaded transitively
+      // at dispatch initialization. ~30 MB combined. Absent dispatch on
+      // non-Intel hardware just means engine_create returns a dispatch
+      // error — model still loads on CPU / GPU.
+      const windowsIntelNpu = [
+        'LiteRtDispatch',
+        'openvino',
+        'openvino_intel_npu_plugin',
+        'openvino_tensorflow_lite_frontend',
+        'tbb12',
+        'tbb12_debug',
+        'tbbbind_2_5',
+        'tbbbind_2_5_debug',
+        'tbbmalloc',
+        'tbbmalloc_debug',
+        'tbbmalloc_proxy',
+        'tbbmalloc_proxy_debug',
+      ];
+      for (final name in [
+        ...windowsLibPrefixed,
+        ...windowsDxc,
+        ...windowsIntelNpu,
+      ]) {
         final fileName = os.dylibFileName(name);
         final fileUri = prebuiltDir.resolve(fileName);
         if (File.fromUri(fileUri).existsSync()) {

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -30,7 +30,7 @@ const _checksums = <String, String>{
   'litertlm-linux_arm64.tar.gz':
       'bab26bf420316ef2f4037ffced1470a18cbb6ee6cda069fc0ae8a5f8eb882bfb',
   'litertlm-windows_x86_64.tar.gz':
-      '6e77c52d2a591f89fb42da517b0d1a4fe9bb8aa07690e2f15d2da6f8e0d1a4d8',
+      '2291db8d4cc104d695b589a179ef04f0c955f906264d625ed4f16babe13d952e',
   'litertlm-macos_arm64.tar.gz':
       'fa3138c9f97b6ba3c19f620c29439207d38566598fff06cc55ff115ade17f8e8',
   'litertlm-ios_arm64.tar.gz':

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.15.0'
+  s.version          = '0.15.1'
   s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
   s.description      = <<-DESC
 The plugin allows running the Gemma AI model locally on a device from a Flutter application.

--- a/lib/core/ffi/litert_lm_bindings.dart
+++ b/lib/core/ffi/litert_lm_bindings.dart
@@ -388,6 +388,58 @@ class LiteRtLmBindings {
       _litert_lm_engine_settings_set_enable_speculative_decodingPtr.asFunction<
           void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)>();
 
+  /// Set the directory where LiteRT dispatch libraries (NPU dispatch
+  /// `LiteRtDispatch.dll`, accelerator plugins) live. Required on Windows
+  /// for `PreferredBackend.npu` — without it the dispatch lookup reads
+  /// uninitialized env option memory and engine_create crashes.
+  /// Caller passes the absolute path to the directory containing
+  /// `LiteRtDispatch.dll` (usually the same dir as `LiteRtLm.dll`).
+  void litert_lm_engine_settings_set_litert_dispatch_lib_dir(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    ffi.Pointer<ffi.Char> lib_dir,
+  ) {
+    return _litert_lm_engine_settings_set_litert_dispatch_lib_dir(
+      settings,
+      lib_dir,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_litert_dispatch_lib_dirPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
+                      ffi.Pointer<ffi.Char>)>>(
+          'litert_lm_engine_settings_set_litert_dispatch_lib_dir');
+  late final _litert_lm_engine_settings_set_litert_dispatch_lib_dir =
+      _litert_lm_engine_settings_set_litert_dispatch_lib_dirPtr.asFunction<
+          void Function(
+              ffi.Pointer<LiteRtLmEngineSettings>, ffi.Pointer<ffi.Char>)>();
+
+  /// Disable NPU hardware mask update path. Required on Intel preview NPU
+  /// silicon (LunarLake / PantherLake) where the default `kWH`
+  /// (Write-Hardware) mask update method is not fully supported and causes
+  /// engine_create to crash. Pass `false` to force CPU/SIMD fallback.
+  /// Patched into our C API (not in upstream LiteRT-LM 0.11.0 C API).
+  void litert_lm_engine_settings_set_use_hw_masking_for_npu(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    bool value,
+  ) {
+    return _litert_lm_engine_settings_set_use_hw_masking_for_npu(
+      settings,
+      value,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_use_hw_masking_for_npuPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
+                      ffi.Bool)>>(
+          'litert_lm_engine_settings_set_use_hw_masking_for_npu');
+  late final _litert_lm_engine_settings_set_use_hw_masking_for_npu =
+      _litert_lm_engine_settings_set_use_hw_masking_for_npuPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)>();
+
   ffi.Pointer<LiteRtLmEngine> litert_lm_engine_create(
     ffi.Pointer<LiteRtLmEngineSettings> settings,
   ) {

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -45,6 +45,7 @@ class LiteRtLmFfiClient {
   Pointer<LiteRtLmConversation>? _conversation;
   bool _isInitialized = false;
   String? _nativeLogPath;
+  String? _backend;
 
   /// Reads back the native log file (set by stream_proxy_redirect_stderr) and
   /// pipes its contents through debugPrint in 800-char chunks. Surfaces
@@ -286,6 +287,7 @@ class LiteRtLmFfiClient {
   }) async {
     final initSw = Stopwatch()..start();
     _ensureBindings();
+    _backend = backend;
     final bindingsMs = initSw.elapsedMilliseconds;
     debugPrint('[LiteRtLmFfi/perf] _ensureBindings: ${bindingsMs}ms');
     final b = _bindings!;
@@ -434,19 +436,30 @@ class LiteRtLmFfiClient {
     // native/litert_lm/patch_c_api.sh ("PATCH: 6-arg overload").
     final sessionConfig = b.litert_lm_session_config_create();
 
-    final samplerParams = calloc<LiteRtLmSamplerParams>();
-    // Upstream LiteRT-LM (commit 5e0d86b) only implements TopP sampling at
-    // engine level — sampler type 1 (TopK) and 3 (Greedy) are rejected with
-    // "UNIMPLEMENTED: Sampler type: N not implemented yet." Use TopP (=2)
-    // unconditionally and pass top_k as a hint; native respects both fields
-    // even though it's gated by the type tag.
-    samplerParams.ref.typeAsInt = 2; // always TopP
-    samplerParams.ref.top_k = topK;
-    samplerParams.ref.top_p = topP ?? 0.95;
-    samplerParams.ref.temperature = temperature;
-    samplerParams.ref.seed = seed;
-    b.litert_lm_session_config_set_sampler_params(sessionConfig, samplerParams);
-    calloc.free(samplerParams);
+    // NPU executor on LiteRT-LM only supports internal greedy sampling — any
+    // sampler params we pass cause engine_create / generation failures
+    // upstream. Skip the setter chain in that case; CPU/GPU paths are
+    // unaffected.
+    if (_backend != 'npu') {
+      final samplerParams = calloc<LiteRtLmSamplerParams>();
+      // Upstream LiteRT-LM (commit 5e0d86b) only implements TopP sampling at
+      // engine level — sampler type 1 (TopK) and 3 (Greedy) are rejected with
+      // "UNIMPLEMENTED: Sampler type: N not implemented yet." Use TopP (=2)
+      // unconditionally and pass top_k as a hint; native respects both fields
+      // even though it's gated by the type tag.
+      samplerParams.ref.typeAsInt = 2; // always TopP
+      samplerParams.ref.top_k = topK;
+      samplerParams.ref.top_p = topP ?? 0.95;
+      samplerParams.ref.temperature = temperature;
+      samplerParams.ref.seed = seed;
+      b.litert_lm_session_config_set_sampler_params(
+          sessionConfig, samplerParams);
+      calloc.free(samplerParams);
+    } else {
+      debugPrint('[LiteRtLmFfi] NPU backend — sampler params '
+          '(temperature, topK, topP, seed) ignored, engine uses '
+          'internal greedy sampling.');
+    }
 
     final systemPtr = systemMessage?.toNativeUtf8();
     final toolsPtr = toolsJson?.toNativeUtf8();
@@ -735,6 +748,7 @@ class LiteRtLmFfiClient {
     }
 
     _isInitialized = false;
+    _backend = null;
   }
 
   /// Get session metrics from current conversation including token usage.

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -338,6 +338,26 @@ class LiteRtLmFfiClient {
             settings, enableSpeculativeDecoding);
       }
 
+      // Windows NPU: point LiteRT at the directory containing
+      // `LiteRtDispatch.dll` and disable HW mask update path. Native Assets
+      // bundles both DLLs next to the executable, so resolvedExecutable.parent
+      // is the right path. Without `dispatch_lib_dir` LiteRT reads
+      // uninitialized env-option memory and engine_create crashes; without
+      // `use_hw_masking_for_npu(false)` LiteRT sets up the kWH HW mask method
+      // which Intel preview NPU (LunarLake/PantherLake) doesn't fully support
+      // → CFG check failure 0xc0000409 (per Matt Kreileder's Intel NPU
+      // pipeline instructions).
+      if (Platform.isWindows && backend == 'npu') {
+        final exeDir = File(Platform.resolvedExecutable).parent.path;
+        final dirPtr = exeDir.toNativeUtf8();
+        b.litert_lm_engine_settings_set_litert_dispatch_lib_dir(
+            settings, dirPtr.cast());
+        calloc.free(dirPtr);
+        b.litert_lm_engine_settings_set_use_hw_masking_for_npu(settings, false);
+        debugPrint(
+            '[LiteRtLmFfi] NPU Windows: dispatch_lib_dir=$exeDir, use_hw_masking_for_npu=false');
+      }
+
       // Create engine in a background isolate to avoid blocking UI.
       // Pass settings pointer as int address (Pointer can't cross isolates).
       debugPrint(

--- a/lib/core/ffi/litert_lm_client_stub.dart
+++ b/lib/core/ffi/litert_lm_client_stub.dart
@@ -19,6 +19,7 @@ class LiteRtLmFfiClient {
     bool enableVision = false,
     int maxNumImages = 0,
     bool enableAudio = false,
+    bool? enableSpeculativeDecoding,
   }) =>
       throw UnsupportedError('web stub — never instantiated');
 }

--- a/lib/core/infrastructure/platform_file_system_service.dart
+++ b/lib/core/infrastructure/platform_file_system_service.dart
@@ -69,7 +69,22 @@ class PlatformFileSystemService implements FileSystemService {
   @override
   Future<String> getTargetPath(String filename) async {
     final dir = await _getDocumentsDirectory();
-    return path.join(dir.path, filename);
+    final newPath = path.join(dir.path, filename);
+
+    // Backward-compat: if model file isn't in the new location but exists
+    // in pre-0.15.1 Documents (where desktop stored everything before the
+    // OneDrive/iCloud-sync fix), keep using that path so existing installs
+    // don't break on upgrade. Writes always go to the new location.
+    if (!kIsWeb &&
+        (Platform.isWindows || Platform.isMacOS || Platform.isLinux) &&
+        !await File(newPath).exists()) {
+      final legacy = await getApplicationDocumentsDirectory();
+      final legacyPath = path.join(legacy.path, filename);
+      if (await File(legacyPath).exists()) {
+        return legacyPath;
+      }
+    }
+    return newPath;
   }
 
   @override
@@ -134,7 +149,14 @@ class PlatformFileSystemService implements FileSystemService {
     // The actual tracking is done in ProtectedFilesRegistry.registerExternalPath()
   }
 
-  /// Gets the app documents directory with caching
+  /// Gets the model storage directory with caching.
+  ///
+  /// Mobile (Android, iOS): app's Documents — sandboxed, never cloud-synced.
+  /// Desktop (Windows, macOS, Linux): Application Support — picked because
+  /// Documents on these platforms is commonly cloud-virtualized (OneDrive on
+  /// Windows, iCloud on macOS, Dropbox/GNOME Online Accounts on Linux) and
+  /// JNI/FFI mmap of >2 GB model files breaks against placeholder cloud
+  /// paths. Falls back to Documents if Application Support is unavailable.
   Future<Directory> _getDocumentsDirectory() async {
     // Web doesn't support local file system
     if (kIsWeb) {
@@ -145,7 +167,20 @@ class PlatformFileSystemService implements FileSystemService {
       return _documentsDirectory!;
     }
 
-    _documentsDirectory = await getApplicationDocumentsDirectory();
+    final base = Platform.isAndroid || Platform.isIOS
+        ? await getApplicationDocumentsDirectory()
+        : await getApplicationSupportDirectory();
+
+    // Namespace under flutter_gemma/ on desktop to keep models out of the
+    // top-level Application Support directory.
+    final dir = Platform.isAndroid || Platform.isIOS
+        ? base
+        : Directory(path.join(base.path, 'flutter_gemma'));
+
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    _documentsDirectory = dir;
     return _documentsDirectory!;
   }
 }

--- a/lib/core/infrastructure/platform_file_system_service.dart
+++ b/lib/core/infrastructure/platform_file_system_service.dart
@@ -152,11 +152,14 @@ class PlatformFileSystemService implements FileSystemService {
   /// Gets the model storage directory with caching.
   ///
   /// Mobile (Android, iOS): app's Documents — sandboxed, never cloud-synced.
-  /// Desktop (Windows, macOS, Linux): Application Support — picked because
-  /// Documents on these platforms is commonly cloud-virtualized (OneDrive on
-  /// Windows, iCloud on macOS, Dropbox/GNOME Online Accounts on Linux) and
-  /// JNI/FFI mmap of >2 GB model files breaks against placeholder cloud
-  /// paths. Falls back to Documents if Application Support is unavailable.
+  /// Desktop:
+  ///   - Windows: `%LOCALAPPDATA%\flutter_gemma\` — truly local, never
+  ///     OneDrive-synced (unlike Documents or Roaming AppData). NOTE:
+  ///     path_provider's `getApplicationSupportDirectory()` returns
+  ///     `%APPDATA%` (Roaming) which is Domain-synced in corporate envs,
+  ///     so we use LOCALAPPDATA directly via env var.
+  ///   - macOS/Linux: `getApplicationSupportDirectory()` — not cloud-synced
+  ///     by default.
   Future<Directory> _getDocumentsDirectory() async {
     // Web doesn't support local file system
     if (kIsWeb) {
@@ -167,15 +170,24 @@ class PlatformFileSystemService implements FileSystemService {
       return _documentsDirectory!;
     }
 
-    final base = Platform.isAndroid || Platform.isIOS
-        ? await getApplicationDocumentsDirectory()
-        : await getApplicationSupportDirectory();
-
-    // Namespace under flutter_gemma/ on desktop to keep models out of the
-    // top-level Application Support directory.
-    final dir = Platform.isAndroid || Platform.isIOS
-        ? base
-        : Directory(path.join(base.path, 'flutter_gemma'));
+    final Directory dir;
+    if (Platform.isAndroid || Platform.isIOS) {
+      dir = await getApplicationDocumentsDirectory();
+    } else if (Platform.isWindows) {
+      // LOCALAPPDATA is set by Windows for every user session. Fall back
+      // to the Roaming Application Support if it is somehow unset (very
+      // unusual but possible in stripped-down environments).
+      final local = Platform.environment['LOCALAPPDATA'];
+      final base = local != null && local.isNotEmpty
+          ? Directory(local)
+          : await getApplicationSupportDirectory();
+      dir = Directory(path.join(base.path, 'flutter_gemma'));
+    } else {
+      // macOS, Linux — namespace under flutter_gemma/ inside Application
+      // Support so models don't pollute the package root.
+      final base = await getApplicationSupportDirectory();
+      dir = Directory(path.join(base.path, 'flutter_gemma'));
+    }
 
     if (!await dir.exists()) {
       await dir.create(recursive: true);

--- a/native/litert_lm/build_android.sh
+++ b/native/litert_lm/build_android.sh
@@ -164,6 +164,36 @@ for lib in libGemmaModelConstraintProvider.so \
   fi
 done
 
+# 8b. Patch sampler libs with DT_NEEDED libLiteRtLm.so. Bionic per-library
+#     linker namespaces (Nougat+) only resolve UND symbols against the
+#     caller's DT_NEEDED chain, NOT against arbitrary libs already loaded
+#     in the process. Upstream samplers reference LiteRtCreateEnvironment
+#     as UND but ship with NEEDED list containing only libm/libdl/liblog/
+#     libc — so dlopen fails at runtime and the engine silently falls back
+#     to CPU sampling (~3× decode slowdown). Adding libLiteRtLm.so to
+#     NEEDED on each sampler binary lets bionic resolve LiteRtCreateEnvironment
+#     against our libLiteRtLm.so (which exports it). See:
+#       - DenisovAV/flutter_gemma#270
+#       - google-ai-edge/LiteRT-LM#2211
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "WARN: patchelf not installed — skipping DT_NEEDED fix for samplers"
+  echo "      Install with: brew install patchelf"
+else
+  echo ""
+  echo "=== Patching sampler DT_NEEDED (#270) ==="
+  for lib in libLiteRtTopKOpenClSampler.so libLiteRtTopKWebGpuSampler.so; do
+    if [ -f "$PREBUILT_DIR/$lib" ]; then
+      # Idempotent: only add if not already present.
+      if ! patchelf --print-needed "$PREBUILT_DIR/$lib" | grep -q '^libLiteRtLm\.so$'; then
+        patchelf --add-needed libLiteRtLm.so "$PREBUILT_DIR/$lib"
+        echo "  $lib: added libLiteRtLm.so to NEEDED"
+      else
+        echo "  $lib: libLiteRtLm.so already in NEEDED, skipping"
+      fi
+    fi
+  done
+fi
+
 # 9. Verify
 echo ""
 echo "=== Verification ==="

--- a/native/litert_lm/patch_c_api.sh
+++ b/native/litert_lm/patch_c_api.sh
@@ -264,8 +264,8 @@ void litert_lm_engine_settings_set_use_hw_masking_for_npu(\
     LiteRtLmEngineSettings* settings, bool value) {\
   if (settings \&\& settings->settings) {\
     auto\& exec = settings->settings->GetMutableMainExecutorSettings();\
-    NpuConfig config;\
-    auto current = exec.GetBackendConfig<NpuConfig>();\
+    litert::lm::NpuConfig config;\
+    auto current = exec.GetBackendConfig<litert::lm::NpuConfig>();\
     if (current.ok()) {\
       config = *current;\
     }\

--- a/native/litert_lm/patch_c_api.sh
+++ b/native/litert_lm/patch_c_api.sh
@@ -63,12 +63,15 @@ EXPORTS
   litert_lm_engine_settings_enable_benchmark
   litert_lm_engine_settings_set_activation_data_type
   litert_lm_engine_settings_set_cache_dir
+  litert_lm_engine_settings_set_enable_speculative_decoding
+  litert_lm_engine_settings_set_litert_dispatch_lib_dir
   litert_lm_engine_settings_set_max_num_images
   litert_lm_engine_settings_set_max_num_tokens
   litert_lm_engine_settings_set_num_decode_tokens
   litert_lm_engine_settings_set_num_prefill_tokens
   litert_lm_engine_settings_set_parallel_file_section_loading
   litert_lm_engine_settings_set_prefill_chunk_size
+  litert_lm_engine_settings_set_use_hw_masking_for_npu
   litert_lm_json_response_delete
   litert_lm_json_response_get_string
   litert_lm_responses_delete
@@ -230,6 +233,51 @@ void litert_lm_engine_settings_set_litert_dispatch_lib_dir(\
   echo "  OK: Added set_litert_dispatch_lib_dir impl to c/engine.cc"
 else
   echo "  SKIP: c/engine.cc already has set_litert_dispatch_lib_dir"
+fi
+
+# ── 4b. Add set_use_hw_masking_for_npu for Intel LunarLake/PantherLake ──
+# Default NpuConfig.use_hw_masking_for_npu=true makes LiteRT setup HW mask
+# update path (MaskUpdateMethod::kWH) which Intel preview NPU silicon
+# doesn't fully support → engine_create crash (CFG / 0xc0000409). Per Matt
+# Kreileder's Intel NPU pipeline instructions, must call with `false` for
+# LunarLake / PantherLake. Upstream C API doesn't expose this — patch in
+# our own setter that writes through NpuConfig variant on main executor.
+if ! grep -q "set_use_hw_masking_for_npu" "$DIR/c/engine.h"; then
+  sed -i.bak '/Creates a LiteRT LM Engine from the given settings/i\
+// Sets whether to use hardware masking for NPU. Default is true which on\
+// Intel LunarLake/PantherLake preview silicon causes engine_create to\
+// crash because the NPU HW mask update path is not fully supported.\
+// Pass false to force CPU/SIMD mask update fallback.\
+LITERT_LM_C_API_EXPORT\
+void litert_lm_engine_settings_set_use_hw_masking_for_npu(\
+    LiteRtLmEngineSettings* settings, bool value);\
+' "$DIR/c/engine.h"
+  rm -f "$DIR/c/engine.h.bak"
+  echo "  OK: Added set_use_hw_masking_for_npu to c/engine.h"
+else
+  echo "  SKIP: c/engine.h already has set_use_hw_masking_for_npu"
+fi
+
+if ! grep -q "set_use_hw_masking_for_npu" "$DIR/c/engine.cc"; then
+  sed -i.bak '/void litert_lm_engine_settings_set_activation_data_type/i\
+void litert_lm_engine_settings_set_use_hw_masking_for_npu(\
+    LiteRtLmEngineSettings* settings, bool value) {\
+  if (settings \&\& settings->settings) {\
+    auto\& exec = settings->settings->GetMutableMainExecutorSettings();\
+    NpuConfig config;\
+    auto current = exec.GetBackendConfig<NpuConfig>();\
+    if (current.ok()) {\
+      config = *current;\
+    }\
+    config.use_hw_masking_for_npu = value;\
+    exec.SetBackendConfig(config);\
+  }\
+}\
+' "$DIR/c/engine.cc"
+  rm -f "$DIR/c/engine.cc.bak"
+  echo "  OK: Added set_use_hw_masking_for_npu impl to c/engine.cc"
+else
+  echo "  SKIP: c/engine.cc already has set_use_hw_masking_for_npu"
 fi
 
 # ── 5. Patch litert_lm_conversation_config_create to 6-arg signature ──

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.15.0
+version: 0.15.1
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 


### PR DESCRIPTION
## Summary

- 🪟 **Windows Intel NPU end-to-end** — `PreferredBackend.npu` on LunarLake/PantherLake. Native bundle ships Intel dispatch + OpenVino + TBB; verified empirically through Flutter SDK on Tiber Cloud LNL VM.
- 🖼️ **Multi-image input, FFI session metrics, prefix replay** (PR #262, thanks @frdteknikelektro)
- 🤖 **Android GPU sampler dlopen fix** (#270, thanks @prithidevghosh) — +15–30% decode speedup on Pixel-class devices
- 💾 **Desktop storage** (#179, co-author @ProjectEdge-Jim) — Application Support / LOCALAPPDATA / XDG_DATA_HOME instead of Documents
- ⚙️ **NPU greedy-only sampler skip** — sampler params silently ignored on `PreferredBackend.npu` (matches LiteRT-LM upstream NPU executor behaviour)
- 🌐 **Web build fix** — `LiteRtLmFfiClient` stub was missing `enableSpeculativeDecoding` (latent 0.15.0 bug)
- 📦 **native-v0.11.0-b** — new Windows tarball (`62f7a8e` LiteRT-LM, 24 DLLs incl Intel NPU bundle); other 6 platforms unchanged from `-a`

## Test plan
- [x] `flutter analyze` — 0 errors (391 pre-existing info lints)
- [x] `flutter test` — 343/343 passed
- [x] `dart pub publish --dry-run` — 0 warnings, 625 KB package
- [x] `flutter build web --no-tree-shake-icons` — built (catches stub drift)
- [x] `flutter build macos --debug`
- [x] `flutter build apk --debug`
- [x] `flutter build ios --no-codesign --debug`
- [x] macOS Metal — Gemma 4 E2B full suite 17/17 (15 tests + 2 NPU skipped)
- [x] Pixel 8 Android 16 — Gemma 4 E2B full suite 17/17
- [x] Windows LunarLake VM (Tiber Cloud) — NPU end-to-end "What is the capital of France?" → "Paris" via `PreferredBackend.npu` through flutter_gemma SDK
- [ ] iPhone spot test — optional, not run

## Issues
- Closes #270 (Android GPU sampler dlopen)
- Closes #179 (Desktop storage, already closed with co-author credit)
- Includes #262 (multi-image, merged earlier into branch)
- Comment posted: #273 (workaround until 0.15.2), #265 (deferred), #264 (deferred to 0.15.2)