### PR TITLE
0.16.2: exclude chromedriver from pub package + multi-session edge-case tests

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -144,3 +144,8 @@ example/macos/Podfile.lock
 
 # Example web test HTML fixture (used by vector store dev tests).
 example/web/test_vectorstore.html
+
+# chromedriver binary — maintainer tool for running web integration tests
+# (flutter drive -d chrome). ~16 MB, not part of the plugin. Without this
+# it leaks into the pub package and bloats it (8 MB → archive).
+chromedriver/

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -498,6 +498,73 @@ void main() {
       expect(rb.trim(), isNotEmpty);
       await b.close();
     });
+
+    // ── Edge cases from the PR #294 review fixes ──────────────────────
+
+    // C2: an abandoned stream must release the generation mutex, or the next
+    // session deadlocks. Subscribe, cancel mid-flight, then a fresh session
+    // must still be able to generate.
+    testWidgets('abandoning a stream releases the mutex (no deadlock)',
+        (t) async {
+      final model = await _ensureModel(PreferredBackend.gpu, 1024);
+      final a = await model.openSession(temperature: 0.0, topK: 1);
+      await a.addQueryChunk(
+          const Message(text: 'Count slowly to twenty.', isUser: true));
+      // Start streaming, then cancel the subscription after the first chunk
+      // without draining — this is the "abandoned stream" case.
+      final sub = a.getResponseAsync().listen((_) {});
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await sub.cancel();
+
+      // If the mutex leaked, this second generation hangs (test times out).
+      final b = await model.openSession(temperature: 0.0, topK: 1);
+      final rb = await _ask(b, 'Say hi in one word.');
+      print('[multi-session C2] B after abandon = "$rb"');
+      expect(rb.trim(), isNotEmpty);
+      await a.close();
+      await b.close();
+    });
+
+    // C5: closing a session whose generation is in flight must not crash
+    // (use-after-free on the shared conversation). The other session stays
+    // usable afterwards.
+    testWidgets('closing a session mid-generation is safe (no UAF)', (t) async {
+      final model = await _ensureModel(PreferredBackend.gpu, 1024);
+      final a = await model.openSession(temperature: 0.0, topK: 1);
+      final b = await model.openSession(temperature: 0.0, topK: 1);
+      await a.addQueryChunk(
+          const Message(text: 'Count slowly to twenty.', isUser: true));
+      final sub = a.getResponseAsync().listen((_) {});
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      // Close A while its turn is (likely) still streaming.
+      await a.close();
+      await sub.cancel();
+
+      final rb = await _ask(b, 'Say hi in one word.');
+      print('[multi-session C5] B after A.close-mid-gen = "$rb"');
+      expect(rb.trim(), isNotEmpty);
+      await b.close();
+    });
+
+    // Media on a virtual (openSession) .litertlm session is rejected loudly,
+    // not silently dropped — history is replayed text-only on switch.
+    testWidgets('openSession rejects image/audio loudly', (t) async {
+      final model = await _ensureModel(PreferredBackend.gpu, 1024);
+      final a = await model.openSession(temperature: 0.0, topK: 1);
+      try {
+        await a.addQueryChunk(Message(
+          text: 'describe',
+          isUser: true,
+          imageBytes: Uint8List.fromList(List<int>.filled(16, 0)),
+        ));
+        await expectLater(
+          a.getResponse(),
+          throwsA(isA<UnsupportedError>()),
+        );
+      } finally {
+        await a.close();
+      }
+    });
   });
 
   // ── Gemma4 NPU: 0.15.1 sampler-skip behaviour ────────────────────


### PR DESCRIPTION
Two post-merge follow-ups for 0.16.2:

- **Exclude `chromedriver/` from the pub package.** The chromedriver binary (a maintainer tool for `flutter drive -d chrome` web integration tests) sits at repo root (~16 MB) and leaked into the published archive, bloating it to 8 MB. With it ignored the archive drops to ~683 KB. `dart pub publish --dry-run`: 0 warnings.
- **Multi-session edge-case integration tests** (cherry-picked) — abandoning a stream releases the mutex (no deadlock), closing a session mid-generation is safe (no use-after-free), openSession rejects image/audio loudly on the text-only `.litertlm` virtual path. Verified 23/23 on macOS.