### PR TITLE
docs: position the plugin as multi-LLM, not Gemma-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@
 
 ## Project Overview
 
-**Flutter Gemma** — multi-platform Flutter plugin for running Google's Gemma AI models locally on devices (Android, iOS, Web, macOS, Windows, Linux). Supports multimodal vision, function calling, thinking mode, GPU acceleration, LoRA weights.
+**Flutter Gemma** — multi-platform Flutter plugin for running Gemma and other on-device LLMs (Qwen, DeepSeek, Phi, FastVLM, SmolLM, …) on Android, iOS, Web, macOS, Windows, Linux. Supports multimodal vision, function calling, thinking mode, GPU acceleration, LoRA weights.
 
 ## Architecture Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://raw.githubusercontent.com/DenisovAV/flutter_gemma/main/assets/gemma3.png" alt="gemma_github_cover">
 </p>
 
-Bring the power of Google's lightweight Gemma language models directly to your Flutter applications. With Flutter Gemma, you can seamlessly incorporate advanced AI capabilities into your Flutter applications, all without relying on external servers.
+Bring the power of Google's lightweight Gemma language models and other on-device LLMs directly to your Flutter applications. With Flutter Gemma, you can seamlessly incorporate advanced AI capabilities into your Flutter applications, all without relying on external servers.
 
 There is an example of using:
 
@@ -27,7 +27,7 @@ There is an example of using:
 
 ## Features
 
-- **Local Execution:** Run Gemma models directly on user devices for enhanced privacy and offline functionality.
+- **Local Execution:** Run Gemma and other LLMs (Qwen, DeepSeek, Phi, FastVLM, SmolLM, …) directly on user devices for enhanced privacy and offline functionality.
 - **Platform Support:** Compatible with iOS, Android, Web, macOS, Windows, and Linux platforms.
 - **🖥️ Desktop Support:** Native desktop apps (macOS, Windows, Linux) with GPU acceleration via LiteRT-LM, called directly from Dart through `dart:ffi` — no JVM/JRE bundling. See [DESKTOP_SUPPORT.md](DESKTOP_SUPPORT.md) for details.
 - **🖼️ Multimodal Support:** Text + Image input with Gemma 4, Gemma3n, and FastVLM vision models


### PR DESCRIPTION
README + CLAUDE.md framed only Gemma in the top-level pitch and Features bullet, but we ship Qwen3, Qwen 2.5, DeepSeek R1, Phi-4 Mini, FastVLM, FunctionGemma, SmolLM alongside Gemma 4 / Gemma3n / Gemma 3.

Three small edits:
- README hero paragraph
- README "Local Execution" Features bullet
- CLAUDE.md project tagline

## Test plan
- [x] Docs only