### PR TITLE
fix: make iOS LiteRtLm artifacts Native-Assets strippable

### DIFF
--- a/native/litert_lm/build_ios.sh
+++ b/native/litert_lm/build_ios.sh
@@ -24,13 +24,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LITERT_LM_DIR="/tmp/LiteRT-LM"
+LITERT_LM_DIR="${LITERT_LM_DIR:-/tmp/LiteRT-LM}"
 VERSION="${1:-}"
 
 echo "=== Building libLiteRtLm.dylib for iOS ==="
 
 # 1. Clone or update LiteRT-LM
-if [ -d "$LITERT_LM_DIR" ]; then
+if [ -d "$LITERT_LM_DIR/.git" ]; then
   echo "Updating $LITERT_LM_DIR..."
   cd "$LITERT_LM_DIR"
   # --force so a tag that moved upstream (e.g. v0.11.0 itself was retagged
@@ -65,7 +65,7 @@ cc_binary(
     linkshared = True,
     linkopts = select({
         "@platforms//os:macos": ["-Wl,-exported_symbol,_LiteRt*", "-Wl,-exported_symbol,_litert_lm_*"],
-        "@platforms//os:ios": ["-Wl,-exported_symbol,_LiteRt*", "-Wl,-exported_symbol,_litert_lm_*"],
+        "@platforms//os:ios": ["-Wl,-exported_symbol,_LiteRt*", "-Wl,-exported_symbol,_litert_lm_*", "-Wl,-x"],
         "@platforms//os:linux": ["-Wl,--export-dynamic-symbol=LiteRt*", "-Wl,--export-dynamic-symbol=litert_lm_*"],
         "//conditions:default": [],
     }),
@@ -82,6 +82,23 @@ bash "$SCRIPT_DIR/patch_c_api.sh" "$LITERT_LM_DIR"
 # 4. Pull LFS files
 echo "Pulling LFS files..."
 git lfs pull --include="prebuilt/ios_arm64/*,prebuilt/ios_sim_arm64/*"
+
+verify_flutter_ios_strip() {
+  local dylib="$1"
+  local probe
+  local output
+
+  probe="$(mktemp)"
+  cp "$dylib" "$probe"
+  if ! output="$(xcrun strip -x -S "$probe" 2>&1)"; then
+    rm -f "$probe"
+    echo "ERROR: $dylib is not compatible with Flutter iOS Native Assets release stripping."
+    echo "Flutter runs: xcrun strip -x -S <dylib>"
+    printf '%s\n' "$output"
+    return 1
+  fi
+  rm -f "$probe"
+}
 
 # 5. Build for iOS device (arm64)
 echo ""
@@ -162,9 +179,15 @@ echo "=== Verification ==="
 echo "Device (ios_arm64):"
 ls -lh "$DEVICE_DIR/"
 nm -gU "$DEVICE_DIR/libLiteRtLm.dylib" | grep "litert_lm_engine_create" | head -1
+for dylib in "$DEVICE_DIR"/*.dylib; do
+  verify_flutter_ios_strip "$dylib"
+done
 echo ""
 echo "Simulator (ios_sim_arm64):"
 ls -lh "$SIM_DIR/"
 nm -gU "$SIM_DIR/libLiteRtLm.dylib" | grep "litert_lm_engine_create" | head -1
+for dylib in "$SIM_DIR"/*.dylib; do
+  verify_flutter_ios_strip "$dylib"
+done
 echo ""
 echo "=== Done ==="


### PR DESCRIPTION
## Summary
- keep iOS `LiteRtLm` on the normal Flutter Native Assets path; no host-side iOS `Podfile` `post_install` is required
- add the Apple linker `-Wl,-x` flag when generating the LiteRT-LM iOS shared library target so local symbols are removed at link time while the exported LiteRT-LM C API remains exported
- make `native/litert_lm/build_ios.sh` fail the iOS archive build unless every generated iOS dylib survives Flutter's release-build strip command, `xcrun strip -x -S`
- let maintainers override `LITERT_LM_DIR` for local rebuilds and only treat the directory as an existing checkout when it contains `.git`

## Why
Flutter's iOS Native Assets release pipeline strips bundled dylibs with `xcrun strip -x -S`. The currently published `libLiteRtLm.dylib` fails that exact command because its indirect symbol table references symbols that strip wants to remove. A host-app `Podfile` workaround can avoid the strip step, but that makes every iOS app carry package-specific Xcode logic.

The cleaner ownership boundary is the native artifact build: emit an iOS dylib that Native Assets can install normally, then prove it before publishing the archive.

## Validation
Environment:
- macOS 26.5 (25F71)
- Xcode 26.3 (17C529)
- Flutter 3.44.0 stable
- `xcrun` 72, strip at `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip`

Commands/proofs:
- `bash -n native/litert_lm/build_ios.sh`
- `git diff --check`
- reproduced the current published artifact failure with `/usr/bin/xcrun strip -x -S <copied published libLiteRtLm.dylib>`:
  - exit code: `1`
  - error: `symbols referenced by indirect symbol table entries that can't be stripped in: ...`
- rebuilt the full LiteRT-LM iOS artifacts with this script for:
  - `native/litert_lm/prebuilt/ios_arm64`
  - `native/litert_lm/prebuilt/ios_sim_arm64`
- the script's built-in `verify_flutter_ios_strip` pass completed for every generated dylib in both directories
- repeated explicit strip probes over every generated iOS dylib:
  - `libGemmaModelConstraintProvider.dylib`
  - `libLiteRtLm.dylib`
  - `libLiteRtMetalAccelerator.dylib`
  - `libStreamProxy.dylib`
- confirmed `vtool -show-build` still reports iOS/simulator platform metadata and the existing `libGemmaModelConstraintProvider.dylib` minos patch at 16.0
- built the example app end-to-end:
  - `flutter build ios --release --no-pub --no-codesign`
  - result: `✓ Built build/ios/iphoneos/Runner.app (93.3MB)`
  - app bundle contains the expected Native Assets frameworks: `LiteRtLm.framework`, `GemmaModelConstraintProvider.framework`, `LiteRtMetalAccelerator.framework`, `StreamProxy.framework`, plus qdrant/sqlite assets

Locally generated archive checksums from the rebuilt artifacts:
- `litertlm-ios_arm64.tar.gz`: `71e038a39ce32b7be82db64ea9bd2db9fcc2577e5548cf0fa7a8942bea5ee06f`
- `litertlm-ios_sim_arm64.tar.gz`: `60268e7cac4798b6dec3fd25426a3263eab4792a4397054086730de47548be76`

## Release note
This changes the native iOS artifact build path. Before publishing a package release that consumes this fix, rebuild/upload the iOS LiteRT-LM archives and update `hook/build.dart` checksums/version to point at the newly published archive contents.