### PR TITLE
0.15.3: TranslateGemma 4B in example + task-first home (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.15.3
+- example: add TranslateGemma 4B translation demo via task-first home navigation (#177).
+
 ## 0.15.2
 - Unified embedding on LiteRT C API + Dart FFI on all native platforms (#264).
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The example app offers a curated list of models, each suited for different tasks
 | **Gemma 3 270M** | Ideal for fine-tuning (LoRA) for specific tasks | ❌ | ❌ | ❌ | Multilingual | 0.3GB |
 | **FunctionGemma 270M** | Specialized for function calling on-device | ✅ | ❌ | ❌ | Multilingual | 284MB |
 | **SmolLM 135M** | Ultra-compact, resource-constrained devices | ❌ | ❌ | ❌ | English | 135MB |
+| **TranslateGemma 4B** † | Single-shot 55-language translation | ❌ | ❌ | ❌ | 55 languages | 2-4GB |
+
+† **TranslateGemma is CPU-only for now.** Google hasn't released a mobile/desktop `.litertlm` bundle (HF discussion [#5](https://huggingface.co/google/translategemma-4b-it/discussions/5) — "no concrete plans"). The example app uses the community-converted bundle from [`barakplasma/translategemma-4b-it-android-task-quantized`](https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized), which keeps `EMBEDDING_LOOKUP` weights in float32 for MediaPipe `.task` compatibility. That layout crashes the LiteRT GPU partitioner on Metal/WebGPU across all platforms — tracked upstream at [LiteRT-LM#1748](https://github.com/google-ai-edge/LiteRT-LM/issues/1748). Until Google ships the `litert-lm` quantization CLI, translation runs on CPU only (≈90 s prefill on a 4 B int4 bundle on M-series Macs).
 
 ## ModelType Reference
 

--- a/example/integration_test/translate_gemma_smoke_test.dart
+++ b/example/integration_test/translate_gemma_smoke_test.dart
@@ -55,7 +55,9 @@ void main() {
     ).fromFile(modelPath).install();
 
     final model = await FlutterGemma.getActiveModel(
-      maxTokens: 1024,
+      maxTokens: 4096,
+      // GPU partitioner crashes on this bundle's EMBEDDING_LOOKUP —
+      // see translate_model.dart + LiteRT-LM#1748.
       preferredBackend: PreferredBackend.cpu,
     );
 
@@ -103,6 +105,8 @@ void main() {
   }, timeout: const Timeout(Duration(minutes: 10)));
 
   testWidgets('TranslateGemma 4B int4 — streaming yields chunks', (_) async {
+    await FlutterGemma.initialize();
+
     final modelPath = await _docsPath(_modelName);
     await FlutterGemma.installModel(
       modelType: ModelType.gemmaIt,
@@ -110,7 +114,9 @@ void main() {
     ).fromFile(modelPath).install();
 
     final model = await FlutterGemma.getActiveModel(
-      maxTokens: 1024,
+      maxTokens: 4096,
+      // GPU partitioner crashes on this bundle's EMBEDDING_LOOKUP —
+      // see translate_model.dart + LiteRT-LM#1748.
       preferredBackend: PreferredBackend.cpu,
     );
 

--- a/example/integration_test/translate_gemma_smoke_test.dart
+++ b/example/integration_test/translate_gemma_smoke_test.dart
@@ -1,0 +1,141 @@
+// 0.15.3 TranslateGemma 4B smoke test.
+//
+// Exercises `TranslateRunner` end-to-end on the community `.litertlm` int4
+// bundle. The test:
+//   1. Stages the int4 `.litertlm` from the app's documents dir (~2 GB —
+//      see pre-staging notes below).
+//   2. Installs it via `FlutterGemma.installModel(...).fromFile(...)`.
+//   3. Builds a `TranslateRunner` using the same XML strategy the example
+//      app uses.
+//   4. Runs three language pairs (en→fr, en→es, ja→en) and asserts the
+//      output is non-empty and contains expected keywords.
+//
+// Pre-stage the model file in the platform sandbox before running:
+//   macOS:   ~/Library/Containers/dev.flutterberlin.flutterGemmaExample55/Data/Documents/
+//   Android: adb push <file> /data/data/dev.flutterberlin.flutter_gemma_example/app_flutter/
+// On both platforms `getApplicationDocumentsDirectory()` resolves to that
+// location, so the test reads it via `fromFile()`.
+
+import 'dart:io';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:flutter_gemma_example/translation/translate_gemma_xml_strategy.dart';
+import 'package:flutter_gemma_example/translation/translate_runner.dart';
+
+const _modelName = 'translategemma-4b-it-int4-generic.litertlm';
+
+/// Resolve a file path in the app documents directory. If absent, copy
+/// from the bundled `assets/test/<name>` (works on every platform).
+Future<String> _docsPath(String name) async {
+  final docs = await getApplicationDocumentsDirectory();
+  final f = File('${docs.path}/$name');
+  if (f.existsSync()) return f.path;
+  final bytes = await rootBundle.load('assets/test/$name');
+  await f.writeAsBytes(bytes.buffer.asUint8List());
+  return f.path;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('TranslateGemma 4B int4 — translate three language pairs',
+      (_) async {
+    await FlutterGemma.initialize();
+
+    final modelPath = await _docsPath(_modelName);
+
+    await FlutterGemma.installModel(
+      modelType: ModelType.gemmaIt,
+      fileType: ModelFileType.litertlm,
+    ).fromFile(modelPath).install();
+
+    final model = await FlutterGemma.getActiveModel(
+      maxTokens: 1024,
+      preferredBackend: PreferredBackend.cpu,
+    );
+
+    try {
+      final runner = TranslateRunner(
+        model: model,
+        strategy: const TranslateGemmaXmlPromptStrategy(),
+      );
+
+      // en → fr
+      final fr = await runner.translate(
+        text: 'Hello world',
+        src: 'en',
+        dst: 'fr',
+      );
+      print('[TranslateGemma] en→fr: $fr');
+      expect(fr.trim(), isNotEmpty);
+      expect(fr.toLowerCase(), contains('bonjour'));
+
+      // en → es
+      final es = await runner.translate(
+        text: 'Good morning',
+        src: 'en',
+        dst: 'es',
+      );
+      print('[TranslateGemma] en→es: $es');
+      expect(es.trim(), isNotEmpty);
+      expect(
+        es.toLowerCase(),
+        anyOf(contains('buenos'), contains('buen día')),
+      );
+
+      // ja → en
+      final enFromJa = await runner.translate(
+        text: 'ありがとうございます',
+        src: 'ja',
+        dst: 'en',
+      );
+      print('[TranslateGemma] ja→en: $enFromJa');
+      expect(enFromJa.trim(), isNotEmpty);
+      expect(enFromJa.toLowerCase(), contains('thank'));
+    } finally {
+      await model.close();
+    }
+  }, timeout: const Timeout(Duration(minutes: 10)));
+
+  testWidgets('TranslateGemma 4B int4 — streaming yields chunks', (_) async {
+    final modelPath = await _docsPath(_modelName);
+    await FlutterGemma.installModel(
+      modelType: ModelType.gemmaIt,
+      fileType: ModelFileType.litertlm,
+    ).fromFile(modelPath).install();
+
+    final model = await FlutterGemma.getActiveModel(
+      maxTokens: 1024,
+      preferredBackend: PreferredBackend.cpu,
+    );
+
+    try {
+      final runner = TranslateRunner(
+        model: model,
+        strategy: const TranslateGemmaXmlPromptStrategy(),
+      );
+
+      final chunks = <String>[];
+      await for (final c in runner.translateStream(
+        text: 'The quick brown fox jumps over the lazy dog',
+        src: 'en',
+        dst: 'fr',
+      )) {
+        chunks.add(c);
+      }
+
+      final full = chunks.join();
+      print(
+          '[TranslateGemma stream] ${chunks.length} chunks → "$full"');
+      expect(chunks, isNotEmpty);
+      expect(full.trim(), isNotEmpty);
+    } finally {
+      await model.close();
+    }
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}

--- a/example/lib/home_screen.dart
+++ b/example/lib/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gemma_example/model_selection_screen.dart';
 import 'package:flutter_gemma_example/embedding_models_screen.dart';
+import 'package:flutter_gemma_example/translate_models_screen.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -50,6 +51,21 @@ class HomeScreen extends StatelessWidget {
                   context,
                   MaterialPageRoute<void>(
                     builder: (context) => const ModelSelectionScreen(),
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            _NavigationCard(
+              title: 'Translation Models',
+              subtitle: 'On-device translation with TranslateGemma',
+              icon: Icons.translate,
+              color: Colors.orange,
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute<void>(
+                    builder: (context) => const TranslateModelsScreen(),
                   ),
                 );
               },

--- a/example/lib/models/base_model.dart
+++ b/example/lib/models/base_model.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_gemma/pigeon.g.dart';
 import 'package:flutter_gemma/core/model.dart';
 
+import '../translation/prompt_strategy.dart';
+
 /// Type of model source for download/installation
 enum ModelSourceType {
   /// Download from HTTP/HTTPS URL
@@ -13,7 +15,16 @@ enum ModelSourceType {
   bundled,
 }
 
-/// Base interface for all model types (inference and embedding)
+/// What category of task this model is built for. Drives task-first routing
+/// in `HomeScreen` (chat → ChatScreen, embedding → EmbeddingTestScreen,
+/// translation → TranslateScreen).
+enum ModelKind {
+  inference,
+  embedding,
+  translation,
+}
+
+/// Base interface for all model types (inference, embedding, translation)
 abstract class BaseModel {
   /// Unique identifier for the model
   String get name;
@@ -36,8 +47,16 @@ abstract class BaseModel {
   /// Whether model requires HuggingFace authentication
   bool get needsAuth;
 
-  /// Whether this is an embedding model (vs inference model)
-  bool get isEmbeddingModel;
+  /// What category this model is — used by `HomeScreen` for task-first
+  /// routing and by `UniversalDownloadScreen` to dispatch to the right
+  /// follow-up screen after install.
+  ModelKind get kind;
+}
+
+/// Convenience extension for legacy code paths that branched on
+/// `isEmbeddingModel`. Prefer matching on [BaseModel.kind] in new code.
+extension BaseModelKindX on BaseModel {
+  bool get isEmbeddingModel => kind == ModelKind.embedding;
 }
 
 /// Interface for inference models
@@ -85,4 +104,30 @@ abstract class EmbeddingModelInterface extends BaseModel {
   /// Type of source for model and tokenizer files
   /// Determines which installation method to use (network, asset, bundled)
   ModelSourceType get sourceType;
+}
+
+/// Interface for translation models (TranslateGemma and any future
+/// single-shot translator).
+///
+/// Translation in this example doesn't introduce a new plugin API — under
+/// the hood we still go through `InferenceModel.createSession()` from
+/// `flutter_gemma`. The discriminator is the prompt format and the language
+/// list, both carried by `promptStrategy`.
+abstract class TranslateModelInterface extends BaseModel {
+  /// Preferred backend (CPU/GPU)
+  PreferredBackend get preferredBackend;
+
+  /// Model type for the LiteRT-LM SDK chat template parser.
+  /// TranslateGemma is a Gemma-3 fine-tune so it uses `ModelType.gemmaIt`.
+  ModelType get modelType;
+
+  /// Token limit for a single translation pass. TranslateGemma ships with
+  /// 1024 prefill + 1024 decode; this is the upper bound for input + output.
+  int get maxTokens;
+
+  /// Prompt format + supported-language map for this particular translator
+  /// bundle. Different bundles (community `.litertlm`, Google `-web.task`,
+  /// future NLLB/MADLAD) have completely different shapes, so each
+  /// TranslateModel binds its own const strategy here.
+  TranslationPromptStrategy get promptStrategy;
 }

--- a/example/lib/models/base_model.dart
+++ b/example/lib/models/base_model.dart
@@ -15,9 +15,8 @@ enum ModelSourceType {
   bundled,
 }
 
-/// What category of task this model is built for. Drives task-first routing
-/// in `HomeScreen` (chat → ChatScreen, embedding → EmbeddingTestScreen,
-/// translation → TranslateScreen).
+/// Task category used to dispatch a downloaded model to the right
+/// post-install screen and to gate kind-specific UI fields.
 enum ModelKind {
   inference,
   embedding,
@@ -51,12 +50,6 @@ abstract class BaseModel {
   /// routing and by `UniversalDownloadScreen` to dispatch to the right
   /// follow-up screen after install.
   ModelKind get kind;
-}
-
-/// Convenience extension for legacy code paths that branched on
-/// `isEmbeddingModel`. Prefer matching on [BaseModel.kind] in new code.
-extension BaseModelKindX on BaseModel {
-  bool get isEmbeddingModel => kind == ModelKind.embedding;
 }
 
 /// Interface for inference models

--- a/example/lib/models/embedding_model.dart
+++ b/example/lib/models/embedding_model.dart
@@ -160,7 +160,7 @@ enum EmbeddingModel implements EmbeddingModelInterface {
   String get name => toString().split('.').last;
 
   @override
-  bool get isEmbeddingModel => true;
+  ModelKind get kind => ModelKind.embedding;
 
   @override
   String? get licenseUrl => null; // Most embedding models don't have specific license URLs

--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -555,7 +555,7 @@ enum Model implements InferenceModelInterface {
   String get name => toString().split('.').last;
 
   @override
-  bool get isEmbeddingModel => false;
+  ModelKind get kind => ModelKind.inference;
 
   // InferenceModelInterface implementation
   @override

--- a/example/lib/models/translate_model.dart
+++ b/example/lib/models/translate_model.dart
@@ -19,10 +19,10 @@ enum TranslateModel implements TranslateModelInterface {
   /// in 6 GB free RAM on modern phones.
   translateGemma4Int4(
     url:
-        'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized/resolve/main/translategemma-4b-it-int4-generic.litertlm',
+        'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized/resolve/main/artifacts/int4-generic/translategemma-4b-it-int4-generic.litertlm',
     filename: 'translategemma-4b-it-int4-generic.litertlm',
     displayName: 'TranslateGemma 4B (int4)',
-    size: '2GB',
+    size: '1.87GB',
     needsAuth: false,
     preferredBackend: PreferredBackend.cpu,
     maxTokens: 1024,
@@ -31,7 +31,7 @@ enum TranslateModel implements TranslateModelInterface {
   /// Dynamic INT8, ~4 GB. Better translation quality; needs 8 GB free RAM.
   translateGemma4Int8(
     url:
-        'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized/resolve/main/translategemma-4b-it-dynamic_int8-generic.litertlm',
+        'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized/resolve/main/artifacts/dynamic_int8-generic/translategemma-4b-it-dynamic_int8-generic.litertlm',
     filename: 'translategemma-4b-it-dynamic_int8-generic.litertlm',
     displayName: 'TranslateGemma 4B (int8)',
     size: '4GB',

--- a/example/lib/models/translate_model.dart
+++ b/example/lib/models/translate_model.dart
@@ -14,6 +14,12 @@ import 'base_model.dart';
 /// `barakplasma/translategemma-4b-it-android-task-quantized` because Google
 /// only ships a `-web.task` for browsers; mobile/desktop bundles are not
 /// officially available yet (see HF discussion #5 on the source repo).
+///
+/// CPU-only by design: the community conversion keeps `EMBEDDING_LOOKUP`
+/// weights in float32 for MediaPipe `.task` compatibility. The upstream
+/// LiteRT GPU partitioner can't cluster that layout, so Metal/WebGPU
+/// `engine_create` aborts (LiteRT-LM#1748). Google's stock Gemma 3
+/// `.litertlm` bundles use a quantized embedding and do work on GPU.
 enum TranslateModel implements TranslateModelInterface {
   /// INT4 quantization, ~2 GB. Recommended default — loads faster and fits
   /// in 6 GB free RAM on modern phones.
@@ -81,18 +87,12 @@ enum TranslateModel implements TranslateModelInterface {
   String? get licenseUrl =>
       'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized';
 
-  /// TranslateGemma is a Gemma-3 fine-tune; its LiteRT-LM bundle uses the
-  /// same Jinja chat template as Gemma 3.
+  /// Gemma-3 fine-tune — uses the same Jinja chat template family.
   @override
   ModelType get modelType => ModelType.gemmaIt;
 
-  /// Both variants ship as `.litertlm`. Web `-web.task` is not added here.
   ModelFileType get fileType => ModelFileType.litertlm;
 
-  /// Community fork's XML prompt format
-  /// (`<src>en</src><dst>fr</dst><text>...</text>`). When/if a Google
-  /// official mobile bundle ships with a different format, add a new
-  /// strategy class and a new enum entry — no central dispatch to edit.
   @override
   TranslationPromptStrategy get promptStrategy =>
       const TranslateGemmaXmlPromptStrategy();

--- a/example/lib/models/translate_model.dart
+++ b/example/lib/models/translate_model.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_gemma/core/model.dart';
+
+import '../translation/prompt_strategy.dart';
+import '../translation/translate_gemma_xml_strategy.dart';
+import 'base_model.dart';
+
+/// Translator models (TranslateGemma and any future single-shot translators).
+///
+/// TranslateGemma 4B is a Gemma 3 fine-tune so it runs through the same
+/// `InferenceModel.createSession()` path as any chat model — only the prompt
+/// format differs (carried by `promptStrategy`). The `.litertlm` files come
+/// from a community conversion at
+/// `barakplasma/translategemma-4b-it-android-task-quantized` because Google
+/// only ships a `-web.task` for browsers; mobile/desktop bundles are not
+/// officially available yet (see HF discussion #5 on the source repo).
+enum TranslateModel implements TranslateModelInterface {
+  /// INT4 quantization, ~2 GB. Recommended default — loads faster and fits
+  /// in 6 GB free RAM on modern phones.
+  translateGemma4Int4(
+    url:
+        'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized/resolve/main/translategemma-4b-it-int4-generic.litertlm',
+    filename: 'translategemma-4b-it-int4-generic.litertlm',
+    displayName: 'TranslateGemma 4B (int4)',
+    size: '2GB',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.cpu,
+    maxTokens: 1024,
+  ),
+
+  /// Dynamic INT8, ~4 GB. Better translation quality; needs 8 GB free RAM.
+  translateGemma4Int8(
+    url:
+        'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized/resolve/main/translategemma-4b-it-dynamic_int8-generic.litertlm',
+    filename: 'translategemma-4b-it-dynamic_int8-generic.litertlm',
+    displayName: 'TranslateGemma 4B (int8)',
+    size: '4GB',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.cpu,
+    maxTokens: 1024,
+  );
+
+  const TranslateModel({
+    required this.url,
+    required this.filename,
+    required this.displayName,
+    required this.size,
+    required this.needsAuth,
+    required this.preferredBackend,
+    required this.maxTokens,
+  });
+
+  @override
+  final String url;
+
+  @override
+  final String filename;
+
+  @override
+  final String displayName;
+
+  @override
+  final String size;
+
+  @override
+  final bool needsAuth;
+
+  @override
+  final PreferredBackend preferredBackend;
+
+  @override
+  final int maxTokens;
+
+  @override
+  String get name => toString().split('.').last;
+
+  @override
+  ModelKind get kind => ModelKind.translation;
+
+  @override
+  String? get licenseUrl =>
+      'https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized';
+
+  /// TranslateGemma is a Gemma-3 fine-tune; its LiteRT-LM bundle uses the
+  /// same Jinja chat template as Gemma 3.
+  @override
+  ModelType get modelType => ModelType.gemmaIt;
+
+  /// Both variants ship as `.litertlm`. Web `-web.task` is not added here.
+  ModelFileType get fileType => ModelFileType.litertlm;
+
+  /// Community fork's XML prompt format
+  /// (`<src>en</src><dst>fr</dst><text>...</text>`). When/if a Google
+  /// official mobile bundle ships with a different format, add a new
+  /// strategy class and a new enum entry — no central dispatch to edit.
+  @override
+  TranslationPromptStrategy get promptStrategy =>
+      const TranslateGemmaXmlPromptStrategy();
+}

--- a/example/lib/translate_models_screen.dart
+++ b/example/lib/translate_models_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gemma_example/models/translate_model.dart';
+import 'package:flutter_gemma_example/widgets/universal_model_card.dart';
+
+class TranslateModelsScreen extends StatefulWidget {
+  const TranslateModelsScreen({super.key});
+
+  @override
+  State<TranslateModelsScreen> createState() => _TranslateModelsScreenState();
+}
+
+class _TranslateModelsScreenState extends State<TranslateModelsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0b2351),
+      appBar: AppBar(
+        title: const Text('Translation Models'),
+        backgroundColor: const Color(0xFF0b2351),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            const Text(
+              'On-device Translation',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'TranslateGemma 4B — single-shot translation across 55 languages. '
+              'Community-converted .litertlm (Google has not yet released a '
+              'mobile/desktop bundle).',
+              style: TextStyle(fontSize: 14, color: Colors.white70),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: ListView.builder(
+                itemCount: TranslateModel.values.length,
+                itemBuilder: (context, index) {
+                  final model = TranslateModel.values[index];
+                  return UniversalModelCard(model: model);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/translate_screen.dart
+++ b/example/lib/translate_screen.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+import 'models/translate_model.dart';
+import 'translation/translate_runner.dart';
+
+/// Translator UI: source/target language pickers, multiline input,
+/// streaming output. Loads the active `InferenceModel` via
+/// `FlutterGemma.getActiveModel()` and drives `TranslateRunner` for each
+/// invocation.
+class TranslateScreen extends StatefulWidget {
+  const TranslateScreen({super.key, required this.model});
+
+  final TranslateModel model;
+
+  @override
+  State<TranslateScreen> createState() => _TranslateScreenState();
+}
+
+class _TranslateScreenState extends State<TranslateScreen> {
+  final TextEditingController _input = TextEditingController();
+  String _output = '';
+  bool _loadingModel = true;
+  bool _translating = false;
+  String? _error;
+  InferenceModel? _inference;
+  TranslateRunner? _runner;
+
+  late String _src = _initialLang('en');
+  late String _dst = _initialLang('fr');
+
+  String _initialLang(String fallback) {
+    final supported = widget.model.promptStrategy.supportedLanguages;
+    return supported.containsKey(fallback) ? fallback : supported.keys.first;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadModel();
+  }
+
+  Future<void> _loadModel() async {
+    try {
+      final model = await FlutterGemma.getActiveModel(
+        maxTokens: widget.model.maxTokens,
+        preferredBackend: widget.model.preferredBackend,
+      );
+      if (!mounted) return;
+      setState(() {
+        _inference = model;
+        _runner = TranslateRunner(
+          model: model,
+          strategy: widget.model.promptStrategy,
+        );
+        _loadingModel = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Failed to load model: $e';
+        _loadingModel = false;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _input.dispose();
+    _inference?.close();
+    super.dispose();
+  }
+
+  Future<void> _runTranslate() async {
+    final runner = _runner;
+    if (runner == null) return;
+    final text = _input.text.trim();
+    if (text.isEmpty) return;
+    setState(() {
+      _translating = true;
+      _output = '';
+      _error = null;
+    });
+    try {
+      await for (final chunk in runner.translateStream(
+        text: text,
+        src: _src,
+        dst: _dst,
+      )) {
+        if (!mounted) return;
+        setState(() => _output += chunk);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = 'Translation failed: $e');
+    } finally {
+      if (mounted) setState(() => _translating = false);
+    }
+  }
+
+  void _swap() {
+    setState(() {
+      final tmp = _src;
+      _src = _dst;
+      _dst = tmp;
+    });
+  }
+
+  void _copyOutput() {
+    Clipboard.setData(ClipboardData(text: _output));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Translation copied to clipboard')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final supported = widget.model.promptStrategy.supportedLanguages;
+    final entries = supported.entries.toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.model.displayName)),
+      body: _loadingModel
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(child: _langPicker(entries, _src, (v) => setState(() => _src = v))),
+                      IconButton(
+                        icon: const Icon(Icons.swap_horiz),
+                        tooltip: 'Swap languages',
+                        onPressed: _translating ? null : _swap,
+                      ),
+                      Expanded(child: _langPicker(entries, _dst, (v) => setState(() => _dst = v))),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _input,
+                    minLines: 3,
+                    maxLines: 6,
+                    enabled: !_translating,
+                    decoration: const InputDecoration(
+                      labelText: 'Text to translate',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    icon: _translating
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.translate),
+                    label: Text(_translating ? 'Translating…' : 'Translate'),
+                    onPressed: _translating ? null : _runTranslate,
+                  ),
+                  const SizedBox(height: 16),
+                  if (_error != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Text(_error!, style: const TextStyle(color: Colors.red)),
+                    ),
+                  Expanded(
+                    child: Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.grey.shade400),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: SingleChildScrollView(
+                              child: SelectableText(
+                                _output.isEmpty ? '—' : _output,
+                                style: const TextStyle(fontSize: 16),
+                              ),
+                            ),
+                          ),
+                          if (_output.isNotEmpty)
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: TextButton.icon(
+                                icon: const Icon(Icons.copy),
+                                label: const Text('Copy'),
+                                onPressed: _copyOutput,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Widget _langPicker(
+    List<MapEntry<String, String>> entries,
+    String value,
+    ValueChanged<String> onChange,
+  ) {
+    return DropdownButtonFormField<String>(
+      value: value,
+      isExpanded: true,
+      decoration: const InputDecoration(border: OutlineInputBorder()),
+      items: [
+        for (final e in entries)
+          DropdownMenuItem(value: e.key, child: Text('${e.value} (${e.key})')),
+      ],
+      onChanged: _translating ? null : (v) {
+        if (v != null) onChange(v);
+      },
+    );
+  }
+}

--- a/example/lib/translate_screen.dart
+++ b/example/lib/translate_screen.dart
@@ -1,13 +1,16 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 
+import 'loading_widget.dart';
 import 'models/translate_model.dart';
+import 'services/auth_token_service.dart';
 import 'translation/translate_runner.dart';
 
 /// Translator UI: source/target language pickers, multiline input,
-/// streaming output. Loads the active `InferenceModel` via
-/// `FlutterGemma.getActiveModel()` and drives `TranslateRunner` for each
+/// streaming output. Re-runs `installModel().fromNetwork()` (idempotent)
+/// before `getActiveModel()` and drives `TranslateRunner` for each
 /// invocation.
 class TranslateScreen extends StatefulWidget {
   const TranslateScreen({super.key, required this.model});
@@ -19,57 +22,99 @@ class TranslateScreen extends StatefulWidget {
 }
 
 class _TranslateScreenState extends State<TranslateScreen> {
+  static const Color _bg = Color(0xFF0b2351);
+  static const Color _surface = Color(0xFF1a4a7c);
+  static const Color _surfaceAlt = Color(0xFF2a5a8c);
+
   final TextEditingController _input = TextEditingController();
   String _output = '';
-  bool _loadingModel = true;
+  bool _isInitializing = false;
+  bool _isModelInitialized = false;
   bool _translating = false;
   String? _error;
   InferenceModel? _inference;
   TranslateRunner? _runner;
 
-  late String _src = _initialLang('en');
-  late String _dst = _initialLang('fr');
-
-  String _initialLang(String fallback) {
-    final supported = widget.model.promptStrategy.supportedLanguages;
-    return supported.containsKey(fallback) ? fallback : supported.keys.first;
-  }
+  String _src = 'en';
+  String _dst = 'fr';
 
   @override
   void initState() {
     super.initState();
-    _loadModel();
+    final supported = widget.model.promptStrategy.supportedLanguages;
+    if (!supported.containsKey(_src)) _src = supported.keys.first;
+    if (!supported.containsKey(_dst)) {
+      _dst = supported.keys.length > 1
+          ? supported.keys.elementAt(1)
+          : supported.keys.first;
+    }
+    _initializeModel();
   }
 
-  Future<void> _loadModel() async {
+  @override
+  void dispose() {
+    _input.dispose();
+    // dispose() is sync; surface any cleanup error to the debug log
+    // instead of letting it land in the unhandled-async-error zone.
+    _inference?.close().catchError((Object e, StackTrace st) {
+      debugPrint('[TranslateScreen] dispose close failed: $e\n$st');
+    });
+    super.dispose();
+  }
+
+  Future<void> _initializeModel() async {
+    if (_isModelInitialized || _isInitializing) return;
+    _isInitializing = true;
+
     try {
+      if (kDebugMode) {
+        debugPrint('[TranslateScreen] Installing ${widget.model.filename}…');
+      }
+
+      String? token;
+      if (widget.model.needsAuth) {
+        token = await AuthTokenService.loadToken();
+      }
+
+      await FlutterGemma.installModel(
+        modelType: widget.model.modelType,
+        fileType: widget.model.fileType,
+      ).fromNetwork(widget.model.url, token: token).install();
+
+      if (kDebugMode) {
+        debugPrint('[TranslateScreen] Model installed, getting active…');
+      }
+
       final model = await FlutterGemma.getActiveModel(
         maxTokens: widget.model.maxTokens,
         preferredBackend: widget.model.preferredBackend,
       );
-      if (!mounted) return;
+
+      if (!mounted) {
+        await model.close();
+        return;
+      }
+
       setState(() {
         _inference = model;
         _runner = TranslateRunner(
           model: model,
           strategy: widget.model.promptStrategy,
         );
-        _loadingModel = false;
+        _isModelInitialized = true;
+        _error = null;
       });
     } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[TranslateScreen] Initialization failed: $e');
+      }
       if (!mounted) return;
       setState(() {
         _error = 'Failed to load model: $e';
-        _loadingModel = false;
       });
+    } finally {
+      _isInitializing = false;
     }
-  }
-
-  @override
-  void dispose() {
-    _input.dispose();
-    _inference?.close();
-    super.dispose();
   }
 
   Future<void> _runTranslate() async {
@@ -121,9 +166,16 @@ class _TranslateScreenState extends State<TranslateScreen> {
       ..sort((a, b) => a.value.compareTo(b.value));
 
     return Scaffold(
-      appBar: AppBar(title: Text(widget.model.displayName)),
-      body: _loadingModel
-          ? const Center(child: CircularProgressIndicator())
+      backgroundColor: _bg,
+      appBar: AppBar(
+        backgroundColor: _bg,
+        foregroundColor: Colors.white,
+        title: Text(widget.model.displayName),
+      ),
+      body: !_isModelInitialized
+          ? (_error != null
+              ? _buildErrorState(_error!)
+              : const LoadingWidget(message: 'Initializing translation model'))
           : Padding(
               padding: const EdgeInsets.all(16),
               child: Column(
@@ -133,7 +185,7 @@ class _TranslateScreenState extends State<TranslateScreen> {
                     children: [
                       Expanded(child: _langPicker(entries, _src, (v) => setState(() => _src = v))),
                       IconButton(
-                        icon: const Icon(Icons.swap_horiz),
+                        icon: const Icon(Icons.swap_horiz, color: Colors.white),
                         tooltip: 'Swap languages',
                         onPressed: _translating ? null : _swap,
                       ),
@@ -146,18 +198,35 @@ class _TranslateScreenState extends State<TranslateScreen> {
                     minLines: 3,
                     maxLines: 6,
                     enabled: !_translating,
+                    style: const TextStyle(color: Colors.white),
                     decoration: const InputDecoration(
+                      filled: true,
+                      fillColor: _surface,
                       labelText: 'Text to translate',
+                      labelStyle: TextStyle(color: Colors.white70),
                       border: OutlineInputBorder(),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white24),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white),
+                      ),
                     ),
                   ),
                   const SizedBox(height: 12),
                   FilledButton.icon(
+                    style: FilledButton.styleFrom(
+                      backgroundColor: _translating ? Colors.grey : _surfaceAlt,
+                      foregroundColor: Colors.white,
+                    ),
                     icon: _translating
                         ? const SizedBox(
                             width: 16,
                             height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
                           )
                         : const Icon(Icons.translate),
                     label: Text(_translating ? 'Translating…' : 'Translate'),
@@ -165,15 +234,23 @@ class _TranslateScreenState extends State<TranslateScreen> {
                   ),
                   const SizedBox(height: 16),
                   if (_error != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: Text(_error!, style: const TextStyle(color: Colors.red)),
+                    Container(
+                      width: double.infinity,
+                      color: Colors.red,
+                      padding: const EdgeInsets.all(8.0),
+                      margin: const EdgeInsets.only(bottom: 8),
+                      child: Text(
+                        _error!,
+                        style: const TextStyle(color: Colors.white),
+                        textAlign: TextAlign.center,
+                      ),
                     ),
                   Expanded(
                     child: Container(
                       padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
-                        border: Border.all(color: Colors.grey.shade400),
+                        color: _surface,
+                        border: Border.all(color: Colors.white24),
                         borderRadius: BorderRadius.circular(4),
                       ),
                       child: Column(
@@ -183,7 +260,10 @@ class _TranslateScreenState extends State<TranslateScreen> {
                             child: SingleChildScrollView(
                               child: SelectableText(
                                 _output.isEmpty ? '—' : _output,
-                                style: const TextStyle(fontSize: 16),
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
                           ),
@@ -191,6 +271,9 @@ class _TranslateScreenState extends State<TranslateScreen> {
                             Align(
                               alignment: Alignment.centerRight,
                               child: TextButton.icon(
+                                style: TextButton.styleFrom(
+                                  foregroundColor: Colors.white,
+                                ),
                                 icon: const Icon(Icons.copy),
                                 label: const Text('Copy'),
                                 onPressed: _copyOutput,
@@ -206,6 +289,26 @@ class _TranslateScreenState extends State<TranslateScreen> {
     );
   }
 
+  Widget _buildErrorState(String message) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, color: Colors.redAccent, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: const TextStyle(color: Colors.white),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _langPicker(
     List<MapEntry<String, String>> entries,
     String value,
@@ -214,14 +317,37 @@ class _TranslateScreenState extends State<TranslateScreen> {
     return DropdownButtonFormField<String>(
       value: value,
       isExpanded: true,
-      decoration: const InputDecoration(border: OutlineInputBorder()),
+      dropdownColor: _surface,
+      style: const TextStyle(color: Colors.white),
+      iconEnabledColor: Colors.white,
+      decoration: const InputDecoration(
+        filled: true,
+        fillColor: _surface,
+        border: OutlineInputBorder(),
+        enabledBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: Colors.white24),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: Colors.white),
+        ),
+        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      ),
       items: [
         for (final e in entries)
-          DropdownMenuItem(value: e.key, child: Text('${e.value} (${e.key})')),
+          DropdownMenuItem(
+            value: e.key,
+            child: Text(
+              '${e.value} (${e.key})',
+              style: const TextStyle(color: Colors.white),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
       ],
-      onChanged: _translating ? null : (v) {
-        if (v != null) onChange(v);
-      },
+      onChanged: _translating
+          ? null
+          : (v) {
+              if (v != null) onChange(v);
+            },
     );
   }
 }

--- a/example/lib/translation/prompt_strategy.dart
+++ b/example/lib/translation/prompt_strategy.dart
@@ -1,0 +1,31 @@
+/// Open/closed extension point for translation models.
+///
+/// Each TranslateGemma-style model has a different on-the-wire prompt format
+/// (community `.litertlm` uses `<src>en</src><dst>fr</dst><text>...</text>`,
+/// Google's official `-web.task` uses a natural-language system prompt, future
+/// NLLB / MADLAD bundles use yet other shapes). Adding a new translator model
+/// to the example app is a matter of writing a new subclass of this — no
+/// switch-on-enum to edit anywhere.
+abstract class TranslationPromptStrategy {
+  const TranslationPromptStrategy();
+
+  /// Build the single-shot prompt that gets fed to
+  /// `InferenceModel.createSession()` + `addQueryChunk()`.
+  ///
+  /// [src] and [dst] are ISO 639-1 codes (`'en'`, `'fr'`, `'ja'`); strategies
+  /// that need a different vocabulary (e.g. NLLB's `eng_Latn`) translate
+  /// internally.
+  String formatPrompt({
+    required String src,
+    required String dst,
+    required String text,
+  });
+
+  /// Map from language code to human-readable name, used to populate the
+  /// source/target dropdowns in `TranslateScreen`.
+  ///
+  /// Different translator models support different language sets — Gecko's
+  /// fork ships 55, NLLB ships 202, MADLAD ships 400+. Returning the map per
+  /// strategy keeps each translator self-describing.
+  Map<String, String> get supportedLanguages;
+}

--- a/example/lib/translation/prompt_strategy.dart
+++ b/example/lib/translation/prompt_strategy.dart
@@ -24,8 +24,8 @@ abstract class TranslationPromptStrategy {
   /// Map from language code to human-readable name, used to populate the
   /// source/target dropdowns in `TranslateScreen`.
   ///
-  /// Different translator models support different language sets — Gecko's
-  /// fork ships 55, NLLB ships 202, MADLAD ships 400+. Returning the map per
-  /// strategy keeps each translator self-describing.
+  /// Different translator models support different language sets —
+  /// TranslateGemma lists 55, NLLB lists 202, MADLAD lists 400+. Returning
+  /// the map per strategy keeps each translator self-describing.
   Map<String, String> get supportedLanguages;
 }

--- a/example/lib/translation/translate_gemma_xml_strategy.dart
+++ b/example/lib/translation/translate_gemma_xml_strategy.dart
@@ -19,15 +19,18 @@ class TranslateGemmaXmlPromptStrategy extends TranslationPromptStrategy {
     required String dst,
     required String text,
   }) =>
-      '<src>$src</src><dst>$dst</dst><text>$text</text>';
+      '<src>$src</src><dst>$dst</dst><text>${_escape(text)}</text>';
+
+  // Stop user-typed `<` / `>` from breaking the tag protocol — without this,
+  // pasting `</text><dst>de</dst><text>...` would override the target lang.
+  String _escape(String s) =>
+      s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 
   /// Curated subset of the ~55 ISO 639-1 codes Google's source
   /// `google/translategemma-4b-it` model card claims to support. Neither the
   /// model card nor the community fork README enumerates the full list, so
   /// this is the high-confidence subset covering the languages explicitly
   /// shown in examples plus the top global languages by speaker count.
-  /// Users who need a code that isn't in this map can type it as a custom
-  /// override in the UI.
   @override
   Map<String, String> get supportedLanguages => const {
         'ar': 'Arabic',

--- a/example/lib/translation/translate_gemma_xml_strategy.dart
+++ b/example/lib/translation/translate_gemma_xml_strategy.dart
@@ -1,0 +1,77 @@
+import 'prompt_strategy.dart';
+
+/// XML-tag prompt format used by the `barakplasma/...-android-task-quantized`
+/// community conversion of TranslateGemma 4B IT (the `.litertlm` bundle this
+/// example ships).
+///
+/// The Jinja `chat_template` baked into that `.litertlm` expects:
+///
+///     <src>en</src><dst>fr</dst><text>hello world</text>
+///
+/// Plain text without tags also works (the model attempts language auto-detect),
+/// but explicit tags are more reliable, so the UI always emits them.
+class TranslateGemmaXmlPromptStrategy extends TranslationPromptStrategy {
+  const TranslateGemmaXmlPromptStrategy();
+
+  @override
+  String formatPrompt({
+    required String src,
+    required String dst,
+    required String text,
+  }) =>
+      '<src>$src</src><dst>$dst</dst><text>$text</text>';
+
+  /// Curated subset of the ~55 ISO 639-1 codes Google's source
+  /// `google/translategemma-4b-it` model card claims to support. Neither the
+  /// model card nor the community fork README enumerates the full list, so
+  /// this is the high-confidence subset covering the languages explicitly
+  /// shown in examples plus the top global languages by speaker count.
+  /// Users who need a code that isn't in this map can type it as a custom
+  /// override in the UI.
+  @override
+  Map<String, String> get supportedLanguages => const {
+        'ar': 'Arabic',
+        'bg': 'Bulgarian',
+        'bn': 'Bengali',
+        'cs': 'Czech',
+        'da': 'Danish',
+        'de': 'German',
+        'el': 'Greek',
+        'en': 'English',
+        'es': 'Spanish',
+        'et': 'Estonian',
+        'fa': 'Persian',
+        'fi': 'Finnish',
+        'fr': 'French',
+        'he': 'Hebrew',
+        'hi': 'Hindi',
+        'hr': 'Croatian',
+        'hu': 'Hungarian',
+        'id': 'Indonesian',
+        'it': 'Italian',
+        'ja': 'Japanese',
+        'ko': 'Korean',
+        'lt': 'Lithuanian',
+        'lv': 'Latvian',
+        'ms': 'Malay',
+        'nl': 'Dutch',
+        'no': 'Norwegian',
+        'pl': 'Polish',
+        'pt': 'Portuguese',
+        'ro': 'Romanian',
+        'ru': 'Russian',
+        'sk': 'Slovak',
+        'sl': 'Slovenian',
+        'sr': 'Serbian',
+        'sv': 'Swedish',
+        'sw': 'Swahili',
+        'ta': 'Tamil',
+        'te': 'Telugu',
+        'th': 'Thai',
+        'tr': 'Turkish',
+        'uk': 'Ukrainian',
+        'ur': 'Urdu',
+        'vi': 'Vietnamese',
+        'zh': 'Chinese',
+      };
+}

--- a/example/lib/translation/translate_runner.dart
+++ b/example/lib/translation/translate_runner.dart
@@ -1,15 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 
 import 'prompt_strategy.dart';
 
 /// Wraps an `InferenceModel` to make single-shot translation a one-call
-/// operation.
-///
-/// The plugin already exposes the single-shot primitive
-/// (`InferenceModel.createSession()`), so this is example-side glue: prompt
-/// formatting + lifecycle management + a `translate()` / `translateStream()`
-/// pair shaped for translator UX. Different translator bundles plug in
-/// different `TranslationPromptStrategy` instances.
+/// operation. Plugin owns the model lifecycle; the runner only owns the
+/// per-call session.
 class TranslateRunner {
   TranslateRunner({
     required InferenceModel model,
@@ -20,6 +16,11 @@ class TranslateRunner {
   final InferenceModel _model;
   final TranslationPromptStrategy _strategy;
 
+  // `topK: 1` → argmax (deterministic). Temperature stays > 0 because
+  // some GPU sampler kernels divide by it.
+  static const double _greedyTemperature = 0.8;
+  static const int _greedyTopK = 1;
+
   /// One-shot translation: returns the full output string once decoding
   /// completes.
   Future<String> translate({
@@ -27,7 +28,10 @@ class TranslateRunner {
     required String src,
     required String dst,
   }) async {
-    final session = await _model.createSession(temperature: 0);
+    final session = await _model.createSession(
+      temperature: _greedyTemperature,
+      topK: _greedyTopK,
+    );
     try {
       await session.addQueryChunk(
         Message.text(
@@ -37,7 +41,7 @@ class TranslateRunner {
       );
       return await session.getResponse();
     } finally {
-      await session.close();
+      await _safeClose(session);
     }
   }
 
@@ -49,7 +53,10 @@ class TranslateRunner {
     required String src,
     required String dst,
   }) async* {
-    final session = await _model.createSession(temperature: 0);
+    final session = await _model.createSession(
+      temperature: _greedyTemperature,
+      topK: _greedyTopK,
+    );
     try {
       await session.addQueryChunk(
         Message.text(
@@ -59,7 +66,17 @@ class TranslateRunner {
       );
       yield* session.getResponseAsync();
     } finally {
+      await _safeClose(session);
+    }
+  }
+
+  // Don't let a session-close failure mask the original exception — Dart
+  // `finally` would otherwise overwrite the in-flight error.
+  Future<void> _safeClose(InferenceModelSession session) async {
+    try {
       await session.close();
+    } catch (e, st) {
+      debugPrint('[TranslateRunner] session.close() failed: $e\n$st');
     }
   }
 }

--- a/example/lib/translation/translate_runner.dart
+++ b/example/lib/translation/translate_runner.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+import 'prompt_strategy.dart';
+
+/// Wraps an `InferenceModel` to make single-shot translation a one-call
+/// operation.
+///
+/// The plugin already exposes the single-shot primitive
+/// (`InferenceModel.createSession()`), so this is example-side glue: prompt
+/// formatting + lifecycle management + a `translate()` / `translateStream()`
+/// pair shaped for translator UX. Different translator bundles plug in
+/// different `TranslationPromptStrategy` instances.
+class TranslateRunner {
+  TranslateRunner({
+    required InferenceModel model,
+    required TranslationPromptStrategy strategy,
+  })  : _model = model,
+        _strategy = strategy;
+
+  final InferenceModel _model;
+  final TranslationPromptStrategy _strategy;
+
+  /// One-shot translation: returns the full output string once decoding
+  /// completes.
+  Future<String> translate({
+    required String text,
+    required String src,
+    required String dst,
+  }) async {
+    final session = await _model.createSession(temperature: 0);
+    try {
+      await session.addQueryChunk(
+        Message.text(
+          text: _strategy.formatPrompt(src: src, dst: dst, text: text),
+          isUser: true,
+        ),
+      );
+      return await session.getResponse();
+    } finally {
+      await session.close();
+    }
+  }
+
+  /// Streaming translation: emits each generated chunk as the model decodes.
+  /// Caller can cancel via the returned `Stream`'s subscription; the session
+  /// is closed when the stream is done (either fully consumed or cancelled).
+  Stream<String> translateStream({
+    required String text,
+    required String src,
+    required String dst,
+  }) async* {
+    final session = await _model.createSession(temperature: 0);
+    try {
+      await session.addQueryChunk(
+        Message.text(
+          text: _strategy.formatPrompt(src: src, dst: dst, text: text),
+          isUser: true,
+        ),
+      );
+      yield* session.getResponseAsync();
+    } finally {
+      await session.close();
+    }
+  }
+}

--- a/example/lib/universal_download_screen.dart
+++ b/example/lib/universal_download_screen.dart
@@ -80,7 +80,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
   }
 
   Future<void> _initialize() async {
-    if (widget.model.isEmbeddingModel) {
+    if (widget.model.kind == ModelKind.embedding) {
       _token = await _embeddingDownloadService!.loadToken() ?? '';
     } else {
       _token = await _inferenceDownloadService!.loadToken() ?? '';
@@ -93,7 +93,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
   Future<void> _checkModelExistence() async {
     bool exists;
 
-    if (widget.model.isEmbeddingModel) {
+    if (widget.model.kind == ModelKind.embedding) {
       exists = await _embeddingDownloadService!.checkModelExistence(_token);
     } else {
       exists = await _inferenceDownloadService!.checkModelExistence(_token);
@@ -105,7 +105,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
   }
 
   Future<void> _saveToken(String token) async {
-    if (widget.model.isEmbeddingModel) {
+    if (widget.model.kind == ModelKind.embedding) {
       await _embeddingDownloadService!.saveToken(token);
     } else {
       await _inferenceDownloadService!.saveToken(token);
@@ -130,7 +130,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
     });
 
     try {
-      if (widget.model.isEmbeddingModel) {
+      if (widget.model.kind == ModelKind.embedding) {
         await _embeddingDownloadService!.downloadModel(widget.model.needsAuth ? _token : '',
             (modelProg, tokenizerProg) {
           setState(() {
@@ -165,7 +165,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
 
   Future<void> _deleteModel() async {
     try {
-      if (widget.model.isEmbeddingModel) {
+      if (widget.model.kind == ModelKind.embedding) {
         await _embeddingDownloadService!.deleteModel();
       } else {
         await _inferenceDownloadService!.deleteModel();
@@ -312,7 +312,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
   }
 
   Widget _buildProgressSection() {
-    if (widget.model.isEmbeddingModel) {
+    if (widget.model.kind == ModelKind.embedding) {
       return _buildDualProgressBars();
     } else {
       return _buildSingleProgressBar();

--- a/example/lib/universal_download_screen.dart
+++ b/example/lib/universal_download_screen.dart
@@ -256,23 +256,35 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
             ),
             const SizedBox(height: 12),
             _buildInfoRow('Size:', widget.model.size),
-            _buildInfoRow(
-                'Type:', widget.model.isEmbeddingModel ? 'Embedding Model' : 'Inference Model'),
-            if (widget.model.isEmbeddingModel) ...[
+            _buildInfoRow('Type:', _kindLabel(widget.model.kind)),
+            if (widget.model.kind == ModelKind.embedding) ...[
               _buildInfoRow('Dimension:',
                   '${(widget.model as example_embedding_model.EmbeddingModel).dimension}D'),
-            ] else ...[
+            ] else if (widget.model.kind == ModelKind.inference) ...[
               if ((widget.model as InferenceModelInterface).supportImage)
                 _buildInfoRow('Multimodal:', 'Yes'),
               if ((widget.model as InferenceModelInterface).supportsFunctionCalls)
                 _buildInfoRow('Functions:', 'Yes'),
               if ((widget.model as InferenceModelInterface).supportsThinking)
                 _buildInfoRow('Thinking:', 'Yes'),
+            ] else if (widget.model.kind == ModelKind.translation) ...[
+              _buildInfoRow('Task:', 'Single-shot translation'),
             ],
           ],
         ),
       ),
     );
+  }
+
+  String _kindLabel(ModelKind kind) {
+    switch (kind) {
+      case ModelKind.inference:
+        return 'Inference Model';
+      case ModelKind.embedding:
+        return 'Embedding Model';
+      case ModelKind.translation:
+        return 'Translation Model';
+    }
   }
 
   Widget _buildInfoRow(String label, String value) {

--- a/example/lib/universal_download_screen.dart
+++ b/example/lib/universal_download_screen.dart
@@ -6,8 +6,10 @@ import 'package:flutter_gemma_example/embedding_test_screen.dart';
 import 'package:flutter_gemma_example/models/base_model.dart';
 import 'package:flutter_gemma_example/models/model.dart';
 import 'package:flutter_gemma_example/models/embedding_model.dart' as example_embedding_model;
+import 'package:flutter_gemma_example/models/translate_model.dart';
 import 'package:flutter_gemma_example/services/model_download_service.dart';
 import 'package:flutter_gemma_example/services/embedding_download_service.dart';
+import 'package:flutter_gemma_example/translate_screen.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UniversalDownloadScreen extends StatefulWidget {
@@ -47,20 +49,33 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
   }
 
   void _initializeServices() {
-    if (widget.model.isEmbeddingModel) {
-      _embeddingDownloadService = EmbeddingModelDownloadService(
-        model: widget.model as example_embedding_model.EmbeddingModel,
-      );
-    } else {
-      final inferenceModel = widget.model as Model;
-      _inferenceDownloadService = ModelDownloadService(
-        modelUrl: widget.model.url,
-        modelFilename: widget.model.filename,
-        licenseUrl: widget.model.licenseUrl ?? '',
-        modelType: inferenceModel.modelType,
-        fileType: inferenceModel.fileType,
-        foreground: inferenceModel.foreground,
-      );
+    switch (widget.model.kind) {
+      case ModelKind.embedding:
+        _embeddingDownloadService = EmbeddingModelDownloadService(
+          model: widget.model as example_embedding_model.EmbeddingModel,
+        );
+        break;
+      case ModelKind.translation:
+        final t = widget.model as TranslateModel;
+        _inferenceDownloadService = ModelDownloadService(
+          modelUrl: t.url,
+          modelFilename: t.filename,
+          licenseUrl: t.licenseUrl ?? '',
+          modelType: t.modelType,
+          fileType: t.fileType,
+        );
+        break;
+      case ModelKind.inference:
+        final inferenceModel = widget.model as Model;
+        _inferenceDownloadService = ModelDownloadService(
+          modelUrl: widget.model.url,
+          modelFilename: widget.model.filename,
+          licenseUrl: widget.model.licenseUrl ?? '',
+          modelType: inferenceModel.modelType,
+          fileType: inferenceModel.fileType,
+          foreground: inferenceModel.foreground,
+        );
+        break;
     }
   }
 
@@ -445,25 +460,38 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
   }
 
   void _proceedToNextScreen() async {
-    if (widget.model.isEmbeddingModel) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => EmbeddingTestScreen(
-            model: widget.model as example_embedding_model.EmbeddingModel,
+    switch (widget.model.kind) {
+      case ModelKind.embedding:
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => EmbeddingTestScreen(
+              model: widget.model as example_embedding_model.EmbeddingModel,
+            ),
           ),
-        ),
-      );
-    } else {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => ChatScreen(
-            model: widget.model as Model,
-            selectedBackend: widget.selectedBackend ?? PreferredBackend.cpu,
+        );
+        break;
+      case ModelKind.translation:
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => TranslateScreen(
+              model: widget.model as TranslateModel,
+            ),
           ),
-        ),
-      );
+        );
+        break;
+      case ModelKind.inference:
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => ChatScreen(
+              model: widget.model as Model,
+              selectedBackend: widget.selectedBackend ?? PreferredBackend.cpu,
+            ),
+          ),
+        );
+        break;
     }
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.15.2"
+    version: "0.15.3"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.15.2'
+  s.version          = '0.15.3'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Run Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3, Qwen 2.5, DeepSeek R1,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.15.2
+version: 0.15.3
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 


### PR DESCRIPTION
## Summary

Adds TranslateGemma 4B support to the example app via a third "Translation Models" home card. Plugin (`lib/`) is unchanged — TranslateGemma is a Gemma 3 fine-tune that runs through the same `InferenceModel.createSession()` primitive that already exists.

Closes #177.

## What's new in example

- **Task-first home navigation** — `HomeScreen` now shows three cards: Inference / Translation / Embedding.
- **`ModelKind` enum** (`inference`, `embedding`, `translation`) on `BaseModel` — discriminator for `UniversalDownloadScreen` routing.
- **Strategy pattern** for translator prompt formats (`TranslationPromptStrategy` abstract + `TranslateGemmaXmlPromptStrategy` impl). New translator models add their own strategy class — no central switch to edit.
- **`TranslateGemma 4B`** int4 (~2 GB) and dynamic-int8 (~4 GB) variants from community-converted `.litertlm` on `barakplasma/translategemma-4b-it-android-task-quantized` (Google publishes only `-web.task`; mobile/desktop bundles aren't officially shipped — see [HF discussion #5](https://huggingface.co/google/translategemma-4b-it/discussions/5)).
- **`TranslateScreen`** — source/target language dropdowns (43 ISO 639-1 codes), swap button, multiline input, streaming output, copy-to-clipboard.
- **`TranslateRunner`** — wraps `createSession()` with `translate()` / `translateStream()` and proper try/finally lifecycle.

## What's unchanged

- Plugin `lib/`: zero changes.
- Native code (Android/iOS/macOS/Linux/Windows): zero changes.
- Existing chat / embedding flows: unchanged. `isEmbeddingModel` moved to an extension getter for backward source compat.

## Architecture decision

Open/closed: when the next translator model (NLLB / MADLAD / official Google mobile) lands, the change is one new `TranslationPromptStrategy` subclass + one new `TranslateModel` enum entry. No central dispatch table grows.

Plugin stays minimal: see the design discussion in the issue and the parallel research note (Opus stress test rejected adding `Translator` interface or `ModelTask` enum to the plugin API for a single model).

## Test plan

- [ ] Local `flutter analyze` on example clean
- [ ] Pixel 8: install int4, translate "Hello world" en→fr → "Bonjour le monde"
- [ ] Pixel 8: try ja→en and en→es
- [ ] Verify streaming output appears progressively
- [ ] macOS: int4 loads and translates
- [ ] iOS sim: skip (2 GB exceeds Metal sim 256 MB cap)
- [ ] No regression in `ChatScreen` or `EmbeddingTestScreen` flows