### PR TITLE
docs: post-0.15.1 cleanup — audio hint (#267) + stale model refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,18 +44,17 @@
 
 | Model Family | Function Calling | Thinking Mode | Multimodal | Platform Support |
 |--------------|------------------|---------------|------------|------------------|
-| Gemma 4 E2B | ✅ | ✅ ¹ | ✅ | Android, iOS, Web, Desktop |
-| Gemma 4 E4B | ✅ | ✅ ¹ | ✅ | Android, iOS, Web, Desktop |
-| Gemma 3 Nano | ✅ | ❌ | ✅ | Android, iOS, Web |
-| Gemma 3 270M | ❌ | ❌ | ❌ | Android, iOS, Web |
-| Gemma-3 1B | ✅ | ❌ | ❌ | Android, iOS, Web |
-| TinyLlama 1.1B | ❌ | ❌ | ❌ | Android, iOS, Web |
-| Llama 3.2 1B | ❌ | ❌ | ❌ | Android, iOS, Web |
-| Hammer 2.1 0.5B | ✅ | ❌ | ❌ | Android, iOS, Web |
-| DeepSeek | ✅ | ✅ | ❌ | Android, iOS, Web |
-| Qwen3 | ✅ | ✅ ² | ❌ | Android, iOS, Web, Desktop |
-| Qwen2.5 | ✅ | ❌ | ❌ | Android, iOS, Web |
-| Phi-4 | ❌ | ❌ | ❌ | Android, iOS, Web |
+| Gemma 4 E2B/E4B | ✅ | ✅ ¹ | ✅ vision + audio | Android, iOS, Web, Desktop |
+| Gemma3n E2B/E4B | ✅ | ❌ | ✅ vision + audio | Android, iOS, Web, Desktop |
+| Gemma 3 1B | ✅ | ❌ | ❌ | Android, iOS, Web, Desktop |
+| Gemma 3 270M | ❌ | ❌ | ❌ | Android, iOS, Web, Desktop |
+| FastVLM 0.5B | ❌ | ❌ | ✅ vision | Desktop (`.litertlm`) |
+| FunctionGemma 270M | ✅ | ❌ | ❌ | Android, iOS, Desktop |
+| Phi-4 Mini | ✅ | ❌ | ❌ | Android, iOS, Web, Desktop |
+| DeepSeek R1 | ✅ | ✅ | ❌ | Android, iOS |
+| Qwen3 0.6B | ✅ | ✅ ² | ❌ | Android, iOS, Web, Desktop |
+| Qwen 2.5 (0.5B/1.5B) | ✅ | ❌ | ❌ | Android, iOS |
+| SmolLM 135M | ❌ | ❌ | ❌ | Android, iOS |
 
 > ¹ Thinking Mode for Gemma 4: Android, iOS, Desktop only. Web (MediaPipe) does not support `extraContext`.
 > ² Qwen3 generates thinking by default; tags are stripped when `isThinking: false`.

--- a/example/README.md
+++ b/example/README.md
@@ -4,19 +4,19 @@
 
 ### 1. Configure HuggingFace Token (Optional)
 
-⚠️ **Note:** HuggingFace token is required for **Gemma and Meta models only**:
+⚠️ **Note:** HuggingFace token is required for **Google-gated repos only**:
 
-**Token Required (gated repos):**
-- All Gemma models (Gemma 3 Nano, 1B, 270M)
-- All EmbeddingGemma models
-- Llama 3.2 1B, Hammer 2.1 0.5B
+**Token Required (gated):**
+- Gemma3n E2B/E4B (`google/gemma-3n-*`)
+- EmbeddingGemma (all sizes)
 
 **Token NOT Required (public repos):**
-- DeepSeek R1, Phi-4, TinyLlama, Qwen 2.5
-- All Gecko embedding models
-- Local asset models (if you have files)
+- Gemma 4 E2B/E4B, Gemma 3 1B, Gemma 3 270M, FunctionGemma 270M
+- FastVLM, Qwen3, Qwen 2.5, DeepSeek R1, Phi-4 Mini, SmolLM
+- Gecko embedding models
+- Local asset / bundled models
 
-**Most models in the app work without a token!** Configure it only if you need Gemma/Meta models:
+**Most models in the app work without a token!** Configure it only if you need Gemma3n or EmbeddingGemma:
 
 **Step 1:** Copy the config template:
 ```bash

--- a/example/lib/chat_screen.dart
+++ b/example/lib/chat_screen.dart
@@ -502,7 +502,7 @@ class ChatScreenState extends State<ChatScreen> {
                   ),
                 ),
                 Text(
-                  'Use the 🎤 button to record audio messages (Android, Web, Desktop only)',
+                  'Use the 🎤 button to record audio messages',
                   style: TextStyle(
                     color: Colors.white.withValues(alpha: 0.7),
                     fontSize: 12,

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -5,10 +5,13 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
   s.version          = '0.15.1'
-  s.summary          = 'Flutter plugin for running Gemma AI models locally with Gemma 3 Nano support.'
+  s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
-The plugin allows running the Gemma AI model locally on a device from a Flutter application.
-Includes support for Gemma 3 Nano models with optimized MediaPipe GenAI v0.10.33.
+Run Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3, Qwen 2.5, DeepSeek R1,
+Phi-4, FunctionGemma, and SmolLM locally on iOS via MediaPipe GenAI
+(`.task`) or LiteRT-LM (`.litertlm`). Supports multimodal vision +
+audio, function calling, thinking mode, text embeddings, and on-device
+RAG.
                        DESC
   s.homepage         = 'https://github.com/DenisovAV/flutter_gemma'
   s.license          = { :file => '../LICENSE' }


### PR DESCRIPTION
## Summary

- **Audio hint text (#267)** — `chat_screen.dart` claimed audio works on "Android, Web, Desktop only", but iOS device audio works since 0.14.0. Dropped the platform list entirely — `supportAudio` per-model flag is the source of truth.
- **CLAUDE.md model table** — removed non-existent TinyLlama / Llama 3.2 / Hammer 2.1 entries; renamed "Gemma 3 Nano" to canonical "Gemma3n E2B/E4B"; added missing FastVLM, FunctionGemma, SmolLM.
- **example/README.md** — same model-list cleanup; corrected gated-repo list (Gemma3n + EmbeddingGemma only).
- **ios/flutter_gemma.podspec** — dropped "Gemma 3 Nano support" summary and "MediaPipe GenAI v0.10.33" version pin from description.

Closes #267.

## Test plan
- [x] No code changes in plugin — docs + example UI string only
- [x] `grep "Gemma 3 Nano"` across CLAUDE.md / example/README.md / podspec → 0 matches