### PR TITLE
0.16.3: Android Qualcomm NPU + GPU sampler fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.16.3
-- **Android Qualcomm NPU** (`PreferredBackend.npu`): bundles QNN dispatch libs for sm8550/sm8650/sm8750/sm8850 (#293).
-- **Fix Android GPU sampler CPU fallback** (#270): patchelf `DT_NEEDED libLiteRtLm.so` on OpenCL/WebGPU samplers restores ~3× decode speedup.
+- **Android Qualcomm NPU** (`PreferredBackend.npu`): auto-extracts QNN dispatch libs from APK at runtime (#293).
+- **Fix Android GPU sampler CPU fallback** (#270): GPU OpenCL/WebGPU samplers now resolve correctly, restoring ~3× decode speed.
 - **qdrant-edge 0.7.1**: drops vendored fork, `wal_options` now native in upstream.
 
 ## 0.16.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.16.3
-- **Android Qualcomm NPU** (`PreferredBackend.npu`): bundles QNN dispatch libs for sm8550/sm8650/sm8750/sm8850.
+- **Android Qualcomm NPU** (`PreferredBackend.npu`): bundles QNN dispatch libs for sm8550/sm8650/sm8750/sm8850 (#293).
+- **Fix Android GPU sampler CPU fallback** (#270): patchelf `DT_NEEDED libLiteRtLm.so` on OpenCL/WebGPU samplers restores ~3× decode speedup.
 - **qdrant-edge 0.7.1**: drops vendored fork, `wal_options` now native in upstream.
 
 ## 0.16.2

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import java.io.File
 import java.io.FileOutputStream
+import java.util.zip.ZipFile
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
@@ -46,7 +47,7 @@ class FlutterGemmaPlugin: FlutterPlugin {
         }
         "getNativeLibraryDir" -> {
           try {
-            result.success(context.applicationInfo.nativeLibraryDir)
+            result.success(extractNpuLibsIfNeeded(context))
           } catch (e: Exception) {
             result.error("NATIVE_LIB_DIR_ERROR", e.message, null)
           }
@@ -75,6 +76,44 @@ class FlutterGemmaPlugin: FlutterPlugin {
     service?.cleanup()
     service = null
   }
+}
+
+// LiteRT's litert_dispatch.cc uses opendir() to scan dispatch_lib_dir for
+// libLiteRtDispatch_*.so. With AGP 8+ default extractNativeLibs=false, .so
+// files are stored in the APK but not extracted to the filesystem, so opendir
+// finds nothing. We extract the QNN dispatch stack to a private cache dir on
+// first NPU use so LiteRT can find them via filesystem scan.
+private val NPU_LIBS = listOf(
+  "libLiteRtDispatch_Qualcomm.so",
+  "libQnnHtp.so",
+  "libQnnSystem.so",
+  "libQnnHtpV73Stub.so",
+  "libQnnHtpV75Stub.so",
+  "libQnnHtpV79Stub.so",
+  "libQnnHtpV81Stub.so",
+)
+
+private fun extractNpuLibsIfNeeded(context: Context): String {
+  val outDir = File(context.codeCacheDir, "npu_libs")
+  outDir.mkdirs()
+
+  val apkPath = context.applicationInfo.sourceDir
+  ZipFile(apkPath).use { zip ->
+    for (libName in NPU_LIBS) {
+      val entry = zip.getEntry("lib/arm64-v8a/$libName") ?: continue
+      val outFile = File(outDir, libName)
+      if (outFile.exists() && outFile.length() == entry.size) continue
+      Log.i("FlutterGemma", "NPU: extracting $libName → ${outFile.absolutePath}")
+      zip.getInputStream(entry).use { input ->
+        FileOutputStream(outFile).use { output ->
+          input.copyTo(output, bufferSize = 65536)
+        }
+      }
+    }
+  }
+
+  Log.i("FlutterGemma", "NPU: dispatch_lib_dir=${outDir.absolutePath}")
+  return outDir.absolutePath
 }
 
 private class PlatformServiceImpl(

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
@@ -99,12 +99,18 @@ private val NPU_LIBS = listOf(
 
 private fun extractNpuLibsIfNeeded(context: Context): String {
   val outDir = File(context.codeCacheDir, "npu_libs")
-  outDir.mkdirs()
+  if (!outDir.mkdirs() && !outDir.isDirectory) {
+    throw java.io.IOException("NPU: failed to create extraction dir: ${outDir.absolutePath}")
+  }
 
   val apkPath = context.applicationInfo.sourceDir
   ZipFile(apkPath).use { zip ->
     for (libName in NPU_LIBS) {
-      val entry = zip.getEntry("lib/arm64-v8a/$libName") ?: continue
+      val entry = zip.getEntry("lib/arm64-v8a/$libName")
+      if (entry == null) {
+        Log.w("FlutterGemma", "NPU: $libName not found in APK — skipping")
+        continue
+      }
       val outFile = File(outDir, libName)
       if (outFile.exists() && outFile.length() == entry.size) continue
       Log.i("FlutterGemma", "NPU: extracting $libName → ${outFile.absolutePath}")

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
@@ -94,6 +94,7 @@ private val NPU_LIBS = listOf(
   "libQnnHtpV79Stub.so",
   "libQnnHtpV79Skel.so",
   "libQnnHtpV81Stub.so",
+  "libQnnHtpV81Skel.so",
 )
 
 private fun extractNpuLibsIfNeeded(context: Context): String {

--- a/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
+++ b/android/src/main/kotlin/dev/flutterberlin/flutter_gemma/FlutterGemmaPlugin.kt
@@ -88,8 +88,11 @@ private val NPU_LIBS = listOf(
   "libQnnHtp.so",
   "libQnnSystem.so",
   "libQnnHtpV73Stub.so",
+  "libQnnHtpV73Skel.so",
   "libQnnHtpV75Stub.so",
+  "libQnnHtpV75Skel.so",
   "libQnnHtpV79Stub.so",
+  "libQnnHtpV79Skel.so",
   "libQnnHtpV81Stub.so",
 )
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -172,7 +172,7 @@ const _litertlmBundle = _NativeBundle(
     'litertlm-ios_sim_arm64.tar.gz':
         '54e067fa11ad510280e01f90260e8bda13f905a27f00e7ebc2d7ef5847868bd1',
     'litertlm-android_arm64.tar.gz':
-        'ff43a1346a4a86d302bb83b2b4cdbf53c3fd3cefe3f433945145221bbd7cf2b1',
+        'f809c5a29867062cda74186c7ebebd500a2f36d0b6ad6f7ca8eab902af7fc784',
   },
   companions: [
     'GemmaModelConstraintProvider',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -172,7 +172,7 @@ const _litertlmBundle = _NativeBundle(
     'litertlm-ios_sim_arm64.tar.gz':
         '54e067fa11ad510280e01f90260e8bda13f905a27f00e7ebc2d7ef5847868bd1',
     'litertlm-android_arm64.tar.gz':
-        'a3fac90d144065a23f24b2ea03f10ad4d5025d012fdb3117e0b9afbe9f829ef7',
+        'a071a5b5f5de51a75fbed47cc20ff134fce8531ecc3786ca12a89b42e1159582',
   },
   companions: [
     'GemmaModelConstraintProvider',
@@ -236,14 +236,18 @@ const _litertlmBundle = _NativeBundle(
   // Extracted from Google AI Edge Gallery APKs (no Qualcomm account needed);
   // ABI verified against litert_dispatch.h at LiteRT commit d865fd82.
   // sm8550=V73, sm8650=V75, sm8750=V79, sm8850=V81.
-  // Skel libs are NOT bundled — device firmware provides them in /vendor/dsp/.
+  // Skel libs (DSP-side code) extracted from Google AI Edge Gallery APKs.
+  // Stub libs are the CPU-side bridge; Skel libs run on Hexagon DSP via FastRPC.
   androidExtraLibs: [
     'LiteRtDispatch_Qualcomm',
     'QnnHtp',
     'QnnSystem',
     'QnnHtpV73Stub',
+    'QnnHtpV73Skel',
     'QnnHtpV75Stub',
+    'QnnHtpV75Skel',
     'QnnHtpV79Stub',
+    'QnnHtpV79Skel',
     'QnnHtpV81Stub',
   ],
 );

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -172,7 +172,7 @@ const _litertlmBundle = _NativeBundle(
     'litertlm-ios_sim_arm64.tar.gz':
         '54e067fa11ad510280e01f90260e8bda13f905a27f00e7ebc2d7ef5847868bd1',
     'litertlm-android_arm64.tar.gz':
-        'a071a5b5f5de51a75fbed47cc20ff134fce8531ecc3786ca12a89b42e1159582',
+        'ff43a1346a4a86d302bb83b2b4cdbf53c3fd3cefe3f433945145221bbd7cf2b1',
   },
   companions: [
     'GemmaModelConstraintProvider',
@@ -249,6 +249,7 @@ const _litertlmBundle = _NativeBundle(
     'QnnHtpV79Stub',
     'QnnHtpV79Skel',
     'QnnHtpV81Stub',
+    'QnnHtpV81Skel',
   ],
 );
 


### PR DESCRIPTION
## Summary

- **Android NPU** (`PreferredBackend.npu`): extracts QNN dispatch stack from APK to `codeCacheDir/npu_libs/` at runtime so `litert_dispatch.cc` `opendir()` scan finds the libs (AGP 8+ `extractNativeLibs=false` keeps `.so` compressed in APK, never extracted to `nativeLibraryDir`). Bundles Qualcomm QNN libs for SM8550/SM8650/SM8750/SM8850 extracted from Google AI Edge Gallery APKs.
- **GPU sampler fix** (#270): applies `patchelf --add-needed libLiteRtLm.so` to `libLiteRtTopKOpenClSampler.so` and `libLiteRtTopKWebGpuSampler.so` — restores ~3× decode speedup on Android GPU.

## Test plan

- [ ] Test `gemma-4-E2B-it_qualcomm_sm8750.litertlm` + `PreferredBackend.npu` on SM8750 device (hacker1024 confirming)
- [ ] Test `gemma-4-E2B-it.litertlm` + `PreferredBackend.gpu` — verify no GPU sampler CPU fallback in logcat
- [ ] Run 18-test suite on Android arm64