### PR TITLE
feat: report initialized backend

### DIFF
--- a/lib/core/ffi/backend_preference.dart
+++ b/lib/core/ffi/backend_preference.dart
@@ -1,0 +1,23 @@
+import '../../pigeon.g.dart';
+
+List<PreferredBackend> ffiBackendFallbackOrder(
+  PreferredBackend? preferredBackend,
+) =>
+    switch (preferredBackend) {
+      PreferredBackend.npu => const [
+          PreferredBackend.npu,
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      PreferredBackend.gpu || null => const [
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      PreferredBackend.cpu => const [PreferredBackend.cpu],
+    };
+
+String ffiBackendWireName(PreferredBackend backend) => switch (backend) {
+      PreferredBackend.npu => 'npu',
+      PreferredBackend.gpu => 'gpu',
+      PreferredBackend.cpu => 'cpu',
+    };

--- a/lib/core/ffi/backend_preference.dart
+++ b/lib/core/ffi/backend_preference.dart
@@ -24,6 +24,7 @@ String ffiBackendWireName(PreferredBackend backend) => switch (backend) {
       PreferredBackend.cpu => 'cpu',
     };
 
+/// Failure details for a single FFI backend initialization attempt.
 class BackendInitAttemptFailure {
   const BackendInitAttemptFailure({
     required this.backend,
@@ -31,20 +32,36 @@ class BackendInitAttemptFailure {
     required this.stackTrace,
   });
 
+  /// Backend used for this initialization attempt.
   final PreferredBackend backend;
+
+  /// Error reported while initializing [backend].
   final Object error;
+
+  /// Stack trace captured with [error].
   final StackTrace stackTrace;
 
   @override
   String toString() => '${ffiBackendWireName(backend)}: $error';
 }
 
+/// Exception thrown after every FFI backend fallback attempt fails.
 class BackendInitException implements Exception {
-  const BackendInitException({required this.attempts})
-      : assert(attempts.length > 0);
+  BackendInitException({required Iterable<BackendInitAttemptFailure> attempts})
+      : attempts = List.unmodifiable(attempts) {
+    if (this.attempts.isEmpty) {
+      throw ArgumentError.value(
+        attempts,
+        'attempts',
+        'must contain at least one failed backend attempt',
+      );
+    }
+  }
 
+  /// Failed backend attempts in the order they were tried.
   final List<BackendInitAttemptFailure> attempts;
 
+  /// Last backend attempt, usually the most actionable failure.
   BackendInitAttemptFailure get lastAttempt => attempts.last;
 
   @override
@@ -99,6 +116,6 @@ Future<({T client, PreferredBackend activeBackend})> initializeFfiRuntime<T>({
     throw StateError('No FFI backend candidates were attempted.');
   }
 
-  final exception = BackendInitException(attempts: List.unmodifiable(attempts));
+  final exception = BackendInitException(attempts: attempts);
   Error.throwWithStackTrace(exception, exception.lastAttempt.stackTrace);
 }

--- a/lib/core/ffi/backend_preference.dart
+++ b/lib/core/ffi/backend_preference.dart
@@ -40,7 +40,8 @@ class BackendInitAttemptFailure {
 }
 
 class BackendInitException implements Exception {
-  const BackendInitException({required this.attempts});
+  const BackendInitException({required this.attempts})
+      : assert(attempts.length > 0);
 
   final List<BackendInitAttemptFailure> attempts;
 

--- a/lib/core/ffi/backend_preference.dart
+++ b/lib/core/ffi/backend_preference.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import '../../pigeon.g.dart';
 
 List<PreferredBackend> ffiBackendFallbackOrder(
@@ -21,3 +23,81 @@ String ffiBackendWireName(PreferredBackend backend) => switch (backend) {
       PreferredBackend.gpu => 'gpu',
       PreferredBackend.cpu => 'cpu',
     };
+
+class BackendInitAttemptFailure {
+  const BackendInitAttemptFailure({
+    required this.backend,
+    required this.error,
+    required this.stackTrace,
+  });
+
+  final PreferredBackend backend;
+  final Object error;
+  final StackTrace stackTrace;
+
+  @override
+  String toString() => '${ffiBackendWireName(backend)}: $error';
+}
+
+class BackendInitException implements Exception {
+  const BackendInitException({required this.attempts});
+
+  final List<BackendInitAttemptFailure> attempts;
+
+  BackendInitAttemptFailure get lastAttempt => attempts.last;
+
+  @override
+  String toString() {
+    final failures = attempts.map((attempt) => attempt.toString()).join('; ');
+    return 'BackendInitException: all FFI backends failed. '
+        'Last attempted ${ffiBackendWireName(lastAttempt.backend)}. '
+        'Attempts: $failures';
+  }
+}
+
+Future<({T client, PreferredBackend activeBackend})> initializeFfiRuntime<T>({
+  required PreferredBackend? preferredBackend,
+  required String logTag,
+  required T Function() createClient,
+  required Future<void> Function(T client, PreferredBackend backend)
+      initializeClient,
+  required void Function(T client) shutdownClient,
+}) async {
+  final attempts = <BackendInitAttemptFailure>[];
+  final backends = ffiBackendFallbackOrder(preferredBackend);
+
+  if (backends.isEmpty) {
+    throw StateError('No FFI backend candidates are available.');
+  }
+
+  for (final backend in backends) {
+    final client = createClient();
+    try {
+      await initializeClient(client, backend);
+      return (client: client, activeBackend: backend);
+    } on Exception catch (error, stackTrace) {
+      attempts.add(
+        BackendInitAttemptFailure(
+          backend: backend,
+          error: error,
+          stackTrace: stackTrace,
+        ),
+      );
+      shutdownClient(client);
+      developer.log(
+        '$logTag ${ffiBackendWireName(backend)} backend failed: $error',
+        name: 'flutter_gemma',
+        level: 900,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  if (attempts.isEmpty) {
+    throw StateError('No FFI backend candidates were attempted.');
+  }
+
+  final exception = BackendInitException(attempts: List.unmodifiable(attempts));
+  Error.throwWithStackTrace(exception, exception.lastAttempt.stackTrace);
+}

--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -10,6 +10,7 @@ import '../chat.dart';
 import '../extensions.dart';
 import '../parsing/sdk_response_parser.dart';
 import 'litert_lm_client.dart';
+import '../../pigeon.g.dart';
 
 /// FFI implementation of InferenceModel using dart:ffi → LiteRT-LM C API.
 /// Shared between desktop and mobile (iOS) for .litertlm models.
@@ -18,6 +19,7 @@ class FfiInferenceModel extends InferenceModel {
     required this.ffiClient,
     required this.maxTokens,
     required this.modelType,
+    required this.activeBackend,
     this.fileType = ModelFileType.litertlm,
     this.supportImage = false,
     this.supportAudio = false,
@@ -30,6 +32,8 @@ class FfiInferenceModel extends InferenceModel {
   final ModelFileType fileType;
   @override
   final int maxTokens;
+  @override
+  final PreferredBackend? activeBackend;
   final bool supportImage;
   final bool supportAudio;
   final VoidCallback onClose;

--- a/lib/core/ffi/ffi_inference_model_stub.dart
+++ b/lib/core/ffi/ffi_inference_model_stub.dart
@@ -8,6 +8,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../../flutter_gemma_interface.dart';
+import '../../pigeon.g.dart';
 import '../model.dart';
 import '../tool.dart';
 import 'litert_lm_client_stub.dart';
@@ -18,6 +19,7 @@ class FfiInferenceModel extends InferenceModel {
     required int maxTokens,
     required ModelType modelType,
     ModelFileType fileType = ModelFileType.litertlm,
+    PreferredBackend? activeBackend,
     bool supportImage = false,
     bool supportAudio = false,
     required VoidCallback onClose,
@@ -32,6 +34,10 @@ class FfiInferenceModel extends InferenceModel {
 
   @override
   int get maxTokens =>
+      throw UnsupportedError('web stub — never instantiated');
+
+  @override
+  PreferredBackend? get activeBackend =>
       throw UnsupportedError('web stub — never instantiated');
 
   @override

--- a/lib/desktop/flutter_gemma_desktop.dart
+++ b/lib/desktop/flutter_gemma_desktop.dart
@@ -141,20 +141,14 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
       final cacheDir = (await getApplicationSupportDirectory()).path;
 
       // Initialize via dart:ffi → C API (no JRE, no gRPC)
-      final ffiClient = LiteRtLmFfiClient();
       // NPU is supported via LiteRT-LM's `Backend::NPU` enum on macOS / Linux /
       // Windows (iOS disabled by upstream `LITERT_DISABLE_NPU`). Actual
       // hardware acceleration requires a Qualcomm QNN / Hexagon NN runtime
       // dispatch lib on the device; without one, engine_create fails with a
       // dispatch error from LiteRT-LM. See README for details (#261).
-      final backend = switch (preferredBackend) {
-        PreferredBackend.cpu => 'cpu',
-        PreferredBackend.gpu || null => 'gpu',
-        PreferredBackend.npu => 'npu',
-      };
-      await ffiClient.initialize(
+      final ffiRuntime = await _initializeDesktopFfiInferenceRuntime(
         modelPath: modelPath,
-        backend: backend,
+        preferredBackend: preferredBackend,
         maxTokens: maxTokens,
         cacheDir: cacheDir,
         enableVision: supportImage,
@@ -165,9 +159,10 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
 
       // Create model instance
       final model = _initializedModel = DesktopInferenceModel(
-        ffiClient: ffiClient,
+        ffiClient: ffiRuntime.client,
         maxTokens: maxTokens,
         modelType: modelType,
+        activeBackend: ffiRuntime.activeBackend,
         fileType: fileType,
         supportImage: supportImage,
         supportAudio: supportAudio,
@@ -364,6 +359,69 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
     ServiceRegistry.instance.vectorStoreRepository.enableHnsw = value;
   }
 }
+
+Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
+    _initializeDesktopFfiInferenceRuntime({
+  required String modelPath,
+  required PreferredBackend? preferredBackend,
+  required int maxTokens,
+  required String cacheDir,
+  required bool enableVision,
+  required int maxNumImages,
+  required bool enableAudio,
+  required bool? enableSpeculativeDecoding,
+}) async {
+  Object? firstError;
+  StackTrace? firstStackTrace;
+  for (final backend in _desktopBackendFallbackOrder(preferredBackend)) {
+    final client = LiteRtLmFfiClient();
+    try {
+      await client.initialize(
+        modelPath: modelPath,
+        backend: _desktopBackendWireName(backend),
+        maxTokens: maxTokens,
+        cacheDir: cacheDir,
+        enableVision: enableVision,
+        maxNumImages: maxNumImages,
+        enableAudio: enableAudio,
+        enableSpeculativeDecoding: enableSpeculativeDecoding,
+      );
+      return (client: client, activeBackend: backend);
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+      client.shutdown();
+      debugPrint(
+        '[FlutterGemmaDesktop] ${_desktopBackendWireName(backend)} backend '
+        'failed: $error',
+      );
+    }
+  }
+
+  Error.throwWithStackTrace(firstError!, firstStackTrace!);
+}
+
+List<PreferredBackend> _desktopBackendFallbackOrder(
+  PreferredBackend? preferredBackend,
+) =>
+    switch (preferredBackend) {
+      PreferredBackend.npu => const [
+          PreferredBackend.npu,
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      PreferredBackend.gpu || null => const [
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      PreferredBackend.cpu => const [PreferredBackend.cpu],
+    };
+
+String _desktopBackendWireName(PreferredBackend backend) => switch (backend) {
+      PreferredBackend.npu => 'npu',
+      PreferredBackend.gpu => 'gpu',
+      PreferredBackend.cpu => 'cpu',
+    };
 
 /// Check if current platform is desktop
 bool get isDesktop {

--- a/lib/desktop/flutter_gemma_desktop.dart
+++ b/lib/desktop/flutter_gemma_desktop.dart
@@ -372,11 +372,11 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
   required bool enableAudio,
   required bool? enableSpeculativeDecoding,
 }) async {
-  Object? firstError;
-  StackTrace? firstStackTrace;
-  for (final backend in ffiBackendFallbackOrder(preferredBackend)) {
-    final client = LiteRtLmFfiClient();
-    try {
+  return initializeFfiRuntime(
+    preferredBackend: preferredBackend,
+    logTag: '[FlutterGemmaDesktop]',
+    createClient: LiteRtLmFfiClient.new,
+    initializeClient: (client, backend) async {
       await client.initialize(
         modelPath: modelPath,
         backend: ffiBackendWireName(backend),
@@ -387,19 +387,9 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
         enableAudio: enableAudio,
         enableSpeculativeDecoding: enableSpeculativeDecoding,
       );
-      return (client: client, activeBackend: backend);
-    } on Object catch (error, stackTrace) {
-      firstError ??= error;
-      firstStackTrace ??= stackTrace;
-      client.shutdown();
-      debugPrint(
-        '[FlutterGemmaDesktop] ${ffiBackendWireName(backend)} backend '
-        'failed: $error',
-      );
-    }
-  }
-
-  Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    },
+    shutdownClient: (client) => client.shutdown(),
+  );
 }
 
 /// Check if current platform is desktop

--- a/lib/desktop/flutter_gemma_desktop.dart
+++ b/lib/desktop/flutter_gemma_desktop.dart
@@ -11,6 +11,7 @@ import '../model_file_manager_interface.dart';
 import '../pigeon.g.dart';
 import '../core/model.dart';
 import '../core/di/service_registry.dart';
+import '../core/ffi/backend_preference.dart';
 import '../core/ffi/litert_lm_client.dart';
 import '../core/ffi/ffi_inference_model.dart';
 import '../core/litert/litert_embedding_model.dart';
@@ -373,12 +374,12 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
 }) async {
   Object? firstError;
   StackTrace? firstStackTrace;
-  for (final backend in _desktopBackendFallbackOrder(preferredBackend)) {
+  for (final backend in ffiBackendFallbackOrder(preferredBackend)) {
     final client = LiteRtLmFfiClient();
     try {
       await client.initialize(
         modelPath: modelPath,
-        backend: _desktopBackendWireName(backend),
+        backend: ffiBackendWireName(backend),
         maxTokens: maxTokens,
         cacheDir: cacheDir,
         enableVision: enableVision,
@@ -392,7 +393,7 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
       firstStackTrace ??= stackTrace;
       client.shutdown();
       debugPrint(
-        '[FlutterGemmaDesktop] ${_desktopBackendWireName(backend)} backend '
+        '[FlutterGemmaDesktop] ${ffiBackendWireName(backend)} backend '
         'failed: $error',
       );
     }
@@ -400,28 +401,6 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
 
   Error.throwWithStackTrace(firstError!, firstStackTrace!);
 }
-
-List<PreferredBackend> _desktopBackendFallbackOrder(
-  PreferredBackend? preferredBackend,
-) =>
-    switch (preferredBackend) {
-      PreferredBackend.npu => const [
-          PreferredBackend.npu,
-          PreferredBackend.gpu,
-          PreferredBackend.cpu,
-        ],
-      PreferredBackend.gpu || null => const [
-          PreferredBackend.gpu,
-          PreferredBackend.cpu,
-        ],
-      PreferredBackend.cpu => const [PreferredBackend.cpu],
-    };
-
-String _desktopBackendWireName(PreferredBackend backend) => switch (backend) {
-      PreferredBackend.npu => 'npu',
-      PreferredBackend.gpu => 'gpu',
-      PreferredBackend.cpu => 'cpu',
-    };
 
 /// Check if current platform is desktop
 bool get isDesktop {

--- a/lib/flutter_gemma.dart
+++ b/lib/flutter_gemma.dart
@@ -13,6 +13,8 @@ export 'core/function_call_parser.dart';
 export 'core/tool.dart';
 export 'core/chat.dart';
 export 'core/model_management/cancel_token.dart';
+export 'core/ffi/backend_preference.dart'
+    show BackendInitAttemptFailure, BackendInitException;
 
 // Export image processing utilities to prevent AI image corruption
 export 'core/image_processor.dart';

--- a/lib/flutter_gemma_interface.dart
+++ b/lib/flutter_gemma_interface.dart
@@ -133,6 +133,13 @@ abstract class InferenceModel {
 
   ModelFileType get fileType;
 
+  /// Backend that the runtime initialized for this model, when known.
+  ///
+  /// This value is set after runtime creation and must reflect any fallback the
+  /// plugin performed internally. It is null when the platform runtime does not
+  /// expose a final backend.
+  PreferredBackend? get activeBackend;
+
   /// Creates a new [InferenceModelSession] for generation.
   ///
   /// [temperature], [randomSeed], [topK], [topP] — parameters for sampling.

--- a/lib/flutter_gemma_interface.dart
+++ b/lib/flutter_gemma_interface.dart
@@ -136,8 +136,10 @@ abstract class InferenceModel {
   /// Backend that the runtime initialized for this model, when known.
   ///
   /// This value is set after runtime creation and must reflect any fallback the
-  /// plugin performed internally. It is null when the platform runtime does not
-  /// expose a final backend.
+  /// plugin performed internally. FFI runtimes may fall back silently from a
+  /// requested accelerator to another backend, so callers should check this
+  /// value when the exact backend matters. It is null when the platform runtime
+  /// does not expose a final backend.
   PreferredBackend? get activeBackend;
 
   /// Creates a new [InferenceModelSession] for generation.

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -388,7 +388,6 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
         final cacheDir = (await getApplicationSupportDirectory()).path;
         debugPrint(
             '[FlutterGemmaMobile/perf] getApplicationSupportDirectory: ${ffiPathSw.elapsedMilliseconds}ms');
-        final ffiClient = LiteRtLmFfiClient();
         // NPU on Android `.litertlm` restored to 0.13.x parity. The Kotlin
         // LiteRtLmEngine path was dropped in 0.14.0 (commit 81025da); this
         // routes the same `Backend::NPU` enum value through LiteRT-LM's C
@@ -397,15 +396,10 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
         // a dispatch error from LiteRT-LM. iOS .litertlm: upstream LiteRT-LM
         // disables NPU via LITERT_DISABLE_NPU at build time; engine_create
         // returns a clean Backend::NPU not supported error.
-        final backend = switch (preferredBackend) {
-          PreferredBackend.cpu => 'cpu',
-          PreferredBackend.gpu || null => 'gpu',
-          PreferredBackend.npu => 'npu',
-        };
         final beforeInit = ffiPathSw.elapsedMilliseconds;
-        await ffiClient.initialize(
+        final ffiRuntime = await _initializeFfiInferenceRuntime(
           modelPath: modelPath,
-          backend: backend,
+          preferredBackend: preferredBackend,
           maxTokens: maxTokens,
           cacheDir: cacheDir,
           enableVision: supportImage,
@@ -419,9 +413,10 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
             '[FlutterGemmaMobile/perf] FFI model creation total: ${ffiPathSw.elapsedMilliseconds}ms');
 
         model = _initializedModel = FfiInferenceModel(
-          ffiClient: ffiClient,
+          ffiClient: ffiRuntime.client,
           maxTokens: maxTokens,
           modelType: modelType,
+          activeBackend: ffiRuntime.activeBackend,
           fileType: fileType,
           supportImage: supportImage,
           supportAudio: supportAudio,
@@ -447,6 +442,7 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
           modelType: modelType,
           fileType: fileType,
           preferredBackend: preferredBackend,
+          activeBackend: null,
           supportedLoraRanks: loraRanks ?? supportedLoraRanks,
           supportImage: supportImage,
           supportAudio: supportAudio,
@@ -687,3 +683,66 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
     ServiceRegistry.instance.vectorStoreRepository.enableHnsw = value;
   }
 }
+
+Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
+    _initializeFfiInferenceRuntime({
+  required String modelPath,
+  required PreferredBackend? preferredBackend,
+  required int maxTokens,
+  required String cacheDir,
+  required bool enableVision,
+  required int maxNumImages,
+  required bool enableAudio,
+  required bool? enableSpeculativeDecoding,
+}) async {
+  Object? firstError;
+  StackTrace? firstStackTrace;
+  for (final backend in _backendFallbackOrder(preferredBackend)) {
+    final client = LiteRtLmFfiClient();
+    try {
+      await client.initialize(
+        modelPath: modelPath,
+        backend: _backendWireName(backend),
+        maxTokens: maxTokens,
+        cacheDir: cacheDir,
+        enableVision: enableVision,
+        maxNumImages: maxNumImages,
+        enableAudio: enableAudio,
+        enableSpeculativeDecoding: enableSpeculativeDecoding,
+      );
+      return (client: client, activeBackend: backend);
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+      client.shutdown();
+      debugPrint(
+        '[FlutterGemmaMobile] ${_backendWireName(backend)} backend failed: '
+        '$error',
+      );
+    }
+  }
+
+  Error.throwWithStackTrace(firstError!, firstStackTrace!);
+}
+
+List<PreferredBackend> _backendFallbackOrder(
+  PreferredBackend? preferredBackend,
+) =>
+    switch (preferredBackend) {
+      PreferredBackend.npu => const [
+          PreferredBackend.npu,
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      PreferredBackend.gpu || null => const [
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      PreferredBackend.cpu => const [PreferredBackend.cpu],
+    };
+
+String _backendWireName(PreferredBackend backend) => switch (backend) {
+      PreferredBackend.npu => 'npu',
+      PreferredBackend.gpu => 'gpu',
+      PreferredBackend.cpu => 'cpu',
+    };

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -15,6 +15,7 @@ import '../core/di/service_registry.dart';
 // (FlutterGemmaWeb) registers itself as FlutterGemmaPlugin.instance via
 // registerWith() before any of this code can run, so the stubs' constructors
 // (which throw UnsupportedError) are never reached on web.
+import '../core/ffi/backend_preference.dart';
 import '../core/ffi/litert_lm_client.dart'
     if (dart.library.js_interop) '../core/ffi/litert_lm_client_stub.dart';
 import '../core/ffi/ffi_inference_model.dart'
@@ -697,12 +698,12 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
 }) async {
   Object? firstError;
   StackTrace? firstStackTrace;
-  for (final backend in _backendFallbackOrder(preferredBackend)) {
+  for (final backend in ffiBackendFallbackOrder(preferredBackend)) {
     final client = LiteRtLmFfiClient();
     try {
       await client.initialize(
         modelPath: modelPath,
-        backend: _backendWireName(backend),
+        backend: ffiBackendWireName(backend),
         maxTokens: maxTokens,
         cacheDir: cacheDir,
         enableVision: enableVision,
@@ -716,7 +717,7 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
       firstStackTrace ??= stackTrace;
       client.shutdown();
       debugPrint(
-        '[FlutterGemmaMobile] ${_backendWireName(backend)} backend failed: '
+        '[FlutterGemmaMobile] ${ffiBackendWireName(backend)} backend failed: '
         '$error',
       );
     }
@@ -724,25 +725,3 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
 
   Error.throwWithStackTrace(firstError!, firstStackTrace!);
 }
-
-List<PreferredBackend> _backendFallbackOrder(
-  PreferredBackend? preferredBackend,
-) =>
-    switch (preferredBackend) {
-      PreferredBackend.npu => const [
-          PreferredBackend.npu,
-          PreferredBackend.gpu,
-          PreferredBackend.cpu,
-        ],
-      PreferredBackend.gpu || null => const [
-          PreferredBackend.gpu,
-          PreferredBackend.cpu,
-        ],
-      PreferredBackend.cpu => const [PreferredBackend.cpu],
-    };
-
-String _backendWireName(PreferredBackend backend) => switch (backend) {
-      PreferredBackend.npu => 'npu',
-      PreferredBackend.gpu => 'gpu',
-      PreferredBackend.cpu => 'cpu',
-    };

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -696,11 +696,11 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
   required bool enableAudio,
   required bool? enableSpeculativeDecoding,
 }) async {
-  Object? firstError;
-  StackTrace? firstStackTrace;
-  for (final backend in ffiBackendFallbackOrder(preferredBackend)) {
-    final client = LiteRtLmFfiClient();
-    try {
+  return initializeFfiRuntime(
+    preferredBackend: preferredBackend,
+    logTag: '[FlutterGemmaMobile]',
+    createClient: LiteRtLmFfiClient.new,
+    initializeClient: (client, backend) async {
       await client.initialize(
         modelPath: modelPath,
         backend: ffiBackendWireName(backend),
@@ -711,17 +711,7 @@ Future<({LiteRtLmFfiClient client, PreferredBackend activeBackend})>
         enableAudio: enableAudio,
         enableSpeculativeDecoding: enableSpeculativeDecoding,
       );
-      return (client: client, activeBackend: backend);
-    } on Object catch (error, stackTrace) {
-      firstError ??= error;
-      firstStackTrace ??= stackTrace;
-      client.shutdown();
-      debugPrint(
-        '[FlutterGemmaMobile] ${ffiBackendWireName(backend)} backend failed: '
-        '$error',
-      );
-    }
-  }
-
-  Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    },
+    shutdownClient: (client) => client.shutdown(),
+  );
 }

--- a/lib/mobile/flutter_gemma_mobile_inference_model.dart
+++ b/lib/mobile/flutter_gemma_mobile_inference_model.dart
@@ -7,6 +7,7 @@ class MobileInferenceModel extends InferenceModel {
     required this.modelType,
     this.fileType = ModelFileType.task,
     this.preferredBackend,
+    this.activeBackend,
     this.supportedLoraRanks,
     this.supportImage = false, // Enabling image support
     this.supportAudio = false, // Enabling audio support (Gemma 3n E4B)
@@ -66,6 +67,8 @@ class MobileInferenceModel extends InferenceModel {
 
   @override
   final int maxTokens;
+  @override
+  final PreferredBackend? activeBackend;
   final VoidCallback onClose;
   final PreferredBackend? preferredBackend;
   final List<int>? supportedLoraRanks;

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -376,6 +376,8 @@ class WebInferenceModel extends InferenceModel {
   final ModelType modelType;
   @override
   final ModelFileType fileType;
+  @override
+  PreferredBackend? get activeBackend => null;
   final List<int>? loraRanks;
   final WebModelManager modelManager;
   final bool supportImage; // Enabling image support

--- a/test/core/ffi/backend_preference_test.dart
+++ b/test/core/ffi/backend_preference_test.dart
@@ -44,4 +44,107 @@ void main() {
       expect(ffiBackendWireName(PreferredBackend.cpu), 'cpu');
     });
   });
+
+  group('initializeFfiRuntime', () {
+    test(
+      'returns the first successfully initialized fallback backend',
+      () async {
+        final clients = <_FakeClient>[];
+
+        final runtime = await initializeFfiRuntime<_FakeClient>(
+          preferredBackend: PreferredBackend.gpu,
+          logTag: '[Test]',
+          createClient: () {
+            final client = _FakeClient();
+            clients.add(client);
+            return client;
+          },
+          initializeClient: (client, backend) async {
+            client.backend = backend;
+            if (backend == PreferredBackend.gpu) {
+              throw Exception('gpu unavailable');
+            }
+          },
+          shutdownClient: (client) => client.shutdown(),
+        );
+
+        expect(runtime.activeBackend, PreferredBackend.cpu);
+        expect(runtime.client, same(clients[1]));
+        expect(clients[0].isShutdown, isTrue);
+        expect(clients[1].isShutdown, isFalse);
+      },
+    );
+
+    test('throws an inspectable exception with all backend attempts', () async {
+      final clients = <_FakeClient>[];
+
+      await expectLater(
+        initializeFfiRuntime<_FakeClient>(
+          preferredBackend: PreferredBackend.npu,
+          logTag: '[Test]',
+          createClient: () {
+            final client = _FakeClient();
+            clients.add(client);
+            return client;
+          },
+          initializeClient: (client, backend) async {
+            client.backend = backend;
+            throw Exception('${ffiBackendWireName(backend)} failed');
+          },
+          shutdownClient: (client) => client.shutdown(),
+        ),
+        throwsA(
+          isA<BackendInitException>()
+              .having(
+                (exception) =>
+                    exception.attempts.map((attempt) => attempt.backend),
+                'attempted backends',
+                [
+                  PreferredBackend.npu,
+                  PreferredBackend.gpu,
+                  PreferredBackend.cpu,
+                ],
+              )
+              .having(
+                (exception) => exception.lastAttempt.backend,
+                'last attempt',
+                PreferredBackend.cpu,
+              ),
+        ),
+      );
+
+      expect(clients, hasLength(3));
+      expect(clients.every((client) => client.isShutdown), isTrue);
+    });
+
+    test(
+      'does not catch programming errors as backend fallback failures',
+      () async {
+        final error = AssertionError('bug');
+        late _FakeClient client;
+
+        await expectLater(
+          initializeFfiRuntime<_FakeClient>(
+            preferredBackend: PreferredBackend.cpu,
+            logTag: '[Test]',
+            createClient: () => client = _FakeClient(),
+            initializeClient: (_, __) async => throw error,
+            shutdownClient: (client) => client.shutdown(),
+          ),
+          throwsA(same(error)),
+        );
+
+        expect(client.isShutdown, isFalse);
+      },
+    );
+  });
+}
+
+class _FakeClient {
+  PreferredBackend? backend;
+  bool isShutdown = false;
+
+  void shutdown() {
+    isShutdown = true;
+  }
 }

--- a/test/core/ffi/backend_preference_test.dart
+++ b/test/core/ffi/backend_preference_test.dart
@@ -122,6 +122,13 @@ void main() {
       );
     });
 
+    test('requires at least one failed backend attempt', () {
+      expect(
+        () => BackendInitException(attempts: const []),
+        throwsArgumentError,
+      );
+    });
+
     test(
       'does not catch programming errors as backend fallback failures',
       () async {

--- a/test/core/ffi/backend_preference_test.dart
+++ b/test/core/ffi/backend_preference_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_gemma/core/ffi/backend_preference.dart';
+import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ffiBackendFallbackOrder', () {
+    test('tries NPU, then GPU, then CPU for an NPU preference', () {
+      expect(
+        ffiBackendFallbackOrder(PreferredBackend.npu),
+        const [
+          PreferredBackend.npu,
+          PreferredBackend.gpu,
+          PreferredBackend.cpu,
+        ],
+      );
+    });
+
+    test('tries GPU, then CPU for a GPU preference', () {
+      expect(
+        ffiBackendFallbackOrder(PreferredBackend.gpu),
+        const [PreferredBackend.gpu, PreferredBackend.cpu],
+      );
+    });
+
+    test('tries GPU, then CPU when no preference is provided', () {
+      expect(
+        ffiBackendFallbackOrder(null),
+        const [PreferredBackend.gpu, PreferredBackend.cpu],
+      );
+    });
+
+    test('tries only CPU for a CPU preference', () {
+      expect(
+        ffiBackendFallbackOrder(PreferredBackend.cpu),
+        const [PreferredBackend.cpu],
+      );
+    });
+  });
+
+  group('ffiBackendWireName', () {
+    test('serializes backend preferences for LiteRT-LM', () {
+      expect(ffiBackendWireName(PreferredBackend.npu), 'npu');
+      expect(ffiBackendWireName(PreferredBackend.gpu), 'gpu');
+      expect(ffiBackendWireName(PreferredBackend.cpu), 'cpu');
+    });
+  });
+}

--- a/test/core/ffi/backend_preference_test.dart
+++ b/test/core/ffi/backend_preference_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_gemma/core/ffi/backend_preference.dart';
+import 'package:flutter_gemma/flutter_gemma.dart' as public_api;
 import 'package:flutter_gemma/pigeon.g.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -94,27 +95,31 @@ void main() {
           shutdownClient: (client) => client.shutdown(),
         ),
         throwsA(
-          isA<BackendInitException>()
-              .having(
-                (exception) =>
-                    exception.attempts.map((attempt) => attempt.backend),
-                'attempted backends',
-                [
-                  PreferredBackend.npu,
-                  PreferredBackend.gpu,
-                  PreferredBackend.cpu,
-                ],
-              )
-              .having(
-                (exception) => exception.lastAttempt.backend,
-                'last attempt',
-                PreferredBackend.cpu,
-              ),
+          isA<BackendInitException>().having(
+            (exception) => exception.attempts.map((attempt) => attempt.backend),
+            'attempted backends',
+            [
+              PreferredBackend.npu,
+              PreferredBackend.gpu,
+              PreferredBackend.cpu,
+            ],
+          ).having(
+            (exception) => exception.lastAttempt.backend,
+            'last attempt',
+            PreferredBackend.cpu,
+          ),
         ),
       );
 
       expect(clients, hasLength(3));
       expect(clients.every((client) => client.isShutdown), isTrue);
+    });
+
+    test('exports the aggregate exception from the public API', () {
+      expect(
+        public_api.BackendInitException,
+        same(BackendInitException),
+      );
     });
 
     test(

--- a/test/core/ffi/ffi_inference_model_test.dart
+++ b/test/core/ffi/ffi_inference_model_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_gemma/core/ffi/ffi_inference_model.dart';
+import 'package:flutter_gemma/core/ffi/litert_lm_client.dart';
+import 'package:flutter_gemma/core/model.dart';
+import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('FfiInferenceModel exposes the backend initialized by the runtime', () {
+    final model = FfiInferenceModel(
+      ffiClient: LiteRtLmFfiClient(),
+      maxTokens: 2048,
+      modelType: ModelType.gemmaIt,
+      activeBackend: PreferredBackend.gpu,
+      onClose: () {},
+    );
+
+    expect(model.activeBackend, PreferredBackend.gpu);
+  });
+}


### PR DESCRIPTION
## Summary
- expose `InferenceModel.activeBackend` so callers can inspect the backend actually initialized by the runtime
- make FFI `.litertlm` initialization try backend fallback inside the plugin and return the backend that succeeded
- share and test the FFI backend fallback order / LiteRT-LM wire names
- report null for web and MediaPipe runtimes where the final initialized backend is not currently observable

## Motivation
Callers can request a preferred backend, but the runtime may fall back. This gives applications a way to show users the compute backend actually in use without implementing their own fallback or probe loop.

## Tests
- `test/core/ffi/backend_preference_test.dart` covers NPU -> GPU -> CPU, GPU -> CPU, null -> GPU -> CPU, CPU-only fallback, and wire names
- `test/core/ffi/ffi_inference_model_test.dart` covers that the FFI model exposes the initialized backend

## Validation
- flutter pub get
- dart analyze lib/flutter_gemma_interface.dart lib/core/ffi/backend_preference.dart lib/core/ffi/ffi_inference_model.dart lib/core/ffi/ffi_inference_model_stub.dart lib/mobile/flutter_gemma_mobile_inference_model.dart lib/web/flutter_gemma_web.dart lib/mobile/flutter_gemma_mobile.dart lib/desktop/flutter_gemma_desktop.dart test/core/ffi/backend_preference_test.dart test/core/ffi/ffi_inference_model_test.dart
- flutter test test/core/ffi/backend_preference_test.dart test/core/ffi/ffi_inference_model_test.dart test/core/litertlm_file_type_test.dart test/desktop_vision_params_test.dart --reporter=failures-only
- git diff --check

## Notes
`flutter pub get` updated local lockfile resolution for `meta` and `test_api` with this Flutter SDK, but those lockfile changes were intentionally not included in the commit.