### PR TITLE
Release 0.16.1

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -133,19 +133,31 @@ Also regenerate `checksums_litertlm.txt` for the GitHub Release page (single tex
 
 ## Step 6: Update GitHub Release assets
 
-### Option A — overwrite existing tag (`native-v0.10.2`)
-Use only if `_nativeVersion` did NOT bump. Replaces assets in place; downstream pinning to the tag will silently get new bytes.
-```bash
-RELEASE=native-v0.10.2
-for f in "$DIST"/litertlm-*.tar.gz "$DIST"/checksums_litertlm.txt; do
-  name=$(basename "$f")
-  gh release delete-asset "$RELEASE" "$name" --yes 2>/dev/null || true
-  gh release upload "$RELEASE" "$f"
-done
-```
+### ⛔ NEVER overwrite a tag referenced by a published plugin version
 
-### Option B — new tag (`native-v0.10.3`)
-Cleanest. Old `native-v0.10.2` keeps working for old plugin versions. Need GitHub Release notes describing what changed.
+`gh release upload --clobber` on an existing `native-v*` / `qdrant-edge-v*`
+tag silently breaks every end user already on a plugin version whose
+`hook/build.dart` references that tag. The published SHA256 (in their
+`pubspec.lock`-pinned plugin code) no longer matches the bytes GitHub
+serves, the hook deletes the archive and returns null, the build
+succeeds with a missing CodeAsset, and the app crashes at runtime on
+first `dlopen()`.
+
+This is unrecoverable. `tar -czf` is not deterministic across runs
+(mtime, file ordering, gzip block boundaries differ), so even with
+every original dylib byte you cannot reproduce the original tar SHA256.
+
+**Always publish a new tag instead** — `native-v0.10.3`, not
+`native-v0.10.2` reuploaded. The cost of a new tag is zero; the cost
+of breaking a shipped plugin version is real users with runtime
+crashes who cannot upgrade until the next release cycle.
+
+See `feedback_never_reupload_released_tarballs.md` for the full
+incident write-up.
+
+### Always: new tag (`native-v0.10.3`)
+Old `native-v0.10.2` keeps working for old plugin versions. Need
+GitHub Release notes describing what changed.
 ```bash
 RELEASE=native-v0.10.3
 gh release create "$RELEASE" "$DIST"/litertlm-*.tar.gz "$DIST"/checksums_litertlm.txt \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.16.1
+- **LiteRT-LM v0.12.0** native bump (commit `ffed38a`): NPU dispatch now available on Linux/macOS as well as Windows.
+- **Fix iOS App Store upload (ITMS-90208)** (#286): iOS LiteRT-LM and qdrant-edge artifacts repacked.
+- **Fix iOS Native Assets strip step on Xcode 26** (#289, thanks @merlinnot): emit `libLiteRtLm.dylib` with `-Wl,-x` so `xcrun strip -x -S` succeeds during release builds.
+- **Fix Windows install path** when `%LOCALAPPDATA%` env var is relative — falls back to `USERPROFILE\AppData\Local` then `getApplicationSupportDirectory()`.
+
 ## 0.16.0
 - **Native vector store: qdrant-edge by default.** Replaces sqlite + local_hnsw on every native platform. Web unchanged (wa-sqlite). Old impl `@Deprecated`, removal in 1.0.
 - **Filter DSL** for `searchSimilar(... filter: Filter(must: [...], should: [...], mustNot: [...]))`. Honored on native; silently ignored on Web.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,9 @@
 | iOS Device | ✅ | ✅ | ✅ | GPU via Metal delegate (FFI). Setup via Podfile `post_install` (creates `lib*.dylib` symlinks next to bundled frameworks) |
 | iOS Simulator | ❌ GPU | ❌ GPU | ✅ | CPU only — Metal sim has 256 MB single-allocation cap, LLM weights exceed |
 | Web | ✅ | ❌ | ✅ | MediaPipe only |
-| macOS | ✅ | ✅ LiteRT-LM (CPU + GPU) | ✅ | Vision + audio verified on Metal (Gemma 4 + Gemma 3n); Gemma 3n audio GPU is ~2× faster than CPU |
-| Windows | ✅ | ✅ LiteRT-LM (CPU + GPU) | ✅ | Desktop via FFI; GPU via WebGPU/DX12 |
-| Linux | ✅ | ✅ LiteRT-LM (CPU + GPU) | ✅ | Desktop via FFI; GPU via WebGPU/Vulkan |
+| macOS | ✅ | ✅ LiteRT-LM only | ✅ | Vision + audio verified on Metal (Gemma 4 + Gemma 3n); Gemma 3n audio GPU is ~2× faster than CPU |
+| Windows | ✅ | ✅ LiteRT-LM only | ✅ | Desktop via FFI; GPU via WebGPU/DX12 |
+| Linux | ✅ | ✅ LiteRT-LM only | ✅ | Desktop via FFI; GPU via WebGPU/Vulkan |
 
 ### PreferredBackend
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,9 @@
 | iOS Device | ✅ | ✅ | ✅ | GPU via Metal delegate (FFI). Setup via Podfile `post_install` (creates `lib*.dylib` symlinks next to bundled frameworks) |
 | iOS Simulator | ❌ GPU | ❌ GPU | ✅ | CPU only — Metal sim has 256 MB single-allocation cap, LLM weights exceed |
 | Web | ✅ | ❌ | ✅ | MediaPipe only |
-| macOS | ✅ | ✅ LiteRT-LM only | ✅ | Vision verified on Metal (Gemma 4 + Gemma 3n) |
-| Windows | ✅ | ✅ LiteRT-LM only | ✅ | Desktop via FFI; GPU via WebGPU/DX12 |
-| Linux | ✅ | ✅ LiteRT-LM only | ✅ | Desktop via FFI; GPU via WebGPU/Vulkan |
+| macOS | ✅ | ✅ LiteRT-LM (CPU + GPU) | ✅ | Vision + audio verified on Metal (Gemma 4 + Gemma 3n); Gemma 3n audio GPU is ~2× faster than CPU |
+| Windows | ✅ | ✅ LiteRT-LM (CPU + GPU) | ✅ | Desktop via FFI; GPU via WebGPU/DX12 |
+| Linux | ✅ | ✅ LiteRT-LM (CPU + GPU) | ✅ | Desktop via FFI; GPU via WebGPU/Vulkan |
 
 ### PreferredBackend
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@
 - **ModelSource**: Type-safe sealed class (`NetworkSource`, `AssetSource`, `BundledSource`, `FileSource`). See `lib/core/domain/`
 - **Install vs Runtime separation**: Installation stores identity (modelType + fileType), runtime accepts config (maxTokens, backend, etc.)
 - **Engine selection by file extension**: `.task`/`.bin`/`.tflite` → MediaPipe, `.litertlm` → LiteRT-LM
-- **All five platforms (Android/iOS/macOS/Linux/Windows)**: Dart → `dart:ffi` → LiteRT-LM C API (inference) + LiteRT C API (embeddings). Native prebuilts fetched at build time via `hook/build.dart` (Native Assets) from GitHub release `native-v0.11.0-b`.
+- **All five platforms (Android/iOS/macOS/Linux/Windows)**: Dart → `dart:ffi` → LiteRT-LM C API (inference) + LiteRT C API (embeddings). Native prebuilts fetched at build time via `hook/build.dart` (Native Assets) from GitHub release `native-v0.12.0`.
 
 ### Supported Models
 
@@ -119,8 +119,8 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **Dart SDK**: `>=3.6.0 <4.0.0`
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
-- **LiteRT-LM**: native libs from `native-v0.11.0-b` GitHub Release. Windows tarball built from upstream `google-ai-edge/LiteRT-LM` commit `62f7a8e` and bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` on Intel LunarLake/PantherLake silicon. Other 6 platforms unchanged from -a (commit `032334d`). Native Assets bundled — same `.so`/`.dylib`/`.dll` set on all platforms. `-c opt --strip=always` build; retains vtool minos patch (26.2 → 16.0) on iOS `libGemmaModelConstraintProvider.dylib` and 16KB page alignment on Android `libLiteRtLm.so`. MTP (speculative decoding) support for Gemma 4.
-- **Current Version**: 0.16.0 — native vector store switched to qdrant-edge by default. Replaces `DartVectorStoreRepository` (sqlite3 + `local_hnsw`) on every native platform; Web stays on `WebVectorStoreRepository` (wa-sqlite). Adds `Filter` DSL to `searchSimilar`. Old impl `@Deprecated`. Upstream tracking: qdrant/qdrant#9067.
+- **LiteRT-LM**: native libs from `native-v0.12.0` GitHub Release. Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` on Intel LunarLake/PantherLake silicon. MTP (speculative decoding) support for Gemma 4.
+- **Current Version**: 0.16.1
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup
@@ -150,7 +150,7 @@ window.LlmInference = LlmInference;
 
 ### Desktop (macOS/Windows/Linux)
 - Architecture: Dart → `dart:ffi` → LiteRT-LM C API (no JVM, no gRPC)
-- Native libs fetched at build time by `hook/build.dart` from `native-v0.11.0-b` GitHub release; SHA256-verified, bundled via Native Assets
+- Native libs fetched at build time by `hook/build.dart` from `native-v0.12.0` GitHub release; SHA256-verified, bundled via Native Assets
 - Desktop uses `.litertlm` format only (not `.task`)
 - Windows GPU requires `dxil.dll` + `dxcompiler.dll` (DirectXShaderCompiler runtime) — bundled in the Windows native archive
 - Windows NPU (`PreferredBackend.npu`) requires Intel LunarLake/PantherLake silicon — `LiteRtDispatch.dll` + OpenVino runtime + TBB bundled in the Windows native archive (0.15.1+)

--- a/README.md
+++ b/README.md
@@ -1303,7 +1303,7 @@ Function calling is currently supported by the following models:
 |---------|---------|-----|-----|---------|-------|
 | **Text Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All models supported |
 | **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Verified on macOS Metal and Linux Vulkan (Gemma 4 + Gemma 3n) |
-| **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ `.litertlm` only | Gemma3n E2B/E4B; iOS device-only; Desktop via FFI |
+| **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ `.litertlm` (CPU + GPU) | Gemma3n E2B/E4B + Gemma 4; iOS device-only; Desktop CPU + GPU via FFI |
 | **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Gemma 4 native (SDK chat template) |
 | **Thinking Mode** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | DeepSeek & Gemma 4 |
 | **Stop Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Cancel mid-process |

--- a/README.md
+++ b/README.md
@@ -1303,7 +1303,7 @@ Function calling is currently supported by the following models:
 |---------|---------|-----|-----|---------|-------|
 | **Text Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | All models supported |
 | **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Verified on macOS Metal and Linux Vulkan (Gemma 4 + Gemma 3n) |
-| **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ `.litertlm` (CPU + GPU) | Gemma3n E2B/E4B + Gemma 4; iOS device-only; Desktop CPU + GPU via FFI |
+| **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ `.litertlm` only | Gemma3n E2B/E4B + Gemma 4; iOS device-only; Desktop via FFI |
 | **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Gemma 4 native (SDK chat template) |
 | **Thinking Mode** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | DeepSeek & Gemma 4 |
 | **Stop Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Cancel mid-process |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-    # Flutter Gemma
+# Flutter Gemma
 
 [![CI Tests](https://github.com/DenisovAV/flutter_gemma/actions/workflows/test.yml/badge.svg)](https://github.com/DenisovAV/flutter_gemma/actions/workflows/test.yml)
 [![Release Build](https://github.com/DenisovAV/flutter_gemma/actions/workflows/release.yml/badge.svg)](https://github.com/DenisovAV/flutter_gemma/actions/workflows/release.yml)
@@ -53,6 +53,7 @@ There is an example of using:
 - 🚀 **Native vector store on qdrant-edge** — `addDocument()` / `searchSimilar()` API unchanged; 30–300× faster than the legacy sqlite + local_hnsw path on every desktop and mobile target. Old impl `@Deprecated`, removed in 1.0.
 - 🎯 **`Filter` DSL** for `searchSimilar(... filter: Filter(must: [FieldEquals('lang', 'en')], mustNot: [...]))`. Honored on native, silently ignored on Web.
 - 🔧 **Desktop install/validate path fix** — `isModelInstalled()` now reads the same storage location the installer writes to. Affected: Windows/macOS/Linux users on clean machines who saw "Active model is no longer installed" right after install in 0.15.x.
+- ⚡ **LiteRT-LM v0.12.0** (0.16.1) — NPU dispatch now available on Linux and macOS as well as Windows.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -3,3 +3,7 @@ org.gradle.caching=true
 android.useAndroidX=true
 android.enableJetifier=true
 
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/integration_test/desktop_full_test.dart
+++ b/example/integration_test/desktop_full_test.dart
@@ -12,7 +12,8 @@ import 'package:flutter_gemma/core/model.dart';
 // Models in the app sandbox container
 const _containerDir =
     '/Users/sashadenisov/Library/Containers/dev.flutterberlin.flutterGemmaExample55/Data/Documents';
-const _gemma3_1bPath = '$_containerDir/Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm';
+const _gemma3_1bPath =
+    '$_containerDir/Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm';
 const _gemma4Path = '$_containerDir/gemma-4-E2B-it.litertlm';
 const _gemma3nPath = '$_containerDir/gemma-3n-E2B-it-int4.litertlm';
 const _testImagePath = '$_containerDir/test_image.png';
@@ -43,7 +44,8 @@ void main() {
   group('Gemma3-1B text', () {
     testWidgets('sync CPU', (t) async {
       await _install(_gemma3_1bPath);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 512, preferredBackend: PreferredBackend.cpu);
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 512, preferredBackend: PreferredBackend.cpu);
       final session = await model.createSession(temperature: 0.8, topK: 1);
       await session.addQueryChunk(const Message(text: 'Say hi', isUser: true));
       final r = await session.getResponse();
@@ -55,11 +57,15 @@ void main() {
 
     testWidgets('stream GPU', (t) async {
       await _install(_gemma3_1bPath);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 512, preferredBackend: PreferredBackend.gpu);
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 512, preferredBackend: PreferredBackend.gpu);
       final session = await model.createSession(temperature: 0.8, topK: 1);
-      await session.addQueryChunk(const Message(text: 'Say hello', isUser: true));
+      await session
+          .addQueryChunk(const Message(text: 'Say hello', isUser: true));
       final chunks = <String>[];
-      await for (final c in session.getResponseAsync()) { chunks.add(c); }
+      await for (final c in session.getResponseAsync()) {
+        chunks.add(c);
+      }
       print('[g3-1b gpu stream] ${chunks.length} chunks: ${chunks.join()}');
       expect(chunks, isNotEmpty);
       await session.close();
@@ -72,9 +78,11 @@ void main() {
   group('Gemma4 E2B', () {
     testWidgets('sync GPU', (t) async {
       await _install(_gemma4Path);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 512, preferredBackend: PreferredBackend.gpu);
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 512, preferredBackend: PreferredBackend.gpu);
       final session = await model.createSession(temperature: 0.8, topK: 1);
-      await session.addQueryChunk(const Message(text: 'What is 2+2?', isUser: true));
+      await session
+          .addQueryChunk(const Message(text: 'What is 2+2?', isUser: true));
       final r = await session.getResponse();
       print('[g4 gpu sync] $r');
       expect(r, isNotEmpty);
@@ -84,11 +92,15 @@ void main() {
 
     testWidgets('stream GPU', (t) async {
       await _install(_gemma4Path);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 512, preferredBackend: PreferredBackend.gpu);
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 512, preferredBackend: PreferredBackend.gpu);
       final session = await model.createSession(temperature: 0.8, topK: 1);
-      await session.addQueryChunk(const Message(text: 'Say hello', isUser: true));
+      await session
+          .addQueryChunk(const Message(text: 'Say hello', isUser: true));
       final chunks = <String>[];
-      await for (final c in session.getResponseAsync()) { chunks.add(c); }
+      await for (final c in session.getResponseAsync()) {
+        chunks.add(c);
+      }
       print('[g4 gpu stream] ${chunks.length} chunks: ${chunks.join()}');
       expect(chunks, isNotEmpty);
       await session.close();
@@ -98,11 +110,17 @@ void main() {
     testWidgets('vision GPU', (t) async {
       await _install(_gemma4Path);
       final model = await FlutterGemma.getActiveModel(
-        maxTokens: 512, preferredBackend: PreferredBackend.gpu,
-        supportImage: true, maxNumImages: 1,
+        maxTokens: 512,
+        preferredBackend: PreferredBackend.gpu,
+        supportImage: true,
+        maxNumImages: 1,
       );
-      final session = await model.createSession(temperature: 0.8, topK: 1, enableVisionModality: true);
-      await session.addQueryChunk(Message(text: 'Describe this image briefly', isUser: true, imageBytes: _testImage));
+      final session = await model.createSession(
+          temperature: 0.8, topK: 1, enableVisionModality: true);
+      await session.addQueryChunk(Message(
+          text: 'Describe this image briefly',
+          isUser: true,
+          imageBytes: _testImage));
       final r = await session.getResponse();
       print('[g4 gpu vision] $r');
       expect(r, isNotEmpty);
@@ -113,11 +131,14 @@ void main() {
     testWidgets('audio GPU', (t) async {
       await _install(_gemma4Path);
       final model = await FlutterGemma.getActiveModel(
-        maxTokens: 512, preferredBackend: PreferredBackend.gpu,
+        maxTokens: 512,
+        preferredBackend: PreferredBackend.gpu,
         supportAudio: true,
       );
-      final session = await model.createSession(temperature: 0.8, topK: 1, enableAudioModality: true);
-      await session.addQueryChunk(Message(text: 'What did you hear?', isUser: true, audioBytes: _testAudio));
+      final session = await model.createSession(
+          temperature: 0.8, topK: 1, enableAudioModality: true);
+      await session.addQueryChunk(Message(
+          text: 'What did you hear?', isUser: true, audioBytes: _testAudio));
       final r = await session.getResponse();
       print('[g4 gpu audio] $r');
       expect(r, isNotEmpty);
@@ -127,9 +148,12 @@ void main() {
 
     testWidgets('thinking GPU', (t) async {
       await _install(_gemma4Path);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 2048, preferredBackend: PreferredBackend.gpu);
-      final session = await model.createSession(temperature: 0.8, topK: 1, enableThinking: true);
-      await session.addQueryChunk(const Message(text: 'Why is the sky blue? Think step by step.', isUser: true));
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 2048, preferredBackend: PreferredBackend.gpu);
+      final session = await model.createSession(
+          temperature: 0.8, topK: 1, enableThinking: true);
+      await session.addQueryChunk(const Message(
+          text: 'Why is the sky blue? Think step by step.', isUser: true));
       final chunks = <String>[];
       bool hasThinking = false;
       bool hasText = false;
@@ -139,8 +163,10 @@ void main() {
         if (!c.contains('<|channel>')) hasText = true;
       }
       final full = chunks.join();
-      print('[g4 gpu thinking] ${chunks.length} chunks, thinking=$hasThinking, text=$hasText');
-      print('[g4 gpu thinking] first 200: ${full.substring(0, full.length.clamp(0, 200))}');
+      print(
+          '[g4 gpu thinking] ${chunks.length} chunks, thinking=$hasThinking, text=$hasText');
+      print(
+          '[g4 gpu thinking] first 200: ${full.substring(0, full.length.clamp(0, 200))}');
       expect(chunks, isNotEmpty);
       expect(hasThinking, true, reason: 'Should have thinking chunks');
       expect(hasText, true, reason: 'Should have text chunks');
@@ -154,7 +180,8 @@ void main() {
   group('Gemma3n E2B', () {
     testWidgets('sync CPU', (t) async {
       await _install(_gemma3nPath);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 512, preferredBackend: PreferredBackend.cpu);
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 512, preferredBackend: PreferredBackend.cpu);
       final session = await model.createSession(temperature: 0.8, topK: 1);
       await session.addQueryChunk(const Message(text: 'Say hi', isUser: true));
       final r = await session.getResponse();
@@ -166,11 +193,15 @@ void main() {
 
     testWidgets('stream GPU', (t) async {
       await _install(_gemma3nPath);
-      final model = await FlutterGemma.getActiveModel(maxTokens: 512, preferredBackend: PreferredBackend.gpu);
+      final model = await FlutterGemma.getActiveModel(
+          maxTokens: 512, preferredBackend: PreferredBackend.gpu);
       final session = await model.createSession(temperature: 0.8, topK: 1);
-      await session.addQueryChunk(const Message(text: 'Say hello', isUser: true));
+      await session
+          .addQueryChunk(const Message(text: 'Say hello', isUser: true));
       final chunks = <String>[];
-      await for (final c in session.getResponseAsync()) { chunks.add(c); }
+      await for (final c in session.getResponseAsync()) {
+        chunks.add(c);
+      }
       print('[g3n gpu stream] ${chunks.length} chunks: ${chunks.join()}');
       expect(chunks, isNotEmpty);
       await session.close();
@@ -180,11 +211,17 @@ void main() {
     testWidgets('vision GPU', (t) async {
       await _install(_gemma3nPath);
       final model = await FlutterGemma.getActiveModel(
-        maxTokens: 512, preferredBackend: PreferredBackend.gpu,
-        supportImage: true, maxNumImages: 1,
+        maxTokens: 512,
+        preferredBackend: PreferredBackend.gpu,
+        supportImage: true,
+        maxNumImages: 1,
       );
-      final session = await model.createSession(temperature: 0.8, topK: 1, enableVisionModality: true);
-      await session.addQueryChunk(Message(text: 'Describe this image briefly', isUser: true, imageBytes: _testImage));
+      final session = await model.createSession(
+          temperature: 0.8, topK: 1, enableVisionModality: true);
+      await session.addQueryChunk(Message(
+          text: 'Describe this image briefly',
+          isUser: true,
+          imageBytes: _testImage));
       final r = await session.getResponse();
       print('[g3n gpu vision] $r');
       expect(r, isNotEmpty);
@@ -195,13 +232,34 @@ void main() {
     testWidgets('audio CPU', (t) async {
       await _install(_gemma3nPath);
       final model = await FlutterGemma.getActiveModel(
-        maxTokens: 512, preferredBackend: PreferredBackend.cpu,
+        maxTokens: 512,
+        preferredBackend: PreferredBackend.cpu,
         supportAudio: true,
       );
-      final session = await model.createSession(temperature: 0.8, topK: 1, enableAudioModality: true);
-      await session.addQueryChunk(Message(text: 'What did you hear?', isUser: true, audioBytes: _testAudio));
+      final session = await model.createSession(
+          temperature: 0.8, topK: 1, enableAudioModality: true);
+      await session.addQueryChunk(Message(
+          text: 'What did you hear?', isUser: true, audioBytes: _testAudio));
       final r = await session.getResponse();
       print('[g3n cpu audio] $r');
+      expect(r, isNotEmpty);
+      await session.close();
+      await model.close();
+    });
+
+    testWidgets('audio GPU', (t) async {
+      await _install(_gemma3nPath);
+      final model = await FlutterGemma.getActiveModel(
+        maxTokens: 512,
+        preferredBackend: PreferredBackend.gpu,
+        supportAudio: true,
+      );
+      final session = await model.createSession(
+          temperature: 0.8, topK: 1, enableAudioModality: true);
+      await session.addQueryChunk(Message(
+          text: 'What did you hear?', isUser: true, audioBytes: _testAudio));
+      final r = await session.getResponse();
+      print('[g3n gpu audio] $r');
       expect(r, isNotEmpty);
       await session.close();
       await model.close();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,52 +1,22 @@
 PODS:
-  - audio_session (0.0.1):
-    - Flutter
-  - background_downloader (0.0.1):
-    - Flutter
   - Flutter (1.0.0)
   - flutter_gemma (0.16.1):
     - Flutter
     - MediaPipeTasksGenAI (= 0.10.33)
     - MediaPipeTasksGenAIC (= 0.10.33)
-  - image_picker_ios (0.0.1):
-    - Flutter
-  - integration_test (0.0.1):
-    - Flutter
-  - just_audio (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - large_file_handler (0.0.1):
     - Flutter
   - MediaPipeTasksGenAI (0.10.33):
     - MediaPipeTasksGenAIC (= 0.10.33)
   - MediaPipeTasksGenAIC (0.10.33)
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - permission_handler_apple (9.3.0):
-    - Flutter
-  - record_ios (1.1.0):
-    - Flutter
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
-  - audio_session (from `.symlinks/plugins/audio_session/ios`)
-  - background_downloader (from `.symlinks/plugins/background_downloader/ios`)
   - Flutter (from `Flutter`)
   - flutter_gemma (from `.symlinks/plugins/flutter_gemma/ios`)
-  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - large_file_handler (from `.symlinks/plugins/large_file_handler/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
-  - record_ios (from `.symlinks/plugins/record_ios/ios`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -54,49 +24,22 @@ SPEC REPOS:
     - MediaPipeTasksGenAIC
 
 EXTERNAL SOURCES:
-  audio_session:
-    :path: ".symlinks/plugins/audio_session/ios"
-  background_downloader:
-    :path: ".symlinks/plugins/background_downloader/ios"
   Flutter:
     :path: Flutter
   flutter_gemma:
     :path: ".symlinks/plugins/flutter_gemma/ios"
-  image_picker_ios:
-    :path: ".symlinks/plugins/image_picker_ios/ios"
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
-  just_audio:
-    :path: ".symlinks/plugins/just_audio/darwin"
   large_file_handler:
     :path: ".symlinks/plugins/large_file_handler/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
-  record_ios:
-    :path: ".symlinks/plugins/record_ios/ios"
-  shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  url_launcher_ios:
-    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
-  background_downloader: 50e91d979067b82081aba359d7d916b3ba5fadad
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_gemma: 8ded1e5c49942dd1494d273f33bba4bdf4c76160
-  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   large_file_handler: b37481e9b4972562ffcdc8f75700f47cd592bcec
   MediaPipeTasksGenAI: 8eed8e6d03fe26d30c4205cb5295ec7b394432ad
   MediaPipeTasksGenAIC: cb098ecea44e248efe8fe7e2f62b4cb0df781802
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  record_ios: f75fa1d57f840012775c0e93a38a7f3ceea1a374
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 53b8e8521f07aac58aa301c168e0c12bcb0abac1
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - background_downloader (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_gemma (0.15.3):
+  - flutter_gemma (0.16.1):
     - Flutter
     - MediaPipeTasksGenAI (= 0.10.33)
     - MediaPipeTasksGenAIC (= 0.10.33)
@@ -85,7 +85,7 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   background_downloader: 50e91d979067b82081aba359d7d916b3ba5fadad
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_gemma: 617f2efab7167a75670759d52641c221a49c2ba6
+  flutter_gemma: 8ded1e5c49942dd1494d273f33bba4bdf4c76160
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		C0CEB01F6FC0BB63F1FCD5E9 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9054F803249A386D58A8F9FB /* Pods_Runner_RunnerUITests.framework */; };
 		F7A8C0A12D0F000000000001 /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = F7A8C0A12D0F000000000002 /* RunnerUITests.m */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,9 @@
 		E6E122A5755C52FDFAF99DE7 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		F7A8C0A12D0F000000000002 /* RunnerUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RunnerUITests.m; sourceTree = "<group>"; };
 		F7A8C0A12D0F000000000003 /* RunnerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* flutter_gemma */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = flutter_gemma; path = ../../ios/flutter_gemma; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				5E79B0B2DB84C52A0648737A /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -119,6 +124,9 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* flutter_gemma */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -176,6 +184,9 @@
 
 /* Begin PBXNativeTarget section */
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -224,6 +235,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -836,6 +850,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,66 +1,21 @@
 PODS:
-  - audio_session (0.0.1):
-    - FlutterMacOS
-  - file_selector_macos (0.0.1):
-    - FlutterMacOS
   - flutter_gemma (0.14.0):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - just_audio (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - record_macos (1.1.0):
-    - FlutterMacOS
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
-  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - flutter_gemma (from `Flutter/ephemeral/.symlinks/plugins/flutter_gemma/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/darwin`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
-  - record_macos (from `Flutter/ephemeral/.symlinks/plugins/record_macos/macos`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
-  audio_session:
-    :path: Flutter/ephemeral/.symlinks/plugins/audio_session/macos
-  file_selector_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   flutter_gemma:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_gemma/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  just_audio:
-    :path: Flutter/ephemeral/.symlinks/plugins/just_audio/darwin
-  path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
-  record_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/record_macos/macos
-  shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
-  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
   flutter_gemma: 6d2de93c6472b2509a7b585de171de2c3a4447b6
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  record_macos: 43194b6c06ca6f8fa132e2acea72b202b92a0f5b
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
 
 PODFILE CHECKSUM: 91fd22244cb06e360ba5496c234dd3f53c3d67bb
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		7392371C68E31E521850BE48 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23030EA7D1830887AEBE90BF /* Pods_Runner.framework */; };
 		CFD99E66D34643DA8E94F691 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B1F913BB07B005013B3C2C1 /* Pods_RunnerTests.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,9 @@
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		AB15F78221336DF050E7C9F9 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		CC0707F7FE6B9B15F3942C0E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* flutter_gemma */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = flutter_gemma; path = ../../../macos/flutter_gemma; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				7392371C68E31E521850BE48 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -177,6 +182,9 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* flutter_gemma */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -231,6 +239,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		33CC10EC2044A3C60003C045 /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -257,6 +268,9 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -841,6 +855,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "flutter_gemma_example.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -775,10 +775,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: caa693ad15a587a2b4fde093b728131a1827903872171089dedb16f7665d3a91
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.1"
   stack_trace:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -458,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -831,10 +831,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.16.0"
+    version: "0.16.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -136,7 +136,7 @@ class _NativeBundle {
 /// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
 const _litertlmBundle = _NativeBundle(
   namespace: 'litertlm',
-  version: '0.11.0-b',
+  version: '0.12.0',
   releaseTagPrefix: 'native-v',
   archivePrefix: 'litertlm',
   mainLibName: 'LiteRtLm',
@@ -149,19 +149,19 @@ const _litertlmBundle = _NativeBundle(
   markerFileName: '.flutter_gemma_native_version',
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
-        '79583513cbbdda784b1714c1068a1fdd0f8133364868574ec3334af8d0eee056',
+        '930296b010ecc316c6b6fc4ed1c722b275b4064b59b5aad8ff7b858e9149c0d7',
     'litertlm-linux_arm64.tar.gz':
-        'bab26bf420316ef2f4037ffced1470a18cbb6ee6cda069fc0ae8a5f8eb882bfb',
+        '616b2e8cb9903bfd4ee54ca600a9a0cce38ddd16ed3e4b847a6d80e548b9aa60',
     'litertlm-windows_x86_64.tar.gz':
-        '2291db8d4cc104d695b589a179ef04f0c955f906264d625ed4f16babe13d952e',
+        'b7264091c05001ef84e53761dfee331f761e3a2362b36b28ab2ce39666400d76',
     'litertlm-macos_arm64.tar.gz':
-        'fa3138c9f97b6ba3c19f620c29439207d38566598fff06cc55ff115ade17f8e8',
+        'a616c6996853cf095fac8c19de1d4dbf9a7434437da7f9bcc167e0e840147e10',
     'litertlm-ios_arm64.tar.gz':
-        'eae0d0ef8b81eeb6e6e0b69a482513f47b371ec2f410f571763538a5d23c7607',
+        'c61b7e7ffcbb16aa9c69a525c3883b42356de045c84cfade8691d05c914421c2',
     'litertlm-ios_sim_arm64.tar.gz':
-        'f92b8fcb3627c82c9398f39bcf6851a46e97f9565d5341d454390802bf1ffd78',
+        'f14308a685d75909fea28271f12c37d0022dbdac56271f48e87846cb83d29c14',
     'litertlm-android_arm64.tar.gz':
-        '9712d55d1a248ad8834531f2d937a9bbf2feceaad8a1d352ef5f63a4dedb8f17',
+        'e24804d922aadd91a85a6faf272a20e9c3e7991ed2754cf2a9071ad08a8fc2ce',
   },
   companions: [
     'GemmaModelConstraintProvider',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -157,9 +157,9 @@ const _litertlmBundle = _NativeBundle(
     'litertlm-macos_arm64.tar.gz':
         'a616c6996853cf095fac8c19de1d4dbf9a7434437da7f9bcc167e0e840147e10',
     'litertlm-ios_arm64.tar.gz':
-        'c61b7e7ffcbb16aa9c69a525c3883b42356de045c84cfade8691d05c914421c2',
+        '88620e05382dcb1fdc5d2d985bfc9812f78f1422b4e9f3d1d8dfbafcf727c4ee',
     'litertlm-ios_sim_arm64.tar.gz':
-        'f14308a685d75909fea28271f12c37d0022dbdac56271f48e87846cb83d29c14',
+        '54e067fa11ad510280e01f90260e8bda13f905a27f00e7ebc2d7ef5847868bd1',
     'litertlm-android_arm64.tar.gz':
         'e24804d922aadd91a85a6faf272a20e9c3e7991ed2754cf2a9071ad08a8fc2ce',
   },
@@ -260,9 +260,9 @@ const _qdrantEdgeBundle = _NativeBundle(
     'qdrant-edge-macos_arm64.tar.gz':
         'ff0e47992aa0f1d220d955646992b23e4587477d9b8162b92284044d5b9c7b9b',
     'qdrant-edge-ios_arm64.tar.gz':
-        'cc48fa47a50197a13c6083e3a4b6d31784eb7c0de61af80d61e3549e85ea675d',
+        'fc07d3b7eb7681be3f0473f90badb5cecb6eeb60d703c68dc2129baa79be3213',
     'qdrant-edge-ios_sim_arm64.tar.gz':
-        '40027167e2e2302757f8f78e167dc7482aa261cf26953331331956f5b1054f6a',
+        '3bcf5bb3b0bb2c0f3fe207d30edf2fea0516f2f7ca850ead1bde08f41c73bce3',
     'qdrant-edge-android_arm64.tar.gz':
         '941b626c191bc0fe5a7abb108ec1086343ef82671fdaec2cbfb052ec63935c10',
   },

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.16.0'
+  s.version          = '0.16.1'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Run Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3, Qwen 2.5, DeepSeek R1,

--- a/lib/core/ffi/litert_lm_bindings.dart
+++ b/lib/core/ffi/litert_lm_bindings.dart
@@ -52,6 +52,24 @@ class LiteRtLmBindings {
       _litert_lm_session_config_set_max_output_tokensPtr
           .asFunction<void Function(ffi.Pointer<LiteRtLmSessionConfig>, int)>();
 
+  void litert_lm_session_config_set_apply_prompt_template(
+    ffi.Pointer<LiteRtLmSessionConfig> config,
+    bool apply_prompt_template,
+  ) {
+    return _litert_lm_session_config_set_apply_prompt_template(
+      config,
+      apply_prompt_template,
+    );
+  }
+
+  late final _litert_lm_session_config_set_apply_prompt_templatePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<LiteRtLmSessionConfig>,
+              ffi.Bool)>>('litert_lm_session_config_set_apply_prompt_template');
+  late final _litert_lm_session_config_set_apply_prompt_template =
+      _litert_lm_session_config_set_apply_prompt_templatePtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmSessionConfig>, bool)>();
+
   void litert_lm_session_config_set_sampler_params(
     ffi.Pointer<LiteRtLmSessionConfig> config,
     ffi.Pointer<LiteRtLmSamplerParams> sampler_params,
@@ -125,6 +143,148 @@ class LiteRtLmBindings {
               ffi.Pointer<ffi.Char>,
               bool)>();
 
+  void litert_lm_conversation_config_set_session_config(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    ffi.Pointer<LiteRtLmSessionConfig> session_config,
+  ) {
+    return _litert_lm_conversation_config_set_session_config(
+      config,
+      session_config,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_session_configPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+                  ffi.Pointer<LiteRtLmSessionConfig>)>>(
+      'litert_lm_conversation_config_set_session_config');
+  late final _litert_lm_conversation_config_set_session_config =
+      _litert_lm_conversation_config_set_session_configPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+              ffi.Pointer<LiteRtLmSessionConfig>)>();
+
+  void litert_lm_conversation_config_set_system_message(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    ffi.Pointer<ffi.Char> system_message_json,
+  ) {
+    return _litert_lm_conversation_config_set_system_message(
+      config,
+      system_message_json,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_system_messagePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+                  ffi.Pointer<ffi.Char>)>>(
+      'litert_lm_conversation_config_set_system_message');
+  late final _litert_lm_conversation_config_set_system_message =
+      _litert_lm_conversation_config_set_system_messagePtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+              ffi.Pointer<ffi.Char>)>();
+
+  void litert_lm_conversation_config_set_tools(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    ffi.Pointer<ffi.Char> tools_json,
+  ) {
+    return _litert_lm_conversation_config_set_tools(
+      config,
+      tools_json,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_toolsPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+                  ffi.Pointer<ffi.Char>)>>(
+      'litert_lm_conversation_config_set_tools');
+  late final _litert_lm_conversation_config_set_tools =
+      _litert_lm_conversation_config_set_toolsPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+              ffi.Pointer<ffi.Char>)>();
+
+  void litert_lm_conversation_config_set_messages(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    ffi.Pointer<ffi.Char> messages_json,
+  ) {
+    return _litert_lm_conversation_config_set_messages(
+      config,
+      messages_json,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_messagesPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+                  ffi.Pointer<ffi.Char>)>>(
+      'litert_lm_conversation_config_set_messages');
+  late final _litert_lm_conversation_config_set_messages =
+      _litert_lm_conversation_config_set_messagesPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+              ffi.Pointer<ffi.Char>)>();
+
+  void litert_lm_conversation_config_set_extra_context(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    ffi.Pointer<ffi.Char> extra_context_json,
+  ) {
+    return _litert_lm_conversation_config_set_extra_context(
+      config,
+      extra_context_json,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_extra_contextPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+                  ffi.Pointer<ffi.Char>)>>(
+      'litert_lm_conversation_config_set_extra_context');
+  late final _litert_lm_conversation_config_set_extra_context =
+      _litert_lm_conversation_config_set_extra_contextPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmConversationConfig>,
+              ffi.Pointer<ffi.Char>)>();
+
+  void litert_lm_conversation_config_set_enable_constrained_decoding(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    bool enable_constrained_decoding,
+  ) {
+    return _litert_lm_conversation_config_set_enable_constrained_decoding(
+      config,
+      enable_constrained_decoding,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_enable_constrained_decodingPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(
+                      ffi.Pointer<LiteRtLmConversationConfig>, ffi.Bool)>>(
+          'litert_lm_conversation_config_set_enable_constrained_decoding');
+  late final _litert_lm_conversation_config_set_enable_constrained_decoding =
+      _litert_lm_conversation_config_set_enable_constrained_decodingPtr
+          .asFunction<
+              void Function(ffi.Pointer<LiteRtLmConversationConfig>, bool)>();
+
+  void litert_lm_conversation_config_set_filter_channel_content_from_kv_cache(
+    ffi.Pointer<LiteRtLmConversationConfig> config,
+    bool filter_channel_content_from_kv_cache,
+  ) {
+    return _litert_lm_conversation_config_set_filter_channel_content_from_kv_cache(
+      config,
+      filter_channel_content_from_kv_cache,
+    );
+  }
+
+  late final _litert_lm_conversation_config_set_filter_channel_content_from_kv_cachePtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(
+                      ffi.Pointer<LiteRtLmConversationConfig>, ffi.Bool)>>(
+          'litert_lm_conversation_config_set_filter_channel_content_from_kv_cache');
+  late final _litert_lm_conversation_config_set_filter_channel_content_from_kv_cache =
+      _litert_lm_conversation_config_set_filter_channel_content_from_kv_cachePtr
+          .asFunction<
+              void Function(ffi.Pointer<LiteRtLmConversationConfig>, bool)>();
+
   void litert_lm_conversation_config_delete(
     ffi.Pointer<LiteRtLmConversationConfig> config,
   ) {
@@ -140,6 +300,58 @@ class LiteRtLmBindings {
   late final _litert_lm_conversation_config_delete =
       _litert_lm_conversation_config_deletePtr
           .asFunction<void Function(ffi.Pointer<LiteRtLmConversationConfig>)>();
+
+  ffi.Pointer<LiteRtLmConversationOptionalArgs>
+      litert_lm_conversation_optional_args_create() {
+    return _litert_lm_conversation_optional_args_create();
+  }
+
+  late final _litert_lm_conversation_optional_args_createPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<LiteRtLmConversationOptionalArgs>
+              Function()>>('litert_lm_conversation_optional_args_create');
+  late final _litert_lm_conversation_optional_args_create =
+      _litert_lm_conversation_optional_args_createPtr.asFunction<
+          ffi.Pointer<LiteRtLmConversationOptionalArgs> Function()>();
+
+  void litert_lm_conversation_optional_args_delete(
+    ffi.Pointer<LiteRtLmConversationOptionalArgs> optional_args,
+  ) {
+    return _litert_lm_conversation_optional_args_delete(
+      optional_args,
+    );
+  }
+
+  late final _litert_lm_conversation_optional_args_deletePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<LiteRtLmConversationOptionalArgs>)>>(
+      'litert_lm_conversation_optional_args_delete');
+  late final _litert_lm_conversation_optional_args_delete =
+      _litert_lm_conversation_optional_args_deletePtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmConversationOptionalArgs>)>();
+
+  void litert_lm_conversation_optional_args_set_visual_token_budget(
+    ffi.Pointer<LiteRtLmConversationOptionalArgs> optional_args,
+    int visual_token_budget,
+  ) {
+    return _litert_lm_conversation_optional_args_set_visual_token_budget(
+      optional_args,
+      visual_token_budget,
+    );
+  }
+
+  late final _litert_lm_conversation_optional_args_set_visual_token_budgetPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(
+                      ffi.Pointer<LiteRtLmConversationOptionalArgs>, ffi.Int)>>(
+          'litert_lm_conversation_optional_args_set_visual_token_budget');
+  late final _litert_lm_conversation_optional_args_set_visual_token_budget =
+      _litert_lm_conversation_optional_args_set_visual_token_budgetPtr
+          .asFunction<
+              void Function(
+                  ffi.Pointer<LiteRtLmConversationOptionalArgs>, int)>();
 
   void litert_lm_set_min_log_level(
     int level,
@@ -239,6 +451,24 @@ class LiteRtLmBindings {
           .asFunction<
               void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)>();
 
+  void litert_lm_engine_settings_set_max_num_images(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    int max_num_images,
+  ) {
+    return _litert_lm_engine_settings_set_max_num_images(
+      settings,
+      max_num_images,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_max_num_imagesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
+              ffi.Int)>>('litert_lm_engine_settings_set_max_num_images');
+  late final _litert_lm_engine_settings_set_max_num_images =
+      _litert_lm_engine_settings_set_max_num_imagesPtr.asFunction<
+          void Function(ffi.Pointer<LiteRtLmEngineSettings>, int)>();
+
   void litert_lm_engine_settings_set_cache_dir(
     ffi.Pointer<LiteRtLmEngineSettings> settings,
     ffi.Pointer<ffi.Char> cache_dir,
@@ -256,6 +486,27 @@ class LiteRtLmBindings {
       'litert_lm_engine_settings_set_cache_dir');
   late final _litert_lm_engine_settings_set_cache_dir =
       _litert_lm_engine_settings_set_cache_dirPtr.asFunction<
+          void Function(
+              ffi.Pointer<LiteRtLmEngineSettings>, ffi.Pointer<ffi.Char>)>();
+
+  void litert_lm_engine_settings_set_litert_dispatch_lib_dir(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    ffi.Pointer<ffi.Char> lib_dir,
+  ) {
+    return _litert_lm_engine_settings_set_litert_dispatch_lib_dir(
+      settings,
+      lib_dir,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_litert_dispatch_lib_dirPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
+                      ffi.Pointer<ffi.Char>)>>(
+          'litert_lm_engine_settings_set_litert_dispatch_lib_dir');
+  late final _litert_lm_engine_settings_set_litert_dispatch_lib_dir =
+      _litert_lm_engine_settings_set_litert_dispatch_lib_dirPtr.asFunction<
           void Function(
               ffi.Pointer<LiteRtLmEngineSettings>, ffi.Pointer<ffi.Char>)>();
 
@@ -347,27 +598,6 @@ class LiteRtLmBindings {
       _litert_lm_engine_settings_set_num_decode_tokensPtr.asFunction<
           void Function(ffi.Pointer<LiteRtLmEngineSettings>, int)>();
 
-  void litert_lm_engine_settings_set_max_num_images(
-    ffi.Pointer<LiteRtLmEngineSettings> settings,
-    int max_num_images,
-  ) {
-    return _litert_lm_engine_settings_set_max_num_images(
-      settings,
-      max_num_images,
-    );
-  }
-
-  late final _litert_lm_engine_settings_set_max_num_imagesPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
-              ffi.Int)>>('litert_lm_engine_settings_set_max_num_images');
-  late final _litert_lm_engine_settings_set_max_num_images =
-      _litert_lm_engine_settings_set_max_num_imagesPtr.asFunction<
-          void Function(ffi.Pointer<LiteRtLmEngineSettings>, int)>();
-
-  /// Toggle Multi-Token Prediction (MTP) / speculative decoding (LiteRT-LM
-  /// v0.11.0+). Only meaningful for models with an `tf_lite_mtp_drafter`
-  /// section in the `.litertlm` binary (Gemma 4 E2B/E4B v2+).
   void litert_lm_engine_settings_set_enable_speculative_decoding(
     ffi.Pointer<LiteRtLmEngineSettings> settings,
     bool enable_speculative_decoding,
@@ -381,45 +611,13 @@ class LiteRtLmBindings {
   late final _litert_lm_engine_settings_set_enable_speculative_decodingPtr =
       _lookup<
               ffi.NativeFunction<
-                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
-                      ffi.Bool)>>(
+                  ffi.Void Function(
+                      ffi.Pointer<LiteRtLmEngineSettings>, ffi.Bool)>>(
           'litert_lm_engine_settings_set_enable_speculative_decoding');
   late final _litert_lm_engine_settings_set_enable_speculative_decoding =
       _litert_lm_engine_settings_set_enable_speculative_decodingPtr.asFunction<
           void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)>();
 
-  /// Set the directory where LiteRT dispatch libraries (NPU dispatch
-  /// `LiteRtDispatch.dll`, accelerator plugins) live. Required on Windows
-  /// for `PreferredBackend.npu` — without it the dispatch lookup reads
-  /// uninitialized env option memory and engine_create crashes.
-  /// Caller passes the absolute path to the directory containing
-  /// `LiteRtDispatch.dll` (usually the same dir as `LiteRtLm.dll`).
-  void litert_lm_engine_settings_set_litert_dispatch_lib_dir(
-    ffi.Pointer<LiteRtLmEngineSettings> settings,
-    ffi.Pointer<ffi.Char> lib_dir,
-  ) {
-    return _litert_lm_engine_settings_set_litert_dispatch_lib_dir(
-      settings,
-      lib_dir,
-    );
-  }
-
-  late final _litert_lm_engine_settings_set_litert_dispatch_lib_dirPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
-                      ffi.Pointer<ffi.Char>)>>(
-          'litert_lm_engine_settings_set_litert_dispatch_lib_dir');
-  late final _litert_lm_engine_settings_set_litert_dispatch_lib_dir =
-      _litert_lm_engine_settings_set_litert_dispatch_lib_dirPtr.asFunction<
-          void Function(
-              ffi.Pointer<LiteRtLmEngineSettings>, ffi.Pointer<ffi.Char>)>();
-
-  /// Disable NPU hardware mask update path. Required on Intel preview NPU
-  /// silicon (LunarLake / PantherLake) where the default `kWH`
-  /// (Write-Hardware) mask update method is not fully supported and causes
-  /// engine_create to crash. Pass `false` to force CPU/SIMD fallback.
-  /// Patched into our C API (not in upstream LiteRT-LM 0.11.0 C API).
   void litert_lm_engine_settings_set_use_hw_masking_for_npu(
     ffi.Pointer<LiteRtLmEngineSettings> settings,
     bool value,
@@ -430,12 +628,11 @@ class LiteRtLmBindings {
     );
   }
 
-  late final _litert_lm_engine_settings_set_use_hw_masking_for_npuPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>,
-                      ffi.Bool)>>(
-          'litert_lm_engine_settings_set_use_hw_masking_for_npu');
+  late final _litert_lm_engine_settings_set_use_hw_masking_for_npuPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Pointer<LiteRtLmEngineSettings>, ffi.Bool)>>(
+      'litert_lm_engine_settings_set_use_hw_masking_for_npu');
   late final _litert_lm_engine_settings_set_use_hw_masking_for_npu =
       _litert_lm_engine_settings_set_use_hw_masking_for_npuPtr.asFunction<
           void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)>();
@@ -504,9 +701,90 @@ class LiteRtLmBindings {
   late final _litert_lm_session_delete = _litert_lm_session_deletePtr
       .asFunction<void Function(ffi.Pointer<LiteRtLmSession>)>();
 
+  void litert_lm_session_cancel_process(
+    ffi.Pointer<LiteRtLmSession> session,
+  ) {
+    return _litert_lm_session_cancel_process(
+      session,
+    );
+  }
+
+  late final _litert_lm_session_cancel_processPtr = _lookup<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<LiteRtLmSession>)>>(
+      'litert_lm_session_cancel_process');
+  late final _litert_lm_session_cancel_process =
+      _litert_lm_session_cancel_processPtr
+          .asFunction<void Function(ffi.Pointer<LiteRtLmSession>)>();
+
+  int litert_lm_session_run_prefill(
+    ffi.Pointer<LiteRtLmSession> session,
+    ffi.Pointer<LiteRtLmInputData> inputs,
+    int num_inputs,
+  ) {
+    return _litert_lm_session_run_prefill(
+      session,
+      inputs,
+      num_inputs,
+    );
+  }
+
+  late final _litert_lm_session_run_prefillPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              ffi.Pointer<LiteRtLmSession>,
+              ffi.Pointer<LiteRtLmInputData>,
+              ffi.Size)>>('litert_lm_session_run_prefill');
+  late final _litert_lm_session_run_prefill =
+      _litert_lm_session_run_prefillPtr.asFunction<
+          int Function(ffi.Pointer<LiteRtLmSession>,
+              ffi.Pointer<LiteRtLmInputData>, int)>();
+
+  ffi.Pointer<LiteRtLmResponses> litert_lm_session_run_decode(
+    ffi.Pointer<LiteRtLmSession> session,
+  ) {
+    return _litert_lm_session_run_decode(
+      session,
+    );
+  }
+
+  late final _litert_lm_session_run_decodePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<LiteRtLmResponses> Function(
+              ffi.Pointer<LiteRtLmSession>)>>('litert_lm_session_run_decode');
+  late final _litert_lm_session_run_decode =
+      _litert_lm_session_run_decodePtr.asFunction<
+          ffi.Pointer<LiteRtLmResponses> Function(
+              ffi.Pointer<LiteRtLmSession>)>();
+
+  ffi.Pointer<LiteRtLmResponses> litert_lm_session_run_text_scoring(
+    ffi.Pointer<LiteRtLmSession> session,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> target_text,
+    int num_targets,
+    bool store_token_lengths,
+  ) {
+    return _litert_lm_session_run_text_scoring(
+      session,
+      target_text,
+      num_targets,
+      store_token_lengths,
+    );
+  }
+
+  late final _litert_lm_session_run_text_scoringPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<LiteRtLmResponses> Function(
+              ffi.Pointer<LiteRtLmSession>,
+              ffi.Pointer<ffi.Pointer<ffi.Char>>,
+              ffi.Size,
+              ffi.Bool)>>('litert_lm_session_run_text_scoring');
+  late final _litert_lm_session_run_text_scoring =
+      _litert_lm_session_run_text_scoringPtr.asFunction<
+          ffi.Pointer<LiteRtLmResponses> Function(ffi.Pointer<LiteRtLmSession>,
+              ffi.Pointer<ffi.Pointer<ffi.Char>>, int, bool)>();
+
   ffi.Pointer<LiteRtLmResponses> litert_lm_session_generate_content(
     ffi.Pointer<LiteRtLmSession> session,
-    ffi.Pointer<InputData> inputs,
+    ffi.Pointer<LiteRtLmInputData> inputs,
     int num_inputs,
   ) {
     return _litert_lm_session_generate_content(
@@ -520,12 +798,12 @@ class LiteRtLmBindings {
       ffi.NativeFunction<
           ffi.Pointer<LiteRtLmResponses> Function(
               ffi.Pointer<LiteRtLmSession>,
-              ffi.Pointer<InputData>,
+              ffi.Pointer<LiteRtLmInputData>,
               ffi.Size)>>('litert_lm_session_generate_content');
   late final _litert_lm_session_generate_content =
       _litert_lm_session_generate_contentPtr.asFunction<
-          ffi.Pointer<LiteRtLmResponses> Function(
-              ffi.Pointer<LiteRtLmSession>, ffi.Pointer<InputData>, int)>();
+          ffi.Pointer<LiteRtLmResponses> Function(ffi.Pointer<LiteRtLmSession>,
+              ffi.Pointer<LiteRtLmInputData>, int)>();
 
   void litert_lm_responses_delete(
     ffi.Pointer<LiteRtLmResponses> responses,
@@ -574,6 +852,133 @@ class LiteRtLmBindings {
   late final _litert_lm_responses_get_response_text_at =
       _litert_lm_responses_get_response_text_atPtr.asFunction<
           ffi.Pointer<ffi.Char> Function(
+              ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  bool litert_lm_responses_has_score_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_has_score_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_has_score_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_has_score_at');
+  late final _litert_lm_responses_has_score_at =
+      _litert_lm_responses_has_score_atPtr
+          .asFunction<bool Function(ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  double litert_lm_responses_get_score_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_get_score_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_get_score_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Float Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_get_score_at');
+  late final _litert_lm_responses_get_score_at =
+      _litert_lm_responses_get_score_atPtr
+          .asFunction<double Function(ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  bool litert_lm_responses_has_token_length_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_has_token_length_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_has_token_length_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_has_token_length_at');
+  late final _litert_lm_responses_has_token_length_at =
+      _litert_lm_responses_has_token_length_atPtr
+          .asFunction<bool Function(ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  int litert_lm_responses_get_token_length_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_get_token_length_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_get_token_length_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_get_token_length_at');
+  late final _litert_lm_responses_get_token_length_at =
+      _litert_lm_responses_get_token_length_atPtr
+          .asFunction<int Function(ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  bool litert_lm_responses_has_token_scores_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_has_token_scores_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_has_token_scores_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_has_token_scores_at');
+  late final _litert_lm_responses_has_token_scores_at =
+      _litert_lm_responses_has_token_scores_atPtr
+          .asFunction<bool Function(ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  int litert_lm_responses_get_num_token_scores_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_get_num_token_scores_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_get_num_token_scores_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_get_num_token_scores_at');
+  late final _litert_lm_responses_get_num_token_scores_at =
+      _litert_lm_responses_get_num_token_scores_atPtr
+          .asFunction<int Function(ffi.Pointer<LiteRtLmResponses>, int)>();
+
+  ffi.Pointer<ffi.Float> litert_lm_responses_get_token_scores_at(
+    ffi.Pointer<LiteRtLmResponses> responses,
+    int index,
+  ) {
+    return _litert_lm_responses_get_token_scores_at(
+      responses,
+      index,
+    );
+  }
+
+  late final _litert_lm_responses_get_token_scores_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Float> Function(ffi.Pointer<LiteRtLmResponses>,
+              ffi.Int)>>('litert_lm_responses_get_token_scores_at');
+  late final _litert_lm_responses_get_token_scores_at =
+      _litert_lm_responses_get_token_scores_atPtr.asFunction<
+          ffi.Pointer<ffi.Float> Function(
               ffi.Pointer<LiteRtLmResponses>, int)>();
 
   ffi.Pointer<LiteRtLmBenchmarkInfo> litert_lm_session_get_benchmark_info(
@@ -751,9 +1156,30 @@ class LiteRtLmBindings {
       _litert_lm_benchmark_info_get_decode_tokens_per_sec_atPtr.asFunction<
           double Function(ffi.Pointer<LiteRtLmBenchmarkInfo>, int)>();
 
+  int litert_lm_session_run_decode_async(
+    ffi.Pointer<LiteRtLmSession> session,
+    LiteRtLmStreamCallback callback,
+    ffi.Pointer<ffi.Void> callback_data,
+  ) {
+    return _litert_lm_session_run_decode_async(
+      session,
+      callback,
+      callback_data,
+    );
+  }
+
+  late final _litert_lm_session_run_decode_asyncPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(ffi.Pointer<LiteRtLmSession>, LiteRtLmStreamCallback,
+              ffi.Pointer<ffi.Void>)>>('litert_lm_session_run_decode_async');
+  late final _litert_lm_session_run_decode_async =
+      _litert_lm_session_run_decode_asyncPtr.asFunction<
+          int Function(ffi.Pointer<LiteRtLmSession>, LiteRtLmStreamCallback,
+              ffi.Pointer<ffi.Void>)>();
+
   int litert_lm_session_generate_content_stream(
     ffi.Pointer<LiteRtLmSession> session,
-    ffi.Pointer<InputData> inputs,
+    ffi.Pointer<LiteRtLmInputData> inputs,
     int num_inputs,
     LiteRtLmStreamCallback callback,
     ffi.Pointer<ffi.Void> callback_data,
@@ -771,15 +1197,19 @@ class LiteRtLmBindings {
           ffi.NativeFunction<
               ffi.Int Function(
                   ffi.Pointer<LiteRtLmSession>,
-                  ffi.Pointer<InputData>,
+                  ffi.Pointer<LiteRtLmInputData>,
                   ffi.Size,
                   LiteRtLmStreamCallback,
                   ffi.Pointer<ffi.Void>)>>(
       'litert_lm_session_generate_content_stream');
   late final _litert_lm_session_generate_content_stream =
       _litert_lm_session_generate_content_streamPtr.asFunction<
-          int Function(ffi.Pointer<LiteRtLmSession>, ffi.Pointer<InputData>,
-              int, LiteRtLmStreamCallback, ffi.Pointer<ffi.Void>)>();
+          int Function(
+              ffi.Pointer<LiteRtLmSession>,
+              ffi.Pointer<LiteRtLmInputData>,
+              int,
+              LiteRtLmStreamCallback,
+              ffi.Pointer<ffi.Void>)>();
 
   ffi.Pointer<LiteRtLmConversation> litert_lm_conversation_create(
     ffi.Pointer<LiteRtLmEngine> engine,
@@ -818,30 +1248,53 @@ class LiteRtLmBindings {
   late final _litert_lm_conversation_delete = _litert_lm_conversation_deletePtr
       .asFunction<void Function(ffi.Pointer<LiteRtLmConversation>)>();
 
+  ffi.Pointer<LiteRtLmConversation> litert_lm_conversation_clone(
+    ffi.Pointer<LiteRtLmConversation> conversation,
+  ) {
+    return _litert_lm_conversation_clone(
+      conversation,
+    );
+  }
+
+  late final _litert_lm_conversation_clonePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<LiteRtLmConversation> Function(
+                  ffi.Pointer<LiteRtLmConversation>)>>(
+      'litert_lm_conversation_clone');
+  late final _litert_lm_conversation_clone =
+      _litert_lm_conversation_clonePtr.asFunction<
+          ffi.Pointer<LiteRtLmConversation> Function(
+              ffi.Pointer<LiteRtLmConversation>)>();
+
   ffi.Pointer<LiteRtLmJsonResponse> litert_lm_conversation_send_message(
     ffi.Pointer<LiteRtLmConversation> conversation,
     ffi.Pointer<ffi.Char> message_json,
     ffi.Pointer<ffi.Char> extra_context,
+    ffi.Pointer<LiteRtLmConversationOptionalArgs> optional_args,
   ) {
     return _litert_lm_conversation_send_message(
       conversation,
       message_json,
       extra_context,
+      optional_args,
     );
   }
 
   late final _litert_lm_conversation_send_messagePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<LiteRtLmJsonResponse> Function(
-              ffi.Pointer<LiteRtLmConversation>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Char>)>>('litert_lm_conversation_send_message');
+          ffi.NativeFunction<
+              ffi.Pointer<LiteRtLmJsonResponse> Function(
+                  ffi.Pointer<LiteRtLmConversation>,
+                  ffi.Pointer<ffi.Char>,
+                  ffi.Pointer<ffi.Char>,
+                  ffi.Pointer<LiteRtLmConversationOptionalArgs>)>>(
+      'litert_lm_conversation_send_message');
   late final _litert_lm_conversation_send_message =
       _litert_lm_conversation_send_messagePtr.asFunction<
           ffi.Pointer<LiteRtLmJsonResponse> Function(
               ffi.Pointer<LiteRtLmConversation>,
               ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Char>)>();
+              ffi.Pointer<ffi.Char>,
+              ffi.Pointer<LiteRtLmConversationOptionalArgs>)>();
 
   void litert_lm_json_response_delete(
     ffi.Pointer<LiteRtLmJsonResponse> response,
@@ -880,6 +1333,7 @@ class LiteRtLmBindings {
     ffi.Pointer<LiteRtLmConversation> conversation,
     ffi.Pointer<ffi.Char> message_json,
     ffi.Pointer<ffi.Char> extra_context,
+    ffi.Pointer<LiteRtLmConversationOptionalArgs> optional_args,
     LiteRtLmStreamCallback callback,
     ffi.Pointer<ffi.Void> callback_data,
   ) {
@@ -887,6 +1341,7 @@ class LiteRtLmBindings {
       conversation,
       message_json,
       extra_context,
+      optional_args,
       callback,
       callback_data,
     );
@@ -898,6 +1353,7 @@ class LiteRtLmBindings {
                   ffi.Pointer<LiteRtLmConversation>,
                   ffi.Pointer<ffi.Char>,
                   ffi.Pointer<ffi.Char>,
+                  ffi.Pointer<LiteRtLmConversationOptionalArgs>,
                   LiteRtLmStreamCallback,
                   ffi.Pointer<ffi.Void>)>>(
       'litert_lm_conversation_send_message_stream');
@@ -907,8 +1363,29 @@ class LiteRtLmBindings {
               ffi.Pointer<LiteRtLmConversation>,
               ffi.Pointer<ffi.Char>,
               ffi.Pointer<ffi.Char>,
+              ffi.Pointer<LiteRtLmConversationOptionalArgs>,
               LiteRtLmStreamCallback,
               ffi.Pointer<ffi.Void>)>();
+
+  ffi.Pointer<ffi.Char> litert_lm_conversation_render_message_to_string(
+    ffi.Pointer<LiteRtLmConversation> conversation,
+    ffi.Pointer<ffi.Char> message_json,
+  ) {
+    return _litert_lm_conversation_render_message_to_string(
+      conversation,
+      message_json,
+    );
+  }
+
+  late final _litert_lm_conversation_render_message_to_stringPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<ffi.Char> Function(
+                  ffi.Pointer<LiteRtLmConversation>, ffi.Pointer<ffi.Char>)>>(
+      'litert_lm_conversation_render_message_to_string');
+  late final _litert_lm_conversation_render_message_to_string =
+      _litert_lm_conversation_render_message_to_stringPtr.asFunction<
+          ffi.Pointer<ffi.Char> Function(
+              ffi.Pointer<LiteRtLmConversation>, ffi.Pointer<ffi.Char>)>();
 
   void litert_lm_conversation_cancel_process(
     ffi.Pointer<LiteRtLmConversation> conversation,
@@ -943,6 +1420,289 @@ class LiteRtLmBindings {
       _litert_lm_conversation_get_benchmark_infoPtr.asFunction<
           ffi.Pointer<LiteRtLmBenchmarkInfo> Function(
               ffi.Pointer<LiteRtLmConversation>)>();
+
+  ffi.Pointer<LiteRtLmTokenizeResult> litert_lm_engine_tokenize(
+    ffi.Pointer<LiteRtLmEngine> engine,
+    ffi.Pointer<ffi.Char> text,
+  ) {
+    return _litert_lm_engine_tokenize(
+      engine,
+      text,
+    );
+  }
+
+  late final _litert_lm_engine_tokenizePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<LiteRtLmTokenizeResult> Function(
+              ffi.Pointer<LiteRtLmEngine>,
+              ffi.Pointer<ffi.Char>)>>('litert_lm_engine_tokenize');
+  late final _litert_lm_engine_tokenize =
+      _litert_lm_engine_tokenizePtr.asFunction<
+          ffi.Pointer<LiteRtLmTokenizeResult> Function(
+              ffi.Pointer<LiteRtLmEngine>, ffi.Pointer<ffi.Char>)>();
+
+  void litert_lm_tokenize_result_delete(
+    ffi.Pointer<LiteRtLmTokenizeResult> result,
+  ) {
+    return _litert_lm_tokenize_result_delete(
+      result,
+    );
+  }
+
+  late final _litert_lm_tokenize_result_deletePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmTokenizeResult>)>>(
+      'litert_lm_tokenize_result_delete');
+  late final _litert_lm_tokenize_result_delete =
+      _litert_lm_tokenize_result_deletePtr
+          .asFunction<void Function(ffi.Pointer<LiteRtLmTokenizeResult>)>();
+
+  ffi.Pointer<ffi.Int> litert_lm_tokenize_result_get_tokens(
+    ffi.Pointer<LiteRtLmTokenizeResult> result,
+  ) {
+    return _litert_lm_tokenize_result_get_tokens(
+      result,
+    );
+  }
+
+  late final _litert_lm_tokenize_result_get_tokensPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<ffi.Int> Function(
+                  ffi.Pointer<LiteRtLmTokenizeResult>)>>(
+      'litert_lm_tokenize_result_get_tokens');
+  late final _litert_lm_tokenize_result_get_tokens =
+      _litert_lm_tokenize_result_get_tokensPtr.asFunction<
+          ffi.Pointer<ffi.Int> Function(ffi.Pointer<LiteRtLmTokenizeResult>)>();
+
+  int litert_lm_tokenize_result_get_num_tokens(
+    ffi.Pointer<LiteRtLmTokenizeResult> result,
+  ) {
+    return _litert_lm_tokenize_result_get_num_tokens(
+      result,
+    );
+  }
+
+  late final _litert_lm_tokenize_result_get_num_tokensPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Size Function(ffi.Pointer<LiteRtLmTokenizeResult>)>>(
+      'litert_lm_tokenize_result_get_num_tokens');
+  late final _litert_lm_tokenize_result_get_num_tokens =
+      _litert_lm_tokenize_result_get_num_tokensPtr
+          .asFunction<int Function(ffi.Pointer<LiteRtLmTokenizeResult>)>();
+
+  ffi.Pointer<LiteRtLmDetokenizeResult> litert_lm_engine_detokenize(
+    ffi.Pointer<LiteRtLmEngine> engine,
+    ffi.Pointer<ffi.Int> tokens,
+    int num_tokens,
+  ) {
+    return _litert_lm_engine_detokenize(
+      engine,
+      tokens,
+      num_tokens,
+    );
+  }
+
+  late final _litert_lm_engine_detokenizePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<LiteRtLmDetokenizeResult> Function(
+              ffi.Pointer<LiteRtLmEngine>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Size)>>('litert_lm_engine_detokenize');
+  late final _litert_lm_engine_detokenize =
+      _litert_lm_engine_detokenizePtr.asFunction<
+          ffi.Pointer<LiteRtLmDetokenizeResult> Function(
+              ffi.Pointer<LiteRtLmEngine>, ffi.Pointer<ffi.Int>, int)>();
+
+  void litert_lm_detokenize_result_delete(
+    ffi.Pointer<LiteRtLmDetokenizeResult> result,
+  ) {
+    return _litert_lm_detokenize_result_delete(
+      result,
+    );
+  }
+
+  late final _litert_lm_detokenize_result_deletePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Pointer<LiteRtLmDetokenizeResult>)>>(
+      'litert_lm_detokenize_result_delete');
+  late final _litert_lm_detokenize_result_delete =
+      _litert_lm_detokenize_result_deletePtr
+          .asFunction<void Function(ffi.Pointer<LiteRtLmDetokenizeResult>)>();
+
+  ffi.Pointer<ffi.Char> litert_lm_detokenize_result_get_string(
+    ffi.Pointer<LiteRtLmDetokenizeResult> result,
+  ) {
+    return _litert_lm_detokenize_result_get_string(
+      result,
+    );
+  }
+
+  late final _litert_lm_detokenize_result_get_stringPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<ffi.Char> Function(
+                  ffi.Pointer<LiteRtLmDetokenizeResult>)>>(
+      'litert_lm_detokenize_result_get_string');
+  late final _litert_lm_detokenize_result_get_string =
+      _litert_lm_detokenize_result_get_stringPtr.asFunction<
+          ffi.Pointer<ffi.Char> Function(
+              ffi.Pointer<LiteRtLmDetokenizeResult>)>();
+
+  void litert_lm_token_union_delete(
+    ffi.Pointer<LiteRtLmTokenUnion> token_union,
+  ) {
+    return _litert_lm_token_union_delete(
+      token_union,
+    );
+  }
+
+  late final _litert_lm_token_union_deletePtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Pointer<LiteRtLmTokenUnion>)>>(
+      'litert_lm_token_union_delete');
+  late final _litert_lm_token_union_delete = _litert_lm_token_union_deletePtr
+      .asFunction<void Function(ffi.Pointer<LiteRtLmTokenUnion>)>();
+
+  LiteRtLmTokenUnionType litert_lm_token_union_get_type(
+    ffi.Pointer<LiteRtLmTokenUnion> token_union,
+  ) {
+    return LiteRtLmTokenUnionType.fromValue(_litert_lm_token_union_get_type(
+      token_union,
+    ));
+  }
+
+  late final _litert_lm_token_union_get_typePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.UnsignedInt Function(ffi.Pointer<LiteRtLmTokenUnion>)>>(
+      'litert_lm_token_union_get_type');
+  late final _litert_lm_token_union_get_type =
+      _litert_lm_token_union_get_typePtr
+          .asFunction<int Function(ffi.Pointer<LiteRtLmTokenUnion>)>();
+
+  ffi.Pointer<ffi.Char> litert_lm_token_union_get_string(
+    ffi.Pointer<LiteRtLmTokenUnion> token_union,
+  ) {
+    return _litert_lm_token_union_get_string(
+      token_union,
+    );
+  }
+
+  late final _litert_lm_token_union_get_stringPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<ffi.Char> Function(ffi.Pointer<LiteRtLmTokenUnion>)>>(
+      'litert_lm_token_union_get_string');
+  late final _litert_lm_token_union_get_string =
+      _litert_lm_token_union_get_stringPtr.asFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<LiteRtLmTokenUnion>)>();
+
+  int litert_lm_token_union_get_ids(
+    ffi.Pointer<LiteRtLmTokenUnion> token_union,
+    ffi.Pointer<ffi.Pointer<ffi.Int>> out_tokens,
+    ffi.Pointer<ffi.Size> out_num_tokens,
+  ) {
+    return _litert_lm_token_union_get_ids(
+      token_union,
+      out_tokens,
+      out_num_tokens,
+    );
+  }
+
+  late final _litert_lm_token_union_get_idsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              ffi.Pointer<LiteRtLmTokenUnion>,
+              ffi.Pointer<ffi.Pointer<ffi.Int>>,
+              ffi.Pointer<ffi.Size>)>>('litert_lm_token_union_get_ids');
+  late final _litert_lm_token_union_get_ids =
+      _litert_lm_token_union_get_idsPtr.asFunction<
+          int Function(ffi.Pointer<LiteRtLmTokenUnion>,
+              ffi.Pointer<ffi.Pointer<ffi.Int>>, ffi.Pointer<ffi.Size>)>();
+
+  void litert_lm_token_unions_delete(
+    ffi.Pointer<LiteRtLmTokenUnions> tokens,
+  ) {
+    return _litert_lm_token_unions_delete(
+      tokens,
+    );
+  }
+
+  late final _litert_lm_token_unions_deletePtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Pointer<LiteRtLmTokenUnions>)>>(
+      'litert_lm_token_unions_delete');
+  late final _litert_lm_token_unions_delete = _litert_lm_token_unions_deletePtr
+      .asFunction<void Function(ffi.Pointer<LiteRtLmTokenUnions>)>();
+
+  int litert_lm_token_unions_get_num_tokens(
+    ffi.Pointer<LiteRtLmTokenUnions> tokens,
+  ) {
+    return _litert_lm_token_unions_get_num_tokens(
+      tokens,
+    );
+  }
+
+  late final _litert_lm_token_unions_get_num_tokensPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Size Function(ffi.Pointer<LiteRtLmTokenUnions>)>>(
+      'litert_lm_token_unions_get_num_tokens');
+  late final _litert_lm_token_unions_get_num_tokens =
+      _litert_lm_token_unions_get_num_tokensPtr
+          .asFunction<int Function(ffi.Pointer<LiteRtLmTokenUnions>)>();
+
+  ffi.Pointer<LiteRtLmTokenUnion> litert_lm_token_unions_get_token_at(
+    ffi.Pointer<LiteRtLmTokenUnions> tokens,
+    int index,
+  ) {
+    return _litert_lm_token_unions_get_token_at(
+      tokens,
+      index,
+    );
+  }
+
+  late final _litert_lm_token_unions_get_token_atPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<LiteRtLmTokenUnion> Function(
+              ffi.Pointer<LiteRtLmTokenUnions>,
+              ffi.Size)>>('litert_lm_token_unions_get_token_at');
+  late final _litert_lm_token_unions_get_token_at =
+      _litert_lm_token_unions_get_token_atPtr.asFunction<
+          ffi.Pointer<LiteRtLmTokenUnion> Function(
+              ffi.Pointer<LiteRtLmTokenUnions>, int)>();
+
+  ffi.Pointer<LiteRtLmTokenUnion> litert_lm_engine_get_start_token(
+    ffi.Pointer<LiteRtLmEngine> engine,
+  ) {
+    return _litert_lm_engine_get_start_token(
+      engine,
+    );
+  }
+
+  late final _litert_lm_engine_get_start_tokenPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<LiteRtLmTokenUnion> Function(
+                  ffi.Pointer<LiteRtLmEngine>)>>(
+      'litert_lm_engine_get_start_token');
+  late final _litert_lm_engine_get_start_token =
+      _litert_lm_engine_get_start_tokenPtr.asFunction<
+          ffi.Pointer<LiteRtLmTokenUnion> Function(
+              ffi.Pointer<LiteRtLmEngine>)>();
+
+  ffi.Pointer<LiteRtLmTokenUnions> litert_lm_engine_get_stop_tokens(
+    ffi.Pointer<LiteRtLmEngine> engine,
+  ) {
+    return _litert_lm_engine_get_stop_tokens(
+      engine,
+    );
+  }
+
+  late final _litert_lm_engine_get_stop_tokensPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<LiteRtLmTokenUnions> Function(
+                  ffi.Pointer<LiteRtLmEngine>)>>(
+      'litert_lm_engine_get_stop_tokens');
+  late final _litert_lm_engine_get_stop_tokens =
+      _litert_lm_engine_get_stop_tokensPtr.asFunction<
+          ffi.Pointer<LiteRtLmTokenUnions> Function(
+              ffi.Pointer<LiteRtLmEngine>)>();
 }
 
 final class LiteRtLmEngine extends ffi.Opaque {}
@@ -957,27 +1717,53 @@ final class LiteRtLmBenchmarkInfo extends ffi.Opaque {}
 
 final class LiteRtLmConversation extends ffi.Opaque {}
 
+final class LiteRtLmConversationOptionalArgs extends ffi.Opaque {}
+
 final class LiteRtLmJsonResponse extends ffi.Opaque {}
+
+final class LiteRtLmDetokenizeResult extends ffi.Opaque {}
+
+final class LiteRtLmTokenizeResult extends ffi.Opaque {}
+
+enum LiteRtLmTokenUnionType {
+  kLiteRtLmTokenUnionTypeString(0),
+  kLiteRtLmTokenUnionTypeIds(1);
+
+  final int value;
+  const LiteRtLmTokenUnionType(this.value);
+
+  static LiteRtLmTokenUnionType fromValue(int value) => switch (value) {
+        0 => kLiteRtLmTokenUnionTypeString,
+        1 => kLiteRtLmTokenUnionTypeIds,
+        _ => throw ArgumentError(
+            'Unknown value for LiteRtLmTokenUnionType: $value'),
+      };
+}
+
+final class LiteRtLmTokenUnion extends ffi.Opaque {}
+
+final class LiteRtLmTokenUnions extends ffi.Opaque {}
 
 final class LiteRtLmSessionConfig extends ffi.Opaque {}
 
 final class LiteRtLmConversationConfig extends ffi.Opaque {}
 
-enum Type {
-  kTypeUnspecified(0),
-  kTopK(1),
-  kTopP(2),
-  kGreedy(3);
+enum LiteRtLmSamplerType {
+  kLiteRtLmSamplerTypeUnspecified(0),
+  kLiteRtLmSamplerTypeTopK(1),
+  kLiteRtLmSamplerTypeTopP(2),
+  kLiteRtLmSamplerTypeGreedy(3);
 
   final int value;
-  const Type(this.value);
+  const LiteRtLmSamplerType(this.value);
 
-  static Type fromValue(int value) => switch (value) {
-        0 => kTypeUnspecified,
-        1 => kTopK,
-        2 => kTopP,
-        3 => kGreedy,
-        _ => throw ArgumentError('Unknown value for Type: $value'),
+  static LiteRtLmSamplerType fromValue(int value) => switch (value) {
+        0 => kLiteRtLmSamplerTypeUnspecified,
+        1 => kLiteRtLmSamplerTypeTopK,
+        2 => kLiteRtLmSamplerTypeTopP,
+        3 => kLiteRtLmSamplerTypeGreedy,
+        _ =>
+          throw ArgumentError('Unknown value for LiteRtLmSamplerType: $value'),
       };
 }
 
@@ -985,7 +1771,7 @@ final class LiteRtLmSamplerParams extends ffi.Struct {
   @ffi.UnsignedInt()
   external int typeAsInt;
 
-  Type get type => Type.fromValue(typeAsInt);
+  LiteRtLmSamplerType get type => LiteRtLmSamplerType.fromValue(typeAsInt);
 
   @ffi.Int32()
   external int top_k;
@@ -1000,31 +1786,32 @@ final class LiteRtLmSamplerParams extends ffi.Struct {
   external int seed;
 }
 
-enum InputDataType {
-  kInputText(0),
-  kInputImage(1),
-  kInputImageEnd(2),
-  kInputAudio(3),
-  kInputAudioEnd(4);
+enum LiteRtLmInputDataType {
+  kLiteRtLmInputDataTypeText(0),
+  kLiteRtLmInputDataTypeImage(1),
+  kLiteRtLmInputDataTypeImageEnd(2),
+  kLiteRtLmInputDataTypeAudio(3),
+  kLiteRtLmInputDataTypeAudioEnd(4);
 
   final int value;
-  const InputDataType(this.value);
+  const LiteRtLmInputDataType(this.value);
 
-  static InputDataType fromValue(int value) => switch (value) {
-        0 => kInputText,
-        1 => kInputImage,
-        2 => kInputImageEnd,
-        3 => kInputAudio,
-        4 => kInputAudioEnd,
-        _ => throw ArgumentError('Unknown value for InputDataType: $value'),
+  static LiteRtLmInputDataType fromValue(int value) => switch (value) {
+        0 => kLiteRtLmInputDataTypeText,
+        1 => kLiteRtLmInputDataTypeImage,
+        2 => kLiteRtLmInputDataTypeImageEnd,
+        3 => kLiteRtLmInputDataTypeAudio,
+        4 => kLiteRtLmInputDataTypeAudioEnd,
+        _ => throw ArgumentError(
+            'Unknown value for LiteRtLmInputDataType: $value'),
       };
 }
 
-final class InputData extends ffi.Struct {
+final class LiteRtLmInputData extends ffi.Struct {
   @ffi.UnsignedInt()
   external int typeAsInt;
 
-  InputDataType get type => InputDataType.fromValue(typeAsInt);
+  LiteRtLmInputDataType get type => LiteRtLmInputDataType.fromValue(typeAsInt);
 
   external ffi.Pointer<ffi.Void> data;
 

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -684,13 +684,22 @@ class LiteRtLmFfiClient {
     final proxyFn = outProxyFn.value;
     calloc.free(outProxyFn);
 
+    // v0.12.0 send_message_stream takes a LiteRtLmConversationOptionalArgs*
+    // that must be a real allocation (passing null sigsegvs inside
+    // litert_lm_lib). We allocate an empty one per call and free it after
+    // the native call returns; the callback fires synchronously inside.
+    final optionalArgs = b.litert_lm_conversation_optional_args_create();
+
     final result = b.litert_lm_conversation_send_message_stream(
       _conversation!,
       messagePtr.cast(),
       extraPtr == nullptr ? nullptr : extraPtr.cast(),
+      optionalArgs,
       proxyFn.cast(),
       proxyData,
     );
+
+    b.litert_lm_conversation_optional_args_delete(optionalArgs);
 
     if (result != 0) {
       controller
@@ -714,11 +723,15 @@ class LiteRtLmFfiClient {
     final extraPtr =
         extraContext != null ? extraContext.toNativeUtf8() : nullptr;
 
+    // v0.12.0 send_message requires a non-null LiteRtLmConversationOptionalArgs*.
+    final optionalArgs = b.litert_lm_conversation_optional_args_create();
+
     try {
       final response = b.litert_lm_conversation_send_message(
         _conversation!,
         messagePtr.cast(),
         extraPtr == nullptr ? nullptr : extraPtr.cast(),
+        optionalArgs,
       );
 
       if (response == nullptr) {
@@ -731,6 +744,7 @@ class LiteRtLmFfiClient {
       b.litert_lm_json_response_delete(response);
       return result;
     } finally {
+      b.litert_lm_conversation_optional_args_delete(optionalArgs);
       calloc.free(messagePtr);
       if (extraPtr != nullptr) calloc.free(extraPtr);
     }

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -689,6 +689,14 @@ class LiteRtLmFfiClient {
     // litert_lm_lib). We allocate an empty one per call and free it after
     // the native call returns; the callback fires synchronously inside.
     final optionalArgs = b.litert_lm_conversation_optional_args_create();
+    if (optionalArgs == nullptr) {
+      calloc.free(messagePtr);
+      if (extraPtr != nullptr) calloc.free(extraPtr);
+      callable.close();
+      throw StateError(
+          'litert_lm_conversation_optional_args_create returned null — '
+          'native libLiteRtLm.dylib initialization failure');
+    }
 
     final result = b.litert_lm_conversation_send_message_stream(
       _conversation!,
@@ -725,6 +733,13 @@ class LiteRtLmFfiClient {
 
     // v0.12.0 send_message requires a non-null LiteRtLmConversationOptionalArgs*.
     final optionalArgs = b.litert_lm_conversation_optional_args_create();
+    if (optionalArgs == nullptr) {
+      calloc.free(messagePtr);
+      if (extraPtr != nullptr) calloc.free(extraPtr);
+      throw StateError(
+          'litert_lm_conversation_optional_args_create returned null — '
+          'native libLiteRtLm.dylib initialization failure');
+    }
 
     try {
       final response = b.litert_lm_conversation_send_message(

--- a/lib/core/infrastructure/platform_file_system_service.dart
+++ b/lib/core/infrastructure/platform_file_system_service.dart
@@ -201,13 +201,41 @@ class PlatformFileSystemService implements FileSystemService {
     if (Platform.isAndroid || Platform.isIOS) {
       dir = await getApplicationDocumentsDirectory();
     } else if (Platform.isWindows) {
-      // LOCALAPPDATA is set by Windows for every user session. Fall back
-      // to the Roaming Application Support if it is somehow unset (very
-      // unusual but possible in stripped-down environments).
+      // Windows: prefer LOCALAPPDATA (never OneDrive-synced, unlike
+      // Documents or Roaming AppData). But the env var is unreliable:
+      // some shells / dev containers / sandboxes return it relative
+      // ("Users\me\AppData\Local") or empty, in which case the
+      // resulting Directory resolves against $PWD at access time —
+      // a moving target that breaks install/validate roundtrips.
+      // See https://github.com/DenisovAV/flutter_gemma/issues/<...>
+      // for the original bug report.
+      //
+      // Defence in depth:
+      //   1. Read LOCALAPPDATA; accept only if non-empty AND absolute.
+      //   2. Otherwise compose from USERPROFILE + \AppData\Local if
+      //      USERPROFILE itself is absolute.
+      //   3. Last resort: path_provider's getApplicationSupportDirectory()
+      //      (Roaming AppData via the Windows SHGetKnownFolderPath API).
       final local = Platform.environment['LOCALAPPDATA'];
-      final base = local != null && local.isNotEmpty
-          ? Directory(local)
-          : await getApplicationSupportDirectory();
+      Directory? base;
+      if (local != null && local.isNotEmpty && path.isAbsolute(local)) {
+        base = Directory(local);
+      } else {
+        if (local != null && local.isNotEmpty) {
+          debugPrint('[flutter_gemma] LOCALAPPDATA is not absolute '
+              '("$local") — falling back to USERPROFILE / Application '
+              'Support. Models would otherwise land in a \$PWD-relative '
+              'directory.');
+        }
+        final userProfile = Platform.environment['USERPROFILE'];
+        if (userProfile != null &&
+            userProfile.isNotEmpty &&
+            path.isAbsolute(userProfile)) {
+          base = Directory(path.join(userProfile, 'AppData', 'Local'));
+        } else {
+          base = await getApplicationSupportDirectory();
+        }
+      }
       dir = Directory(path.join(base.path, 'flutter_gemma'));
     } else {
       // macOS, Linux — namespace under flutter_gemma/ inside Application

--- a/native/litert_lm/build_android.sh
+++ b/native/litert_lm/build_android.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREBUILT_DIR="$SCRIPT_DIR/prebuilt/android_arm64"
 LITERT_LM_DIR="/tmp/LiteRT-LM"
-DEFAULT_REF="032334d81ff96431492be272e536fbafe094b1e9"
+DEFAULT_REF="ffed38adbc33509480b5340e5173638bc20a68ff"
 VERSION="${1:-}"
 
 # Resolve Android NDK — prefer ANDROID_NDK_HOME env, else newest under

--- a/native/litert_lm/build_ios.sh
+++ b/native/litert_lm/build_ios.sh
@@ -154,23 +154,31 @@ for lib in libGemmaModelConstraintProvider.dylib libLiteRtMetalAccelerator.dylib
   [ -f "prebuilt/ios_sim_arm64/$lib" ] && cp "prebuilt/ios_sim_arm64/$lib" "$SIM_DIR/$lib" && echo "  $lib → simulator"
 done
 
-# 8b. Re-apply vtool minos patch on libGemmaModelConstraintProvider.dylib —
-# upstream ships it with minos 26.2 on iOS (only one of the iOS companion
-# dylibs with this issue), causing App Store ITMS-90208 rejection for any
-# app with Info.plist min iOS < 26.2. See google-ai-edge/LiteRT-LM#2158
-# and our downstream issue #245. Lower to 16.0 which matches our podspec.
+# 8b. Normalize iOS minos of all 4 companion dylibs to 13.0 — this matches
+# the MinimumOSVersion that Flutter Native Assets hardcodes into the
+# generated framework wrapper Info.plist (flutter/flutter#148501). Without
+# this, App Store Connect rejects the archive with ITMS-90208 ("framework
+# does not support the minimum OS Version specified in the Info.plist")
+# whenever a dylib's binary minos differs from the wrapper plist's 13.0.
+#
+# The plugin still requires iOS 16+ via the podspec's `s.platform = :ios,
+# '16.0'` — that's the real contract. The minos here is just metadata to
+# satisfy validator equality between binary and wrapper plist; the actual
+# minimum is enforced upstream by CocoaPods. See #245, #286.
 echo ""
-echo "=== Patch libGemmaModelConstraintProvider.dylib minos 26.2 → 16.0 ==="
+echo "=== Patch iOS companion dylibs minos → 13.0 ==="
 for arch_dir_pair in "ios:$DEVICE_DIR" "iossim:$SIM_DIR"; do
   platform="${arch_dir_pair%%:*}"
   dir="${arch_dir_pair##*:}"
-  d="$dir/libGemmaModelConstraintProvider.dylib"
-  if [ -f "$d" ]; then
-    vtool -set-build-version "$platform" 16.0 26.2 -replace -output "$d.new" "$d"
-    mv "$d.new" "$d"
-    chmod +w "$d"
-    echo "  $d: minos $(vtool -show-build "$d" | grep minos | awk '{print $2}')"
-  fi
+  for libname in libGemmaModelConstraintProvider libLiteRtLm libLiteRtMetalAccelerator libStreamProxy; do
+    d="$dir/${libname}.dylib"
+    if [ -f "$d" ]; then
+      vtool -set-build-version "$platform" 13.0 18.5 -replace -output "$d.new" "$d"
+      mv "$d.new" "$d"
+      chmod +w "$d"
+      echo "  $d: minos $(vtool -show-build "$d" | grep minos | awk '{print $2}'), sdk $(vtool -show-build "$d" | grep sdk | awk '{print $2}')"
+    fi
+  done
 done
 
 # 9. Verify

--- a/native/litert_lm/build_ios.sh
+++ b/native/litert_lm/build_ios.sh
@@ -49,7 +49,7 @@ fi
 # This is the first public LiteRT-LM commit where libLiteRtLm rebuilt from
 # source has matching ABI with the prebuilt accelerators. v0.11.0 itself
 # is broken — see the WARNING above and the upstream issue we filed.
-DEFAULT_REF="032334d81ff96431492be272e536fbafe094b1e9"
+DEFAULT_REF="ffed38adbc33509480b5340e5173638bc20a68ff"
 TARGET_REF="${VERSION:-$DEFAULT_REF}"
 echo "Checking out $TARGET_REF..."
 git checkout -f "$TARGET_REF"

--- a/native/litert_lm/build_macos.sh
+++ b/native/litert_lm/build_macos.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREBUILT_DIR="$SCRIPT_DIR/prebuilt/macos_arm64"
 LITERT_LM_DIR="/tmp/LiteRT-LM"
-DEFAULT_REF="032334d81ff96431492be272e536fbafe094b1e9"
+DEFAULT_REF="ffed38adbc33509480b5340e5173638bc20a68ff"
 VERSION="${1:-}"
 
 echo "=== Building libLiteRtLm.dylib for macOS arm64 ==="

--- a/native/litert_lm/include/engine.h
+++ b/native/litert_lm/include/engine.h
@@ -32,7 +32,9 @@ extern "C" {
 #if defined(_WIN32)
 #define LITERT_LM_C_API_EXPORT __declspec(dllexport)
 #else
-#define LITERT_LM_C_API_EXPORT
+// Ensure symbols are exported when building the shared library with
+// -fvisibility=hidden.
+#define LITERT_LM_C_API_EXPORT __attribute__((visibility("default")))
 #endif
 
 // Opaque pointer for the LiteRT LM Engine.
@@ -53,8 +55,38 @@ typedef struct LiteRtLmBenchmarkInfo LiteRtLmBenchmarkInfo;
 // Opaque pointer for the LiteRT LM Conversation.
 typedef struct LiteRtLmConversation LiteRtLmConversation;
 
+// Opaque pointer for the LiteRT LM Conversation Optional Args.
+typedef struct LiteRtLmConversationOptionalArgs
+    LiteRtLmConversationOptionalArgs;
+
 // Opaque pointer for a JSON response.
 typedef struct LiteRtLmJsonResponse LiteRtLmJsonResponse;
+
+// Opaque pointer for a detokenize result.
+// Use `litert_lm_detokenize_result_delete` to free memory.
+typedef struct LiteRtLmDetokenizeResult LiteRtLmDetokenizeResult;
+
+// Opaque pointer for a tokenize result.
+// Use `litert_lm_tokenize_result_delete` to free memory.
+typedef struct LiteRtLmTokenizeResult LiteRtLmTokenizeResult;
+
+// Represents the type of a TokenUnion.
+typedef enum {
+  kLiteRtLmTokenUnionTypeString = 0,
+  kLiteRtLmTokenUnionTypeIds = 1,
+} LiteRtLmTokenUnionType;
+
+// Opaque pointer for LiteRT LM Token Union.
+// Represents a single start or stop token, which could be either a string or a
+// sequence of token ids.
+// Use `litert_lm_token_union_delete` to free memory.
+typedef struct LiteRtLmTokenUnion LiteRtLmTokenUnion;
+
+// Opaque pointer for LiteRT LM Token Unions.
+// Represents a collection of TokenUnion, typically used for model stop
+// conditions.
+// Use `litert_lm_token_unions_delete` to free memory.
+typedef struct LiteRtLmTokenUnions LiteRtLmTokenUnions;
 
 // Opaque pointer for LiteRT LM Session Config.
 typedef struct LiteRtLmSessionConfig LiteRtLmSessionConfig;
@@ -64,19 +96,19 @@ typedef struct LiteRtLmConversationConfig LiteRtLmConversationConfig;
 
 // Represents the type of sampler.
 typedef enum {
-  kTypeUnspecified = 0,
+  kLiteRtLmSamplerTypeUnspecified = 0,
   // Probabilistically pick among the top k tokens.
-  kTopK = 1,
+  kLiteRtLmSamplerTypeTopK = 1,
   // Probabilistically pick among the tokens such that the sum is greater
   // than or equal to p tokens after first performing top-k sampling.
-  kTopP = 2,
+  kLiteRtLmSamplerTypeTopP = 2,
   // Pick the token with maximum logit (i.e., argmax).
-  kGreedy = 3,
-} Type;
+  kLiteRtLmSamplerTypeGreedy = 3,
+} LiteRtLmSamplerType;
 
 // Parameters for the sampler.
 typedef struct {
-  Type type;
+  LiteRtLmSamplerType type;
   int32_t top_k;
   float top_p;
   float temperature;
@@ -97,6 +129,13 @@ LITERT_LM_C_API_EXPORT
 void litert_lm_session_config_set_max_output_tokens(
     LiteRtLmSessionConfig* config, int max_output_tokens);
 
+// Sets whether to apply prompt template for this session.
+// @param config The config to modify.
+// @param apply_prompt_template Whether to apply prompt template.
+LITERT_LM_C_API_EXPORT
+void litert_lm_session_config_set_apply_prompt_template(
+    LiteRtLmSessionConfig* config, bool apply_prompt_template);
+
 // Sets the sampler parameters for this session config.
 // @param config The config to modify.
 // @param sampler_params The sampler parameters to use.
@@ -112,12 +151,6 @@ void litert_lm_session_config_delete(LiteRtLmSessionConfig* config);
 // Creates a LiteRT LM Conversation Config.
 // The caller is responsible for destroying the config using
 // `litert_lm_conversation_config_delete`.
-// @param engine The engine to use.
-// @param session_config The session config to use. If NULL, default
-// session config will be used.
-// @param system_message_json The system message in JSON format.
-// @param tools_json The tools description in JSON array format.
-// @param enable_constrained_decoding Whether to enable constrained decoding.
 // @return A pointer to the created config, or NULL on failure.
 LITERT_LM_C_API_EXPORT
 LiteRtLmConversationConfig* litert_lm_conversation_config_create(
@@ -125,35 +158,109 @@ LiteRtLmConversationConfig* litert_lm_conversation_config_create(
     const char* system_message_json, const char* tools_json,
     const char* messages_json, bool enable_constrained_decoding);
 
+// Sets the session config for this conversation config.
+// @param config The config to modify.
+// @param session_config The session config to use.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_session_config(
+    LiteRtLmConversationConfig* config,
+    const LiteRtLmSessionConfig* session_config);
+
+// Sets the system message for this conversation config.
+// @param config The config to modify.
+// @param system_message_json The system message in JSON format.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_system_message(
+    LiteRtLmConversationConfig* config, const char* system_message_json);
+
+// Sets the tools for this conversation config.
+// @param config The config to modify.
+// @param tools_json The tools description in JSON array format.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_tools(LiteRtLmConversationConfig* config,
+                                             const char* tools_json);
+
+// Sets the initial messages for this conversation config.
+// @param config The config to modify.
+// @param messages_json The initial messages in JSON array format.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_messages(
+    LiteRtLmConversationConfig* config, const char* messages_json);
+
+// Sets the extra context for the conversation preface.
+// @param config The config to modify.
+// @param extra_context_json A JSON string representing the extra context
+// object.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_extra_context(
+    LiteRtLmConversationConfig* config, const char* extra_context_json);
+
+// Sets whether to enable constrained decoding for this conversation config.
+// @param config The config to modify.
+// @param enable_constrained_decoding Whether to enable constrained decoding.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_enable_constrained_decoding(
+    LiteRtLmConversationConfig* config, bool enable_constrained_decoding);
+
+// Sets whether to filter channel content from the KV cache.
+// @param config The config to modify.
+// @param filter_channel_content_from_kv_cache Whether to filter channel
+// content.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_config_set_filter_channel_content_from_kv_cache(
+    LiteRtLmConversationConfig* config,
+    bool filter_channel_content_from_kv_cache);
+
 // Destroys a LiteRT LM Conversation Config.
 // @param config The config to destroy.
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_config_delete(LiteRtLmConversationConfig* config);
 
+// Creates a LiteRT LM Conversation Optional Args. The caller is responsible
+// for destroying the optional args using
+// `litert_lm_conversation_optional_args_delete`.
+// @return A pointer to the created optional args, or NULL on failure.
+LITERT_LM_C_API_EXPORT
+LiteRtLmConversationOptionalArgs* litert_lm_conversation_optional_args_create();
+
+// Destroys a LiteRT LM Conversation Optional Args.
+// @param optional_args The optional args to destroy.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_optional_args_delete(
+    LiteRtLmConversationOptionalArgs* optional_args);
+
+// Sets the visual token budget for the conversation optional args.
+// @param optional_args The optional args to modify.
+// @param visual_token_budget The visual token budget.
+LITERT_LM_C_API_EXPORT
+void litert_lm_conversation_optional_args_set_visual_token_budget(
+    LiteRtLmConversationOptionalArgs* optional_args, int visual_token_budget);
+
 // Sets the minimum log level for the LiteRT LM library.
-// Log levels are: 0=INFO, 1=WARNING, 2=ERROR, 3=FATAL.
+// Log levels are: 0=VERBOSE, 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR, 5=FATAL,
+// 1000=SILENT.
 LITERT_LM_C_API_EXPORT
 void litert_lm_set_min_log_level(int level);
 
 // Represents the type of input data.
 typedef enum {
-  kInputText,
-  kInputImage,
-  kInputImageEnd,
-  kInputAudio,
-  kInputAudioEnd,
-} InputDataType;
+  kLiteRtLmInputDataTypeText,
+  kLiteRtLmInputDataTypeImage,
+  kLiteRtLmInputDataTypeImageEnd,
+  kLiteRtLmInputDataTypeAudio,
+  kLiteRtLmInputDataTypeAudioEnd,
+} LiteRtLmInputDataType;
 
 // Represents a single piece of input data.
 typedef struct {
-  InputDataType type;
+  LiteRtLmInputDataType type;
   // The data pointer. The interpretation depends on the `type`.
   // For kInputText, it's a UTF-8 string.
   // For kInputImage and kInputAudio, it's a pointer to the raw bytes.
   const void* data;
   // The size of the data in bytes.
   size_t size;
-} InputData;
+} LiteRtLmInputData;
 
 // Creates LiteRT LM Engine Settings. The caller is responsible for destroying
 // the settings using `litert_lm_engine_settings_delete`.
@@ -191,6 +298,16 @@ LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_parallel_file_section_loading(
     LiteRtLmEngineSettings* settings, bool parallel_file_section_loading);
 
+// Sets the maximum number of images for the engine.
+//
+// This is only used for the legacy implementation of the engine.
+//
+// @param settings The engine settings.
+// @param max_num_images The maximum number of images.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_max_num_images(
+    LiteRtLmEngineSettings* settings, int max_num_images);
+
 // Sets the cache directory for the engine.
 //
 // @param settings The engine settings.
@@ -198,6 +315,14 @@ void litert_lm_engine_settings_set_parallel_file_section_loading(
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_cache_dir(LiteRtLmEngineSettings* settings,
                                              const char* cache_dir);
+
+// Sets the LiteRT dispatch library directory for NPU backend.
+//
+// @param settings The engine settings.
+// @param lib_dir The dispatch library directory.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_litert_dispatch_lib_dir(
+    LiteRtLmEngineSettings* settings, const char* lib_dir);
 
 // Sets the activation data type.
 //
@@ -241,10 +366,21 @@ LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_num_decode_tokens(
     LiteRtLmEngineSettings* settings, int num_decode_tokens);
 
-// Sets the maximum number of images for multimodal vision support.
+// Sets whether to enable speculative decoding.
+//
+// @param settings The engine settings.
+// @param enable_speculative_decoding Whether to enable speculative decoding.
 LITERT_LM_C_API_EXPORT
-void litert_lm_engine_settings_set_max_num_images(
-    LiteRtLmEngineSettings* settings, int max_num_images);
+void litert_lm_engine_settings_set_enable_speculative_decoding(
+    LiteRtLmEngineSettings* settings, bool enable_speculative_decoding);
+
+// Sets whether to use hardware masking for NPU. Default is true which on
+// Intel LunarLake/PantherLake preview silicon causes engine_create to
+// crash because the NPU HW mask update path is not fully supported.
+// Pass false to force CPU/SIMD mask update fallback.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_use_hw_masking_for_npu(
+    LiteRtLmEngineSettings* settings, bool value);
 // Creates a LiteRT LM Engine from the given settings. The caller is responsible
 // for destroying the engine using `litert_lm_engine_delete`.
 //
@@ -276,18 +412,65 @@ LiteRtLmSession* litert_lm_engine_create_session(LiteRtLmEngine* engine,
 LITERT_LM_C_API_EXPORT
 void litert_lm_session_delete(LiteRtLmSession* session);
 
-// Generates content from the input prompt.
+// Cancels the current processing in the session.
 //
-// @param session The session to use for generation.
+// @param session The session to cancel processing on.
+LITERT_LM_C_API_EXPORT
+void litert_lm_session_cancel_process(LiteRtLmSession* session);
+
+// Adds the input prompt/query to the model for starting the prefilling
+// process. This is a blocking call and the function will return when the
+// prefill process is done.
+//
+// @param session The session to use.
 // @param inputs An array of InputData structs representing the multimodal
 //   input.
 // @param num_inputs The number of InputData structs in the array.
+// @return 0 on success, non-zero on failure.
+LITERT_LM_C_API_EXPORT
+int litert_lm_session_run_prefill(LiteRtLmSession* session,
+                                  const LiteRtLmInputData* inputs,
+                                  size_t num_inputs);
+
+// Starts the decoding process for the model to predict the response based
+// on the input prompt/query added after using litert_lm_session_run_prefill.
+// This is a blocking call and the function will return when the decoding
+// process is done.
+//
+// @param session The session to use.
 // @return A pointer to the responses, or NULL on failure. The caller is
 //   responsible for deleting the responses using `litert_lm_responses_delete`.
 LITERT_LM_C_API_EXPORT
-LiteRtLmResponses* litert_lm_session_generate_content(LiteRtLmSession* session,
-                                                      const InputData* inputs,
-                                                      size_t num_inputs);
+LiteRtLmResponses* litert_lm_session_run_decode(LiteRtLmSession* session);
+
+// Scores the target text after the prefill process is done.
+//
+// @param session The session to use.
+// @param target_text An array of target text strings to score.
+// @param num_targets The number of strings in the target_text array.
+// @param store_token_lengths Whether to store the token lengths of the target
+//   texts in the responses.
+// @return A pointer to the responses, or NULL on failure. The caller is
+//   responsible for deleting the responses using `litert_lm_responses_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmResponses* litert_lm_session_run_text_scoring(LiteRtLmSession* session,
+                                                      const char** target_text,
+                                                      size_t num_targets,
+                                                      bool store_token_lengths);
+
+// Generates content from the input prompt.
+//
+// @param session The session to use for generation.
+// @param inputs An array of LiteRtLmInputData structs representing the
+// multimodal
+//   input.
+// @param num_inputs The number of LiteRtLmInputData structs in the array.
+// @return A pointer to the responses, or NULL on failure. The caller is
+//   responsible for deleting the responses using `litert_lm_responses_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmResponses* litert_lm_session_generate_content(
+    LiteRtLmSession* session, const LiteRtLmInputData* inputs,
+    size_t num_inputs);
 // Destroys a LiteRT LM Responses object.
 //
 // @param responses The responses to destroy.
@@ -310,6 +493,76 @@ int litert_lm_responses_get_num_candidates(const LiteRtLmResponses* responses);
 //   bounds.
 LITERT_LM_C_API_EXPORT
 const char* litert_lm_responses_get_response_text_at(
+    const LiteRtLmResponses* responses, int index);
+
+// Returns whether the response contains a score at the given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return true if the score is available at the given index, false otherwise.
+LITERT_LM_C_API_EXPORT
+bool litert_lm_responses_has_score_at(const LiteRtLmResponses* responses,
+                                      int index);
+
+// Returns the score at a given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return The score. Returns 0.0f if index is out of bounds or no score is
+//   present.
+LITERT_LM_C_API_EXPORT
+float litert_lm_responses_get_score_at(const LiteRtLmResponses* responses,
+                                       int index);
+
+// Returns whether the response contains a token length at the given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return true if the token length is available at the given index, false
+//   otherwise.
+LITERT_LM_C_API_EXPORT
+bool litert_lm_responses_has_token_length_at(const LiteRtLmResponses* responses,
+                                             int index);
+
+// Returns the token length at a given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return The token length. Returns 0 if index is out of bounds or no token
+//   length is present.
+LITERT_LM_C_API_EXPORT
+int litert_lm_responses_get_token_length_at(const LiteRtLmResponses* responses,
+                                            int index);
+
+// Returns whether the response contains token scores at the given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return true if token scores are available at the given index, false
+// otherwise.
+LITERT_LM_C_API_EXPORT
+bool litert_lm_responses_has_token_scores_at(const LiteRtLmResponses* responses,
+                                             int index);
+
+// Returns the number of tokens for which scores are present at a given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return The number of token scores. Returns 0 if index is out of bounds or no
+//   token scores are present.
+LITERT_LM_C_API_EXPORT
+int litert_lm_responses_get_num_token_scores_at(
+    const LiteRtLmResponses* responses, int index);
+
+// Returns the token scores at a given index.
+//
+// @param responses The responses object.
+// @param index The index of the response.
+// @return A pointer to the internal array of token scores. Returns NULL if
+// index
+//   is out of bounds or no token scores are present.
+LITERT_LM_C_API_EXPORT
+const float* litert_lm_responses_get_token_scores_at(
     const LiteRtLmResponses* responses, int index);
 
 // Retrieves the benchmark information from the session. The caller is
@@ -409,21 +662,36 @@ double litert_lm_benchmark_info_get_decode_tokens_per_sec_at(
 typedef void (*LiteRtLmStreamCallback)(void* callback_data, const char* chunk,
                                        bool is_final, const char* error_msg);
 
+// Starts the decoding process for the model to predict the response based
+// on the input prompt/query added after using litert_lm_session_run_prefill.
+// This is a non-blocking call that will stream responses via a callback.
+//
+// @param session The session to use.
+// @param callback The callback function to receive response chunks.
+// @param callback_data A pointer to user data that will be passed to the
+// callback.
+// @return 0 on success, non-zero on failure.
+LITERT_LM_C_API_EXPORT
+int litert_lm_session_run_decode_async(LiteRtLmSession* session,
+                                       LiteRtLmStreamCallback callback,
+                                       void* callback_data);
+
 // Generates content from the input prompt and streams the response via a
 // callback. This is a non-blocking call that will invoke the callback from a
 // background thread for each chunk.
 //
 // @param session The session to use for generation.
-// @param inputs An array of InputData structs representing the multimodal
+// @param inputs An array of LiteRtLmInputData structs representing the
+// multimodal
 //   input.
-// @param num_inputs The number of InputData structs in the array.
+// @param num_inputs The number of LiteRtLmInputData structs in the array.
 // @param callback The callback function to receive response chunks.
 // @param callback_data A pointer to user data that will be passed to the
 // callback.
 // @return 0 on success, non-zero on failure to start the stream.
 LITERT_LM_C_API_EXPORT
 int litert_lm_session_generate_content_stream(LiteRtLmSession* session,
-                                              const InputData* inputs,
+                                              const LiteRtLmInputData* inputs,
                                               size_t num_inputs,
                                               LiteRtLmStreamCallback callback,
                                               void* callback_data);
@@ -445,19 +713,31 @@ LiteRtLmConversation* litert_lm_conversation_create(
 LITERT_LM_C_API_EXPORT
 void litert_lm_conversation_delete(LiteRtLmConversation* conversation);
 
+// Clones a LiteRT LM Conversation, duplicating its prefilled state.
+// The caller is responsible for destroying the cloned conversation using
+// `litert_lm_conversation_delete`.
+//
+// @param conversation The conversation to clone.
+// @return A pointer to the cloned conversation, or NULL on failure.
+LITERT_LM_C_API_EXPORT
+LiteRtLmConversation* litert_lm_conversation_clone(
+    LiteRtLmConversation* conversation);
+
 // Sends a message to the conversation and returns the response.
 // This is a blocking call.
 //
 // @param conversation The conversation to use.
 // @param message_json A JSON string representing the message to send.
 // @param extra_context A JSON string representing the extra context to use.
+// @param optional_args A pointer to the optional arguments to use.
 // @return A pointer to the JSON response, or NULL on failure. The caller is
 //   responsible for deleting the response using
 //   `litert_lm_json_response_delete`.
 LITERT_LM_C_API_EXPORT
 LiteRtLmJsonResponse* litert_lm_conversation_send_message(
     LiteRtLmConversation* conversation, const char* message_json,
-    const char* extra_context);
+    const char* extra_context,
+    const LiteRtLmConversationOptionalArgs* optional_args);
 
 // Destroys a LiteRT LM Json Response object.
 //
@@ -482,6 +762,7 @@ const char* litert_lm_json_response_get_string(
 // @param conversation The conversation to use.
 // @param message_json A JSON string representing the message to send.
 // @param extra_context A JSON string representing the extra context to use.
+// @param optional_args A pointer to the optional arguments to use.
 // @param callback The callback function to receive response chunks.
 // @param callback_data A pointer to user data that will be passed to the
 // callback.
@@ -489,8 +770,25 @@ const char* litert_lm_json_response_get_string(
 LITERT_LM_C_API_EXPORT
 int litert_lm_conversation_send_message_stream(
     LiteRtLmConversation* conversation, const char* message_json,
-    const char* extra_context, LiteRtLmStreamCallback callback,
-    void* callback_data);
+    const char* extra_context,
+    const LiteRtLmConversationOptionalArgs* optional_args,
+    LiteRtLmStreamCallback callback, void* callback_data);
+
+// Renders the message into a string according to the template.
+//
+// This function does not need to be called for actual message sending, as the
+// `litert_lm_conversation_send_message` and
+// `litert_lm_conversation_send_message_stream` functions will handle rendering
+// internally.
+//
+// @param conversation The conversation instance.
+// @param message_json A JSON string representing the message to render.
+// @return A pointer to the rendered string, or NULL on failure. The returned
+//   string is owned by the `conversation` object and is valid until the next
+//   call to this function or until the conversation is deleted.
+LITERT_LM_C_API_EXPORT
+const char* litert_lm_conversation_render_message_to_string(
+    LiteRtLmConversation* conversation, const char* message_json);
 
 // Cancels the ongoing inference process, for asynchronous inference.
 //
@@ -507,6 +805,147 @@ void litert_lm_conversation_cancel_process(LiteRtLmConversation* conversation);
 LITERT_LM_C_API_EXPORT
 LiteRtLmBenchmarkInfo* litert_lm_conversation_get_benchmark_info(
     LiteRtLmConversation* conversation);
+
+// Tokenizes text using the engine's tokenizer.
+//
+// @param engine The engine instance.
+// @param text The UTF-8 string to tokenize.
+// @return A pointer to the tokenize result, or NULL on failure.
+//   The caller is responsible for deleting the result using
+//   `litert_lm_tokenize_result_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmTokenizeResult* litert_lm_engine_tokenize(LiteRtLmEngine* engine,
+                                                  const char* text);
+
+// Destroys a LiteRT LM Tokenize Result.
+//
+// @param result The tokenize result to destroy.
+LITERT_LM_C_API_EXPORT
+void litert_lm_tokenize_result_delete(LiteRtLmTokenizeResult* result);
+
+// Returns the token ids from a tokenize result.
+//
+// @param result The tokenize result.
+// @return A pointer to the internal array of token ids. The returned pointer
+//   is valid only for the lifetime of the `result` object.
+LITERT_LM_C_API_EXPORT
+const int* litert_lm_tokenize_result_get_tokens(
+    const LiteRtLmTokenizeResult* result);
+
+// Returns the number of token ids from a tokenize result.
+//
+// @param result The tokenize result.
+// @return The number of token ids.
+LITERT_LM_C_API_EXPORT
+size_t litert_lm_tokenize_result_get_num_tokens(
+    const LiteRtLmTokenizeResult* result);
+
+// Detokenizes token ids using the engine's tokenizer.
+//
+// @param engine The engine instance.
+// @param tokens An array of token ids to detokenize.
+// @param num_tokens The number of token ids in the array.
+// @return A pointer to the detokenize result, or NULL on failure.
+//   The caller is responsible for deleting the result using
+//   `litert_lm_detokenize_result_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmDetokenizeResult* litert_lm_engine_detokenize(LiteRtLmEngine* engine,
+                                                      const int* tokens,
+                                                      size_t num_tokens);
+
+// Destroys a LiteRT LM Detokenize Result.
+//
+// @param result The detokenize result to destroy.
+LITERT_LM_C_API_EXPORT
+void litert_lm_detokenize_result_delete(LiteRtLmDetokenizeResult* result);
+
+// Returns the string from a detokenize result.
+//
+// @param result The detokenize result.
+// @return The detokenized UTF-8 string. The returned string is owned by the
+//   `result` object and is valid only for its lifetime.
+LITERT_LM_C_API_EXPORT
+const char* litert_lm_detokenize_result_get_string(
+    const LiteRtLmDetokenizeResult* result);
+
+// Destroys a LiteRT LM Token Union.
+//
+// @param token_union The token union to destroy.
+LITERT_LM_C_API_EXPORT
+void litert_lm_token_union_delete(LiteRtLmTokenUnion* token_union);
+
+// Returns the type of the token union.
+//
+// @param token_union The token union.
+// @return The type of the token union.
+LITERT_LM_C_API_EXPORT
+LiteRtLmTokenUnionType litert_lm_token_union_get_type(
+    const LiteRtLmTokenUnion* token_union);
+
+// Returns the string value from a token union.
+//
+// @param token_union The token union.
+// @return The string value, or NULL if the type is not
+//   kLiteRtLmTokenUnionTypeString. The returned string is owned by the
+//   `token_union` object and is valid only for its lifetime.
+LITERT_LM_C_API_EXPORT
+const char* litert_lm_token_union_get_string(
+    const LiteRtLmTokenUnion* token_union);
+
+// Returns the token ids from a token union.
+//
+// @param token_union The token union.
+// @param out_tokens A pointer to receive the internal array of token ids.
+//   The received pointer is valid only for the lifetime of the `token_union`
+//   object.
+// @param out_num_tokens A pointer to receive the number of token ids.
+// @return 0 on success, non-zero if the type is not kLiteRtLmTokenUnionTypeIds.
+LITERT_LM_C_API_EXPORT
+int litert_lm_token_union_get_ids(const LiteRtLmTokenUnion* token_union,
+                                  const int** out_tokens,
+                                  size_t* out_num_tokens);
+
+// Destroys a LiteRT LM Token Unions object.
+//
+// @param tokens The token unions object to destroy.
+LITERT_LM_C_API_EXPORT
+void litert_lm_token_unions_delete(LiteRtLmTokenUnions* tokens);
+
+// Returns the number of token unions in the collection.
+//
+// @param tokens The token unions object.
+// @return The number of token unions.
+LITERT_LM_C_API_EXPORT
+size_t litert_lm_token_unions_get_num_tokens(const LiteRtLmTokenUnions* tokens);
+
+// Returns the token union at a given index from a collection.
+//
+// @param tokens The token unions collection.
+// @param index The index of the token union.
+// @return A pointer to the token union at the given index, or NULL if the index
+//   is out of bounds. The caller is responsible for deleting the result using
+//   `litert_lm_token_union_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmTokenUnion* litert_lm_token_unions_get_token_at(
+    const LiteRtLmTokenUnions* tokens, size_t index);
+
+// Returns the configured start token (BOS), if any.
+//
+// @param engine The engine instance.
+// @return A pointer to the start token, or NULL if none configured. The caller
+//   is responsible for deleting the result using
+//   `litert_lm_token_union_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmTokenUnion* litert_lm_engine_get_start_token(LiteRtLmEngine* engine);
+
+// Returns the configured stop tokens (EOS).
+//
+// @param engine The engine instance.
+// @return A pointer to the stop tokens collection, or NULL if none configured.
+//   The caller is responsible for deleting the result using
+//   `litert_lm_token_unions_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmTokenUnions* litert_lm_engine_get_stop_tokens(LiteRtLmEngine* engine);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -529,10 +529,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: caa693ad15a587a2b4fde093b728131a1827903872171089dedb16f7665d3a91
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.1"
   stack_trace:
     dependency: transitive
     description:
@@ -569,10 +569,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.16.0
+version: 0.16.1
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,8 +31,11 @@ dependencies:
   ffi: ^2.1.0
   # HNSW vector search for O(log n) similarity queries
   local_hnsw: ^1.0.0
-  # Unified VectorStore (dart:ffi SQLite for all native platforms)
-  sqlite3: ^3.1.0
+  # Unified VectorStore (dart:ffi SQLite for all native platforms).
+  # ^3.3.0 — the 3.2.0 hook had a transient iOS-simulator dylib fetch
+  # bug that hung `flutter build ios --simulator`. 3.3.0+ uses a more
+  # robust HttpClient setup.
+  sqlite3: ^3.3.0
   # Pure Dart tokenizer for desktop embeddings (BPE + Unigram)
   dart_sentencepiece_tokenizer: ^1.3.0
   # Native Assets build hooks (for hook/build.dart)


### PR DESCRIPTION
## Summary
- LiteRT-LM v0.12.0 (commit `ffed38a`) — NPU dispatch on Linux/macOS as well as Windows
- iOS App Store ITMS-90208 fix (#286) — repacked iOS dylibs with minos 13.0 to match Flutter Native Assets' hardcoded framework wrapper MinimumOSVersion
- iOS Native Assets strip on Xcode 26 (#289, thanks @merlinnot) — `-Wl,-x` linkopts + strip-probe in `build_ios.sh`
- Windows install path hotfix when `%LOCALAPPDATA%` env var is relative