### PR TITLE
0.16.4: embedding off-UI-isolate (#299), Windows /utf-8 (#212), Intel NPU example models

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,9 +31,14 @@ flutter test                # all pass
 # Skipping this is how `enableSpeculativeDecoding` web breakage shipped
 # in 0.15.0 — analyze was green, tests passed, web build threw
 # `No named parameter ...` at dart2js time.
+#
+# Android MUST be built --release, not --debug: a release build runs R8
+# (shrink/minify/obfuscate) and the full native-asset packaging path, which
+# debug skips. Bugs that only surface under R8 (stripped classes, missing
+# keep rules, native lib packaging) are invisible to `--debug`.
 cd example
 flutter build web --no-tree-shake-icons
-flutter build apk --debug
+flutter build apk --release
 flutter build macos --debug
 flutter build ios --no-codesign --debug
 cd ..
@@ -216,10 +221,13 @@ flutter test
 # Cross-platform compile sanity (also in Pre-flight — rerun here after
 # version bumps in case a setter/getter signature shifted):
 (cd example && flutter build web --no-tree-shake-icons)
-(cd example && flutter build apk --debug)
+(cd example && flutter build apk --release)   # --release, not --debug: exercises R8 + native packaging
 (cd example && flutter build macos --debug)
 (cd example && flutter build ios --no-codesign --debug)
-dart pub publish --dry-run     # 0 warnings; check final package size <= 100 KB
+dart pub publish --dry-run     # 0 warnings (package size is informational — the
+                               # FFI bindings + pigeon + example already push it
+                               # to ~700 KB on 0.16.x; the old <=100 KB ceiling
+                               # predates 0.14.0 and no longer applies)
 ```
 
 **NEVER publish without dry-run first.** Publishing is IRREVERSIBLE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass now runs on a background isolate.
-- **Embedding `preferredBackend`** now wired through to the LiteRT accelerator (CPU/GPU/NPU).
+- **Embedding `preferredBackend`** is now passed to the LiteRT accelerator instead of being ignored (was always CPU).
 - **Fix Windows build on non-UTF-8 locales** (#212): add `/utf-8` to the MSVC plugin target.
 
 ## 0.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.4
+- **Fix embedding freezing the UI thread** (#299): forward pass now runs on a background isolate.
+- **Embedding `preferredBackend`** now wired through to the LiteRT accelerator (CPU/GPU/NPU).
+
 ## 0.16.3
 - **Android Qualcomm NPU** (`PreferredBackend.npu`): auto-extracts QNN dispatch libs from APK at runtime (#293).
 - **Fix Android GPU sampler CPU fallback** (#270): GPU OpenCL/WebGPU samplers now resolve correctly, restoring ~3× decode speed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.16.4
-- **Fix embedding freezing the UI thread** (#299): forward pass now runs on a background isolate.
-- **Embedding `preferredBackend`** is now passed to the LiteRT accelerator instead of being ignored (was always CPU).
+- **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.
+- **Embedding `preferredBackend`** now reaches the LiteRT accelerator.
 - **Fix Windows build on non-UTF-8 locales** (#212): add `/utf-8` to the MSVC plugin target.
+- **Fix macOS "Cycle inside Flutter Assemble" build error** (#300, thanks @fotiDim): stage native dylibs out of the cache dir.
 
 ## 0.16.3
 - **Android Qualcomm NPU** (`PreferredBackend.npu`): auto-extracts QNN dispatch libs from APK at runtime (#293).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass now runs on a background isolate.
 - **Embedding `preferredBackend`** now wired through to the LiteRT accelerator (CPU/GPU/NPU).
+- **Fix Windows build on non-UTF-8 locales** (#212): add `/utf-8` to the MSVC plugin target.
 
 ## 0.16.3
 - **Android Qualcomm NPU** (`PreferredBackend.npu`): auto-extracts QNN dispatch libs from APK at runtime (#293).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.
-- **Embedding `preferredBackend`** now reaches the LiteRT accelerator.
 - **Fix Windows build on non-UTF-8 locales** (#212): add `/utf-8` to the MSVC plugin target.
 - **Fix macOS "Cycle inside Flutter Assemble" build error** (#300, thanks @fotiDim): stage native dylibs out of the cache dir.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.12.0` GitHub Release. Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` on Intel LunarLake/PantherLake silicon. MTP (speculative decoding) support for Gemma 4.
-- **Current Version**: 0.16.3
+- **Current Version**: 0.16.4
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.12.0` GitHub Release. Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` on Intel LunarLake/PantherLake silicon. MTP (speculative decoding) support for Gemma 4.
-- **Current Version**: 0.16.2
+- **Current Version**: 0.16.3
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/example/integration_test/litertlm_ffi_test.dart
+++ b/example/integration_test/litertlm_ffi_test.dart
@@ -742,4 +742,97 @@ void main() {
           reason: 'Path must not be the legacy Documents/$filename');
     });
   });
+
+  // ══════════════════════════════════════════════════════════════════
+  // Embedding must NOT block the calling (UI) isolate (#299)
+  // ══════════════════════════════════════════════════════════════════
+  //
+  // Since the #299 fix, `generateEmbedding` runs the blocking LiteRT forward
+  // pass on a background worker isolate. We prove the main isolate stays alive
+  // by spinning an async counter on it WHILE a batch of embeddings runs: if the
+  // forward were synchronous on the calling isolate, the counter could not
+  // advance during a forward (it would be frozen for the whole pass). A live
+  // counter ⇒ the main isolate kept running ⇒ no UI freeze. This is robust to
+  // the GC noise that makes a Timer-gap meter unreliable on emulators.
+  group('Embedding non-blocking (#299)', () {
+    const modelName = 'embeddinggemma-300M_seq256_mixed-precision.tflite';
+    const tokenizerName = 'sentencepiece.model';
+    EmbeddingModel? embModel;
+
+    Future<String> resolveAsset(String name) async {
+      // Host/Android-pushed path first, then bundled asset fallback.
+      final local = _localPath(name);
+      if (local != null && File(local).existsSync()) return local;
+      final docs = await getApplicationDocumentsDirectory();
+      final f = File('${docs.path}/$name');
+      if (f.existsSync()) return f.path;
+      final bytes = await rootBundle.load('assets/test/$name');
+      await f.writeAsBytes(bytes.buffer.asUint8List());
+      return f.path;
+    }
+
+    setUpAll(() async {
+      await FlutterGemma.installEmbedder()
+          .modelFromFile(await resolveAsset(modelName))
+          .tokenizerFromFile(await resolveAsset(tokenizerName))
+          .install();
+      embModel = await FlutterGemma.getActiveEmbedder();
+    });
+
+    tearDownAll(() async {
+      await embModel?.close();
+      embModel = null;
+    });
+
+    testWidgets('main isolate stays live during a batch of embeddings',
+        (t) async {
+      final model = embModel!;
+      // Warm up (first call pays worker spawn + native compile).
+      await model.generateEmbedding('warm up');
+
+      const texts = [
+        'Renewable energy is reshaping the global power grid.',
+        'A classic margherita pizza needs only flour, tomato, and basil.',
+        'Stock markets reacted sharply to the central bank announcement.',
+        'The quick brown fox jumps over the lazy dog near the riverbank.',
+        'Quantum computing promises exponential speedups for some problems.',
+        'Photosynthesis converts sunlight into chemical energy in plants.',
+      ];
+
+      // Async counter on the main isolate: a self-rescheduling microtask that
+      // increments while we await the embeddings. If a forward blocked the
+      // calling isolate, the counter would stall for the whole pass.
+      var ticks = 0;
+      var running = true;
+      Future<void> spin() async {
+        while (running) {
+          ticks++;
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      final spinner = spin();
+      final sw = Stopwatch()..start();
+      for (final text in texts) {
+        await model.generateEmbedding(text);
+      }
+      sw.stop();
+      running = false;
+      await spinner;
+
+      final perCall = sw.elapsedMilliseconds / texts.length;
+      print('[#299] ${texts.length} embeddings: perCall=${perCall.toStringAsFixed(0)}ms  '
+          'main-isolate ticks during run=$ticks');
+
+      // The whole point of #299: the worker keeps the calling isolate free, so
+      // the main isolate scheduled many microtasks while the forwards ran. A
+      // regression to the synchronous path would freeze the main isolate for
+      // the full forward time, yielding far fewer (near-zero) ticks. We require
+      // comfortably more than one tick per embedding.
+      expect(ticks, greaterThan(texts.length),
+          reason: 'main isolate barely advanced during the embedding batch — '
+              'the forward is blocking the calling isolate (issue #299 '
+              'regression)');
+    });
+  });
 }

--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -70,6 +70,51 @@ enum Model implements InferenceModelInterface {
     isThinking: true,
   ),
 
+  // Gemma 4 E2B compiled for Intel NPU (Windows only, PreferredBackend.npu).
+  // Chip-specific builds — pick the one matching the silicon:
+  //   _LNL = Lunar Lake, _PTL = Panther Lake.
+  // The plugin auto-configures the NPU dispatch dir on Windows; the bundled
+  // LiteRtDispatch.dll + OpenVino + TBB ship in the same native tarball.
+  // Source: https://ai.google.dev/edge/litert/next/litert_lm_npu#intel
+  gemma4_E2B_intel_LNL(
+    baseUrl:
+        'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it_intel_LNL.litertlm',
+    desktopUrl:
+        'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it_intel_LNL.litertlm',
+    filename: 'gemma-4-E2B-it_intel_LNL.litertlm',
+    displayName: 'Gemma 4 E2B IT (Intel NPU - Lunar Lake)',
+    size: '2.96GB',
+    licenseUrl: '',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.npu,
+    modelType: ModelType.gemma4,
+    fileType: ModelFileType.litertlm,
+    temperature: 1.0,
+    topK: 64,
+    topP: 0.95,
+    maxTokens: 4096,
+    isThinking: true,
+  ),
+  gemma4_E2B_intel_PTL(
+    baseUrl:
+        'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it_intel_PTL.litertlm',
+    desktopUrl:
+        'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it_intel_PTL.litertlm',
+    filename: 'gemma-4-E2B-it_intel_PTL.litertlm',
+    displayName: 'Gemma 4 E2B IT (Intel NPU - Panther Lake)',
+    size: '2.95GB',
+    licenseUrl: '',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.npu,
+    modelType: ModelType.gemma4,
+    fileType: ModelFileType.litertlm,
+    temperature: 1.0,
+    topK: 64,
+    topP: 0.95,
+    maxTokens: 4096,
+    isThinking: true,
+  ),
+
   // Gemma 3 Nano models (Multimodal + Function Calls)
   gemma3n_2B(
     baseUrl:

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.16.3'
+  s.version          = '0.16.4'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Run Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3, Qwen 2.5, DeepSeek R1,

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.16.2'
+  s.version          = '0.16.3'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Run Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3, Qwen 2.5, DeepSeek R1,

--- a/lib/core/litert/litert_bindings.dart
+++ b/lib/core/litert/litert_bindings.dart
@@ -150,18 +150,17 @@ class LiteRtLayoutView {
   final Pointer<LiteRtLayoutMsvc> _msvc;
 
   /// Pass to LiteRt accessor functions (e.g. `getInputTensorLayout`).
-  Pointer<Void> get pointer => Platform.isWindows
-      ? _msvc.cast<Void>()
-      : _posix.cast<Void>();
+  Pointer<Void> get pointer =>
+      Platform.isWindows ? _msvc.cast<Void>() : _posix.cast<Void>();
 
-  int get rank => (Platform.isWindows
+  int get rank =>
+      (Platform.isWindows
           ? _msvc.ref.rankAndHasStrides
           : _posix.ref.rankAndHasStrides) &
       0x7f;
 
-  int dimension(int i) => Platform.isWindows
-      ? _msvc.ref.dimensions[i]
-      : _posix.ref.dimensions[i];
+  int dimension(int i) =>
+      Platform.isWindows ? _msvc.ref.dimensions[i] : _posix.ref.dimensions[i];
 
   void free() {
     if (Platform.isWindows) {
@@ -219,9 +218,8 @@ class LiteRtRankedTensorTypeView {
   final Pointer<LiteRtRankedTensorTypeMsvc> _msvc;
 
   /// Pass to LiteRt functions that consume a `LiteRtRankedTensorType*`.
-  Pointer<Void> get pointer => Platform.isWindows
-      ? _msvc.cast<Void>()
-      : _posix.cast<Void>();
+  Pointer<Void> get pointer =>
+      Platform.isWindows ? _msvc.cast<Void>() : _posix.cast<Void>();
 
   set elementType(int value) {
     if (Platform.isWindows) {
@@ -332,8 +330,7 @@ class LiteRtBindings {
 
   late final setOptionsHardwareAccelerators = _lib.lookupFunction<
       Int32 Function(LiteRtOptions, Int32),
-      int Function(
-          LiteRtOptions, int)>('LiteRtSetOptionsHardwareAccelerators');
+      int Function(LiteRtOptions, int)>('LiteRtSetOptionsHardwareAccelerators');
 
   // Compiled model.
 
@@ -450,7 +447,6 @@ class AlignedAlloc {
 AlignedAlloc allocAligned(int bytes, {int align = kLiteRtHostMemoryAlignment}) {
   final raw = calloc<Uint8>(bytes + align + sizeOf<IntPtr>());
   final mask = align - 1;
-  final aligned =
-      Pointer<Uint8>.fromAddress((raw.address + align) & ~mask);
+  final aligned = Pointer<Uint8>.fromAddress((raw.address + align) & ~mask);
   return AlignedAlloc(raw, aligned);
 }

--- a/lib/core/litert/litert_embedding_core.dart
+++ b/lib/core/litert/litert_embedding_core.dart
@@ -101,94 +101,112 @@ class EmbeddingCore {
       );
     }
 
-    final envPtr = calloc<LiteRtEnvironment>();
-    bindings
-        .createEnvironment(0, nullptr, envPtr)
-        .check('LiteRtCreateEnvironment');
-    final environment = envPtr.value;
-    calloc.free(envPtr);
-
-    // Model from .tflite file.
-    final pathC = modelPath.toNativeUtf8();
-    final modelPtr = calloc<LiteRtModel>();
+    // Track native handles as they are created so a failure partway through
+    // (e.g. a bad accelerator, or a non-embedding model with the wrong tensor
+    // rank) frees everything already allocated instead of leaking it — the
+    // LiteRT native heap is process-global and is NOT reclaimed by the
+    // isolate dying.
+    LiteRtEnvironment? environment;
+    LiteRtModel? model;
+    LiteRtOptions? options;
+    LiteRtCompiledModel? compiled;
     try {
+      final envPtr = calloc<LiteRtEnvironment>();
       bindings
-          .createModelFromFile(pathC, modelPtr)
-          .check('LiteRtCreateModelFromFile($modelPath)');
-    } finally {
-      calloc.free(pathC);
-    }
-    final model = modelPtr.value;
-    calloc.free(modelPtr);
+          .createEnvironment(0, nullptr, envPtr)
+          .check('LiteRtCreateEnvironment');
+      environment = envPtr.value;
+      calloc.free(envPtr);
 
-    // Compilation options.
-    final optsPtr = calloc<LiteRtOptions>();
-    bindings.createOptions(optsPtr).check('LiteRtCreateOptions');
-    final options = optsPtr.value;
-    calloc.free(optsPtr);
-    bindings
-        .setOptionsHardwareAccelerators(options, _acceleratorFor(backend))
-        .check('LiteRtSetOptionsHardwareAccelerators');
-
-    // Compile.
-    final compiledPtr = calloc<LiteRtCompiledModel>();
-    bindings
-        .createCompiledModel(environment, model, options, compiledPtr)
-        .check('LiteRtCreateCompiledModel');
-    final compiled = compiledPtr.value;
-    calloc.free(compiledPtr);
-
-    // Auto-detect seqLen + dim from compiled tensor layouts unless pinned.
-    int seqLen, dim;
-    if (inputSequenceLength == null) {
-      final inLayout = LiteRtLayoutView.calloc();
+      // Model from .tflite file.
+      final pathC = modelPath.toNativeUtf8();
+      final modelPtr = calloc<LiteRtModel>();
       try {
         bindings
-            .getInputTensorLayout(compiled, 0, 0, inLayout.pointer)
-            .check('LiteRtGetCompiledModelInputTensorLayout');
-        if (inLayout.rank < 2) {
-          throw StateError(
-              'Embedding model input has rank=${inLayout.rank}, expected >=2');
-        }
-        seqLen = inLayout.dimension(1);
+            .createModelFromFile(pathC, modelPtr)
+            .check('LiteRtCreateModelFromFile($modelPath)');
       } finally {
-        inLayout.free();
+        calloc.free(pathC);
       }
-    } else {
-      seqLen = inputSequenceLength;
-    }
+      model = modelPtr.value;
+      calloc.free(modelPtr);
 
-    if (outputDimension == null) {
-      final outLayouts = LiteRtLayoutView.calloc();
-      try {
-        bindings
-            .getOutputTensorLayouts(compiled, 0, 1, outLayouts.pointer, false)
-            .check('LiteRtGetCompiledModelOutputTensorLayouts');
-        if (outLayouts.rank < 2) {
-          throw StateError(
-              'Embedding model output has rank=${outLayouts.rank}, expected >=2');
+      // Compilation options.
+      final optsPtr = calloc<LiteRtOptions>();
+      bindings.createOptions(optsPtr).check('LiteRtCreateOptions');
+      options = optsPtr.value;
+      calloc.free(optsPtr);
+      bindings
+          .setOptionsHardwareAccelerators(options, _acceleratorFor(backend))
+          .check('LiteRtSetOptionsHardwareAccelerators');
+
+      // Compile.
+      final compiledPtr = calloc<LiteRtCompiledModel>();
+      bindings
+          .createCompiledModel(environment, model, options, compiledPtr)
+          .check('LiteRtCreateCompiledModel');
+      compiled = compiledPtr.value;
+      calloc.free(compiledPtr);
+
+      // Auto-detect seqLen + dim from compiled tensor layouts unless pinned.
+      int seqLen, dim;
+      if (inputSequenceLength == null) {
+        final inLayout = LiteRtLayoutView.calloc();
+        try {
+          bindings
+              .getInputTensorLayout(compiled, 0, 0, inLayout.pointer)
+              .check('LiteRtGetCompiledModelInputTensorLayout');
+          if (inLayout.rank < 2) {
+            throw StateError(
+                'Embedding model input has rank=${inLayout.rank}, expected >=2');
+          }
+          seqLen = inLayout.dimension(1);
+        } finally {
+          inLayout.free();
         }
-        dim = outLayouts.dimension(1);
-      } finally {
-        outLayouts.free();
+      } else {
+        seqLen = inputSequenceLength;
       }
-    } else {
-      dim = outputDimension;
+
+      if (outputDimension == null) {
+        final outLayouts = LiteRtLayoutView.calloc();
+        try {
+          bindings
+              .getOutputTensorLayouts(compiled, 0, 1, outLayouts.pointer, false)
+              .check('LiteRtGetCompiledModelOutputTensorLayouts');
+          if (outLayouts.rank < 2) {
+            throw StateError(
+                'Embedding model output has rank=${outLayouts.rank}, expected >=2');
+          }
+          dim = outLayouts.dimension(1);
+        } finally {
+          outLayouts.free();
+        }
+      } else {
+        dim = outputDimension;
+      }
+
+      debugPrint(
+          '[EmbeddingCore] loaded: seqLen=$seqLen, dim=$dim, backend=$backend');
+
+      return EmbeddingCore._(
+        bindings: bindings,
+        environment: environment,
+        model: model,
+        options: options,
+        compiledModel: compiled,
+        tokenizer: tokenizer,
+        inputSequenceLength: seqLen,
+        outputDimension: dim,
+      );
+    } catch (_) {
+      // Free whatever was created, in reverse order, before rethrowing.
+      if (compiled != null) bindings.destroyCompiledModel(compiled);
+      if (options != null) bindings.destroyOptions(options);
+      if (model != null) bindings.destroyModel(model);
+      if (environment != null) bindings.destroyEnvironment(environment);
+      rethrow;
     }
-
-    debugPrint(
-        '[EmbeddingCore] loaded: seqLen=$seqLen, dim=$dim, backend=$backend');
-
-    return EmbeddingCore._(
-      bindings: bindings,
-      environment: environment,
-      model: model,
-      options: options,
-      compiledModel: compiled,
-      tokenizer: tokenizer,
-      inputSequenceLength: seqLen,
-      outputDimension: dim,
-    );
   }
 
   /// Tokenize ([prefix] + [text]) with Gemma BOS/EOS and run one forward pass.
@@ -206,38 +224,45 @@ class EmbeddingCore {
     final seq = inputSequenceLength;
     final dim = outputDimension;
 
+    // All allocations live inside the try so a failure in either
+    // createTensorBufferFromHostMemory (or runCompiledModel) frees everything
+    // that was created instead of leaking it. Buffers are destroyed only if
+    // they were actually created (the `*Created` flags).
     final inType = LiteRtRankedTensorTypeView.calloc()
       ..elementType = kLiteRtElementTypeInt32
       ..rank = 2
       ..setDimension(0, 1)
       ..setDimension(1, seq);
-
     final inAlloc = allocAligned(seq * 4);
-    final inHost = inAlloc.aligned.cast<Int32>();
-    for (var i = 0; i < seq; i++) {
-      inHost[i] = i < tokens.length ? tokens[i] : 0;
-    }
-
     final inBufPtr = calloc<LiteRtTensorBuffer>();
-    _bindings
-        .createTensorBufferFromHostMemory(
-            inType.pointer, inAlloc.aligned.cast(), seq * 4, nullptr, inBufPtr)
-        .check('CreateTensorBufferFromHostMemory(input)');
-
     final outType = LiteRtRankedTensorTypeView.calloc()
       ..elementType = kLiteRtElementTypeFloat32
       ..rank = 2
       ..setDimension(0, 1)
       ..setDimension(1, dim);
-
     final outAlloc = allocAligned(dim * 4);
     final outBufPtr = calloc<LiteRtTensorBuffer>();
-    _bindings
-        .createTensorBufferFromHostMemory(outType.pointer,
-            outAlloc.aligned.cast(), dim * 4, nullptr, outBufPtr)
-        .check('CreateTensorBufferFromHostMemory(output)');
+    var inBufCreated = false;
+    var outBufCreated = false;
 
     try {
+      final inHost = inAlloc.aligned.cast<Int32>();
+      for (var i = 0; i < seq; i++) {
+        inHost[i] = i < tokens.length ? tokens[i] : 0;
+      }
+
+      _bindings
+          .createTensorBufferFromHostMemory(inType.pointer,
+              inAlloc.aligned.cast(), seq * 4, nullptr, inBufPtr)
+          .check('CreateTensorBufferFromHostMemory(input)');
+      inBufCreated = true;
+
+      _bindings
+          .createTensorBufferFromHostMemory(outType.pointer,
+              outAlloc.aligned.cast(), dim * 4, nullptr, outBufPtr)
+          .check('CreateTensorBufferFromHostMemory(output)');
+      outBufCreated = true;
+
       _bindings
           .runCompiledModel(_compiledModel, 0, 1, inBufPtr, 1, outBufPtr)
           .check('LiteRtRunCompiledModel');
@@ -245,8 +270,8 @@ class EmbeddingCore {
       final outFloat = outAlloc.aligned.cast<Float>();
       return List<double>.generate(dim, (i) => outFloat[i]);
     } finally {
-      _bindings.destroyTensorBuffer(inBufPtr.value);
-      _bindings.destroyTensorBuffer(outBufPtr.value);
+      if (inBufCreated) _bindings.destroyTensorBuffer(inBufPtr.value);
+      if (outBufCreated) _bindings.destroyTensorBuffer(outBufPtr.value);
       calloc.free(inBufPtr);
       calloc.free(outBufPtr);
       calloc.free(inAlloc.raw);

--- a/lib/core/litert/litert_embedding_core.dart
+++ b/lib/core/litert/litert_embedding_core.dart
@@ -267,8 +267,23 @@ class EmbeddingCore {
           .runCompiledModel(_compiledModel, 0, 1, inBufPtr, 1, outBufPtr)
           .check('LiteRtRunCompiledModel');
 
-      final outFloat = outAlloc.aligned.cast<Float>();
-      return List<double>.generate(dim, (i) => outFloat[i]);
+      // Read the result through Lock, NOT from the raw host alloc. On CPU the
+      // locked pointer is the same host memory, but on GPU/NPU the accelerator
+      // writes into device memory and Lock(Read) triggers the device→host sync
+      // (without it the host buffer stays zero — produces all-zero embeddings).
+      final lockedPtr = calloc<Pointer<Void>>();
+      try {
+        _bindings
+            .lockTensorBuffer(
+                outBufPtr.value, lockedPtr, kLiteRtTensorBufferLockModeRead)
+            .check('LiteRtLockTensorBuffer(output)');
+        final outFloat = lockedPtr.value.cast<Float>();
+        final result = List<double>.generate(dim, (i) => outFloat[i]);
+        _bindings.unlockTensorBuffer(outBufPtr.value);
+        return result;
+      } finally {
+        calloc.free(lockedPtr);
+      }
     } finally {
       if (inBufCreated) _bindings.destroyTensorBuffer(inBufPtr.value);
       if (outBufCreated) _bindings.destroyTensorBuffer(outBufPtr.value);

--- a/lib/core/litert/litert_embedding_core.dart
+++ b/lib/core/litert/litert_embedding_core.dart
@@ -1,0 +1,267 @@
+// Synchronous, isolate-agnostic native core for LiteRT text embeddings.
+//
+// Owns the LiteRT C API handles (environment, model, options, compiled model)
+// and the SentencePiece tokenizer. `embed()` runs the blocking forward pass
+// synchronously on the calling thread — it is meant to be driven from a
+// background isolate (see `litert_embedding_worker.dart`) so the UI isolate
+// stays free (issue #299).
+//
+// This is the native code that used to live inline in `LitertEmbeddingModel`;
+// it was extracted unchanged (same pipeline, same special tokens, same
+// alignment) so embedding vectors are byte-identical before/after the #299
+// refactor.
+//
+// Pipeline:
+//   text → prefix + text
+//        → tokenize (dart_sentencepiece_tokenizer)
+//        → [BOS=2, ...ids, EOS=1]                    (Gemma convention)
+//        → right-pad with 0s to seqLength
+//        → Int32 LiteRtTensorBuffer (64-byte aligned host memory)
+//        → LiteRtRunCompiledModel signature 0
+//        → Float32 LiteRtTensorBuffer of shape [1, dim]
+//        → List<double>
+
+import 'dart:ffi';
+
+import 'package:dart_sentencepiece_tokenizer/dart_sentencepiece_tokenizer.dart';
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import 'litert_bindings.dart';
+import 'litert_embedding_worker.dart' show EmbeddingBackend;
+
+/// Gemma special-token IDs. `dart_sentencepiece_tokenizer` defaults to the
+/// swapped pair (bosId=1, eosId=2), so we add them manually.
+const int _bosId = 2;
+const int _eosId = 1;
+
+int _acceleratorFor(EmbeddingBackend backend) {
+  switch (backend) {
+    case EmbeddingBackend.gpu:
+      return kLiteRtHwAcceleratorGpu;
+    case EmbeddingBackend.npu:
+      return kLiteRtHwAcceleratorNpu;
+    case EmbeddingBackend.cpu:
+      return kLiteRtHwAcceleratorCpu;
+  }
+}
+
+/// Synchronous native embedding core. NOT safe to share across isolates — the
+/// FFI handles it holds are owned by the isolate that called [load].
+class EmbeddingCore {
+  EmbeddingCore._({
+    required LiteRtBindings bindings,
+    required LiteRtEnvironment environment,
+    required LiteRtModel model,
+    required LiteRtOptions options,
+    required LiteRtCompiledModel compiledModel,
+    required this.tokenizer,
+    required this.inputSequenceLength,
+    required this.outputDimension,
+  })  : _bindings = bindings,
+        _environment = environment,
+        _model = model,
+        _options = options,
+        _compiledModel = compiledModel;
+
+  final LiteRtBindings _bindings;
+  final LiteRtEnvironment _environment;
+  final LiteRtModel _model;
+  final LiteRtOptions _options;
+  final LiteRtCompiledModel _compiledModel;
+
+  final SentencePieceTokenizer tokenizer;
+  final int inputSequenceLength;
+  final int outputDimension;
+
+  bool _disposed = false;
+
+  /// Load a `.tflite` embedding model and compile it for [backend]. Heavy
+  /// (compile is ~570-780ms) — call once, from a background isolate.
+  static Future<EmbeddingCore> load({
+    required String modelPath,
+    required String tokenizerPath,
+    EmbeddingBackend backend = EmbeddingBackend.cpu,
+    int? inputSequenceLength,
+    int? outputDimension,
+  }) async {
+    final bindings = LiteRtBindings.open();
+
+    // Load tokenizer first (file IO; native side hasn't started yet).
+    final SentencePieceTokenizer tokenizer;
+    if (tokenizerPath.endsWith('.json')) {
+      tokenizer = await TokenizerJsonLoader.fromJsonFile(
+        tokenizerPath,
+        config: const SentencePieceConfig(),
+      );
+    } else {
+      tokenizer = await SentencePieceTokenizer.fromModelFile(
+        tokenizerPath,
+        config: const SentencePieceConfig(),
+      );
+    }
+
+    final envPtr = calloc<LiteRtEnvironment>();
+    bindings
+        .createEnvironment(0, nullptr, envPtr)
+        .check('LiteRtCreateEnvironment');
+    final environment = envPtr.value;
+    calloc.free(envPtr);
+
+    // Model from .tflite file.
+    final pathC = modelPath.toNativeUtf8();
+    final modelPtr = calloc<LiteRtModel>();
+    try {
+      bindings
+          .createModelFromFile(pathC, modelPtr)
+          .check('LiteRtCreateModelFromFile($modelPath)');
+    } finally {
+      calloc.free(pathC);
+    }
+    final model = modelPtr.value;
+    calloc.free(modelPtr);
+
+    // Compilation options.
+    final optsPtr = calloc<LiteRtOptions>();
+    bindings.createOptions(optsPtr).check('LiteRtCreateOptions');
+    final options = optsPtr.value;
+    calloc.free(optsPtr);
+    bindings
+        .setOptionsHardwareAccelerators(options, _acceleratorFor(backend))
+        .check('LiteRtSetOptionsHardwareAccelerators');
+
+    // Compile.
+    final compiledPtr = calloc<LiteRtCompiledModel>();
+    bindings
+        .createCompiledModel(environment, model, options, compiledPtr)
+        .check('LiteRtCreateCompiledModel');
+    final compiled = compiledPtr.value;
+    calloc.free(compiledPtr);
+
+    // Auto-detect seqLen + dim from compiled tensor layouts unless pinned.
+    int seqLen, dim;
+    if (inputSequenceLength == null) {
+      final inLayout = LiteRtLayoutView.calloc();
+      try {
+        bindings
+            .getInputTensorLayout(compiled, 0, 0, inLayout.pointer)
+            .check('LiteRtGetCompiledModelInputTensorLayout');
+        if (inLayout.rank < 2) {
+          throw StateError(
+              'Embedding model input has rank=${inLayout.rank}, expected >=2');
+        }
+        seqLen = inLayout.dimension(1);
+      } finally {
+        inLayout.free();
+      }
+    } else {
+      seqLen = inputSequenceLength;
+    }
+
+    if (outputDimension == null) {
+      final outLayouts = LiteRtLayoutView.calloc();
+      try {
+        bindings
+            .getOutputTensorLayouts(compiled, 0, 1, outLayouts.pointer, false)
+            .check('LiteRtGetCompiledModelOutputTensorLayouts');
+        if (outLayouts.rank < 2) {
+          throw StateError(
+              'Embedding model output has rank=${outLayouts.rank}, expected >=2');
+        }
+        dim = outLayouts.dimension(1);
+      } finally {
+        outLayouts.free();
+      }
+    } else {
+      dim = outputDimension;
+    }
+
+    debugPrint(
+        '[EmbeddingCore] loaded: seqLen=$seqLen, dim=$dim, backend=$backend');
+
+    return EmbeddingCore._(
+      bindings: bindings,
+      environment: environment,
+      model: model,
+      options: options,
+      compiledModel: compiled,
+      tokenizer: tokenizer,
+      inputSequenceLength: seqLen,
+      outputDimension: dim,
+    );
+  }
+
+  /// Tokenize ([prefix] + [text]) with Gemma BOS/EOS and run one forward pass.
+  /// Synchronous and blocking — runs on the calling thread.
+  List<double> embed(String text, {required String prefix}) {
+    if (_disposed) {
+      throw StateError('EmbeddingCore is disposed');
+    }
+    final encoded = tokenizer.encode(prefix + text);
+    final tokens = <int>[_bosId, ...encoded.ids, _eosId];
+    return _runForward(tokens);
+  }
+
+  List<double> _runForward(List<int> tokens) {
+    final seq = inputSequenceLength;
+    final dim = outputDimension;
+
+    final inType = LiteRtRankedTensorTypeView.calloc()
+      ..elementType = kLiteRtElementTypeInt32
+      ..rank = 2
+      ..setDimension(0, 1)
+      ..setDimension(1, seq);
+
+    final inAlloc = allocAligned(seq * 4);
+    final inHost = inAlloc.aligned.cast<Int32>();
+    for (var i = 0; i < seq; i++) {
+      inHost[i] = i < tokens.length ? tokens[i] : 0;
+    }
+
+    final inBufPtr = calloc<LiteRtTensorBuffer>();
+    _bindings
+        .createTensorBufferFromHostMemory(
+            inType.pointer, inAlloc.aligned.cast(), seq * 4, nullptr, inBufPtr)
+        .check('CreateTensorBufferFromHostMemory(input)');
+
+    final outType = LiteRtRankedTensorTypeView.calloc()
+      ..elementType = kLiteRtElementTypeFloat32
+      ..rank = 2
+      ..setDimension(0, 1)
+      ..setDimension(1, dim);
+
+    final outAlloc = allocAligned(dim * 4);
+    final outBufPtr = calloc<LiteRtTensorBuffer>();
+    _bindings
+        .createTensorBufferFromHostMemory(outType.pointer,
+            outAlloc.aligned.cast(), dim * 4, nullptr, outBufPtr)
+        .check('CreateTensorBufferFromHostMemory(output)');
+
+    try {
+      _bindings
+          .runCompiledModel(_compiledModel, 0, 1, inBufPtr, 1, outBufPtr)
+          .check('LiteRtRunCompiledModel');
+
+      final outFloat = outAlloc.aligned.cast<Float>();
+      return List<double>.generate(dim, (i) => outFloat[i]);
+    } finally {
+      _bindings.destroyTensorBuffer(inBufPtr.value);
+      _bindings.destroyTensorBuffer(outBufPtr.value);
+      calloc.free(inBufPtr);
+      calloc.free(outBufPtr);
+      calloc.free(inAlloc.raw);
+      calloc.free(outAlloc.raw);
+      inType.free();
+      outType.free();
+    }
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _bindings.destroyCompiledModel(_compiledModel);
+    _bindings.destroyOptions(_options);
+    _bindings.destroyModel(_model);
+    _bindings.destroyEnvironment(_environment);
+  }
+}

--- a/lib/core/litert/litert_embedding_model.dart
+++ b/lib/core/litert/litert_embedding_model.dart
@@ -1,196 +1,79 @@
-// Shared `EmbeddingModel` implementation backed by the LiteRT C API via
-// dart:ffi. Runs on Android, iOS, macOS, Linux, and Windows.
+// `EmbeddingModel` facade over a background isolate (issue #299).
 //
-// Replaces the per-platform implementations that 0.15.1 shipped:
-//   - Android `EmbeddingModel.kt` (localagents-rag JVM lib)
-//   - iOS `EmbeddingModel.swift` (TensorFlowLiteC.framework)
-//   - Desktop `DesktopEmbeddingModel` (libtensorflowlite_c.{dylib,so,dll})
-// All three are deleted in 0.15.2. Web is unchanged (LiteRT.js).
+// The blocking LiteRT forward pass (`LiteRtRunCompiledModel`) used to run on
+// the calling (UI) isolate, freezing the event loop for the whole pass
+// (~80ms/call, more on mobile). This facade now owns an [EmbeddingWorker]
+// that runs the native lifecycle — lib open, compile-once, tokenize, forward,
+// teardown — on a dedicated background isolate, so the UI stays free.
 //
-// Pipeline (same as the platforms it replaces):
-//   text → TaskType.prefix + text
-//        → tokenize (dart_sentencepiece_tokenizer)
-//        → [BOS=2, ...ids, EOS=1]                    (Gemma convention)
-//        → right-pad with 0s to seqLength
-//        → Int32 LiteRtTensorBuffer (host memory, 64-byte aligned)
-//        → LiteRtRunCompiledModel signature 0
-//        → Float32 LiteRtTensorBuffer of shape [1, dim]
-//        → List<double>
-
-import 'dart:ffi';
-
-import 'package:dart_sentencepiece_tokenizer/dart_sentencepiece_tokenizer.dart';
-import 'package:ffi/ffi.dart';
-import 'package:flutter/foundation.dart' show debugPrint;
+// The native code itself lives in `litert_embedding_core.dart` (driven inside
+// the worker isolate); this file is just the public, async, main-isolate API.
+// Public method signatures are unchanged, so all call sites work as before.
+//
+// Replaces the per-platform implementations that 0.15.1 shipped (Android
+// `EmbeddingModel.kt`, iOS `EmbeddingModel.swift`, desktop tflite C). Web is
+// unchanged (LiteRT.js).
 
 import '../../flutter_gemma_interface.dart' show EmbeddingModel, TaskType;
-import 'litert_bindings.dart';
+import '../../pigeon.g.dart' show PreferredBackend;
+import 'litert_embedding_worker.dart';
 
-/// Gemma special-token IDs. `dart_sentencepiece_tokenizer` defaults to the
-/// swapped pair (bosId=1, eosId=2), so we add them manually.
-const int _bosId = 2;
-const int _eosId = 1;
+/// Signature for the `onClose` callback. Same name Flutter uses.
+typedef VoidCallback = void Function();
+
+EmbeddingBackend _backendFor(PreferredBackend? backend) {
+  switch (backend) {
+    case PreferredBackend.gpu:
+      return EmbeddingBackend.gpu;
+    case PreferredBackend.npu:
+      return EmbeddingBackend.npu;
+    case PreferredBackend.cpu:
+    case null:
+      return EmbeddingBackend.cpu;
+  }
+}
 
 class LitertEmbeddingModel extends EmbeddingModel {
-  LitertEmbeddingModel._({
-    required LiteRtBindings bindings,
-    required LiteRtEnvironment environment,
-    required LiteRtModel model,
-    required LiteRtOptions options,
-    required LiteRtCompiledModel compiledModel,
-    required this.tokenizer,
-    required this.inputSequenceLength,
-    required this.outputDimension,
-    required this.onClose,
-  })  : _bindings = bindings,
-        _environment = environment,
-        _model = model,
-        _options = options,
-        _compiledModel = compiledModel;
+  LitertEmbeddingModel._(this._worker, this.onClose);
 
-  final LiteRtBindings _bindings;
-  final LiteRtEnvironment _environment;
-  final LiteRtModel _model;
-  final LiteRtOptions _options;
-  final LiteRtCompiledModel _compiledModel;
-
-  final SentencePieceTokenizer tokenizer;
-
-  /// Sequence length the model was compiled for (input tensor dim[1]).
-  final int inputSequenceLength;
-
-  /// Output embedding dimension (output tensor dim[1] — 768 for Gecko /
-  /// EmbeddingGemma).
-  final int outputDimension;
-
+  final EmbeddingWorker _worker;
   final VoidCallback onClose;
   bool _isClosed = false;
 
-  /// Load a `.tflite` embedding model from disk and prepare it for
-  /// inference on CPU.
+  /// Sequence length the model was compiled for (input tensor dim[1]).
+  int get inputSequenceLength => _worker.inputSequenceLength;
+
+  /// Output embedding dimension (output tensor dim[1] — 768 for Gecko /
+  /// EmbeddingGemma).
+  int get outputDimension => _worker.outputDimension;
+
+  /// Load a `.tflite` embedding model from disk and prepare it for inference
+  /// on a background isolate.
   ///
   /// [modelPath] points at a `.tflite` file (Gecko 64, EmbeddingGemma 256,
-  /// etc.). [tokenizerPath] is the matching SentencePiece `.model` or
-  /// exported `.json`. Input sequence length and output dimension are
-  /// auto-detected from the compiled model's tensor layouts; pass them
-  /// to override (rare).
+  /// etc.). [tokenizerPath] is the matching SentencePiece `.model` or exported
+  /// `.json`. [preferredBackend] selects the LiteRT HW accelerator (CPU by
+  /// default; GPU delegates are bundled). Input sequence length and output
+  /// dimension are auto-detected from the compiled model's tensor layouts;
+  /// pass them to override (rare).
   ///
   /// Caller owns the returned instance and must call [close] when done.
   static Future<LitertEmbeddingModel> create({
     required String modelPath,
     required String tokenizerPath,
+    PreferredBackend? preferredBackend,
     int? inputSequenceLength,
     int? outputDimension,
     VoidCallback? onClose,
   }) async {
-    final bindings = LiteRtBindings.open();
-
-    // Load tokenizer first (file IO; native side hasn't started yet).
-    final SentencePieceTokenizer tokenizer;
-    if (tokenizerPath.endsWith('.json')) {
-      tokenizer = await TokenizerJsonLoader.fromJsonFile(
-        tokenizerPath,
-        config: const SentencePieceConfig(),
-      );
-    } else {
-      tokenizer = await SentencePieceTokenizer.fromModelFile(
-        tokenizerPath,
-        config: const SentencePieceConfig(),
-      );
-    }
-
-    // Environment (CPU; can be extended later for GPU acceleration).
-    final envPtr = calloc<LiteRtEnvironment>();
-    bindings
-        .createEnvironment(0, nullptr, envPtr)
-        .check('LiteRtCreateEnvironment');
-    final environment = envPtr.value;
-    calloc.free(envPtr);
-
-    // Model from .tflite file.
-    final pathC = modelPath.toNativeUtf8();
-    final modelPtr = calloc<LiteRtModel>();
-    try {
-      bindings
-          .createModelFromFile(pathC, modelPtr)
-          .check('LiteRtCreateModelFromFile($modelPath)');
-    } finally {
-      calloc.free(pathC);
-    }
-    final model = modelPtr.value;
-    calloc.free(modelPtr);
-
-    // Compilation options: CPU only.
-    final optsPtr = calloc<LiteRtOptions>();
-    bindings.createOptions(optsPtr).check('LiteRtCreateOptions');
-    final options = optsPtr.value;
-    calloc.free(optsPtr);
-    bindings
-        .setOptionsHardwareAccelerators(options, kLiteRtHwAcceleratorCpu)
-        .check('LiteRtSetOptionsHardwareAccelerators');
-
-    // Compile.
-    final compiledPtr = calloc<LiteRtCompiledModel>();
-    bindings
-        .createCompiledModel(environment, model, options, compiledPtr)
-        .check('LiteRtCreateCompiledModel');
-    final compiled = compiledPtr.value;
-    calloc.free(compiledPtr);
-
-    // Auto-detect seqLen + dim from compiled tensor layouts unless the
-    // caller pinned them. Embedding models we care about all have:
-    //   input  shape [1, seqLen]   element_type=int32
-    //   output shape [1, dim]      element_type=float32
-    int seqLen, dim;
-    if (inputSequenceLength == null) {
-      final inLayout = LiteRtLayoutView.calloc();
-      try {
-        bindings
-            .getInputTensorLayout(compiled, 0, 0, inLayout.pointer)
-            .check('LiteRtGetCompiledModelInputTensorLayout');
-        if (inLayout.rank < 2) {
-          throw StateError(
-              'Embedding model input has rank=${inLayout.rank}, expected >=2');
-        }
-        seqLen = inLayout.dimension(1);
-      } finally {
-        inLayout.free();
-      }
-    } else {
-      seqLen = inputSequenceLength;
-    }
-
-    if (outputDimension == null) {
-      final outLayouts = LiteRtLayoutView.calloc();
-      try {
-        bindings
-            .getOutputTensorLayouts(compiled, 0, 1, outLayouts.pointer, false)
-            .check('LiteRtGetCompiledModelOutputTensorLayouts');
-        if (outLayouts.rank < 2) {
-          throw StateError(
-              'Embedding model output has rank=${outLayouts.rank}, expected >=2');
-        }
-        dim = outLayouts.dimension(1);
-      } finally {
-        outLayouts.free();
-      }
-    } else {
-      dim = outputDimension;
-    }
-
-    debugPrint('[LitertEmbeddingModel] loaded: seqLen=$seqLen, dim=$dim');
-
-    return LitertEmbeddingModel._(
-      bindings: bindings,
-      environment: environment,
-      model: model,
-      options: options,
-      compiledModel: compiled,
-      tokenizer: tokenizer,
-      inputSequenceLength: seqLen,
-      outputDimension: dim,
-      onClose: onClose ?? () {},
+    final worker = await EmbeddingWorker.spawn(
+      modelPath: modelPath,
+      tokenizerPath: tokenizerPath,
+      backend: _backendFor(preferredBackend),
+      inputSequenceLength: inputSequenceLength,
+      outputDimension: outputDimension,
     );
+    return LitertEmbeddingModel._(worker, onClose ?? () {});
   }
 
   void _assertNotClosed() {
@@ -200,31 +83,26 @@ class LitertEmbeddingModel extends EmbeddingModel {
     }
   }
 
-  /// Tokenize with prefix and add Gemma BOS/EOS.
-  List<int> _prepareTokens(String text, {required TaskType taskType}) {
-    final encoded = tokenizer.encode(taskType.prefix + text);
-    return <int>[_bosId, ...encoded.ids, _eosId];
-  }
-
   @override
   Future<List<double>> generateEmbedding(
     String text, {
     TaskType taskType = TaskType.retrievalQuery,
-  }) async {
+  }) {
     _assertNotClosed();
-    final tokens = _prepareTokens(text, taskType: taskType);
-    return _runForward(tokens);
+    return _worker.embed(text, prefix: taskType.prefix);
   }
 
   @override
   Future<List<List<double>>> generateEmbeddings(
     List<String> texts, {
     TaskType taskType = TaskType.retrievalQuery,
-  }) async {
+  }) {
     _assertNotClosed();
-    return texts
-        .map((text) => _runForward(_prepareTokens(text, taskType: taskType)))
-        .toList();
+    // Each embed() is a separate request the worker serves in order; the UI
+    // isolate stays free between them.
+    return Future.wait(
+      texts.map((text) => _worker.embed(text, prefix: taskType.prefix)),
+    );
   }
 
   @override
@@ -233,80 +111,14 @@ class LitertEmbeddingModel extends EmbeddingModel {
     return outputDimension;
   }
 
-  /// Run one forward pass over an already-tokenized input. Pads/truncates
-  /// to [inputSequenceLength] and returns the [outputDimension]-element
-  /// embedding as `List<double>`.
-  List<double> _runForward(List<int> tokens) {
-    final seq = inputSequenceLength;
-    final dim = outputDimension;
-
-    // Input tensor type [1, seq] Int32.
-    final inType = LiteRtRankedTensorTypeView.calloc()
-      ..elementType = kLiteRtElementTypeInt32
-      ..rank = 2
-      ..setDimension(0, 1)
-      ..setDimension(1, seq);
-
-    // Aligned host memory for input.
-    final inAlloc = allocAligned(seq * 4);
-    final inHost = inAlloc.aligned.cast<Int32>();
-    for (var i = 0; i < seq; i++) {
-      inHost[i] = i < tokens.length ? tokens[i] : 0;
-    }
-
-    final inBufPtr = calloc<LiteRtTensorBuffer>();
-    _bindings
-        .createTensorBufferFromHostMemory(inType.pointer,
-            inAlloc.aligned.cast(), seq * 4, nullptr, inBufPtr)
-        .check('CreateTensorBufferFromHostMemory(input)');
-
-    // Output tensor type [1, dim] Float32.
-    final outType = LiteRtRankedTensorTypeView.calloc()
-      ..elementType = kLiteRtElementTypeFloat32
-      ..rank = 2
-      ..setDimension(0, 1)
-      ..setDimension(1, dim);
-
-    final outAlloc = allocAligned(dim * 4);
-    final outBufPtr = calloc<LiteRtTensorBuffer>();
-    _bindings
-        .createTensorBufferFromHostMemory(outType.pointer,
-            outAlloc.aligned.cast(), dim * 4, nullptr, outBufPtr)
-        .check('CreateTensorBufferFromHostMemory(output)');
-
-    try {
-      _bindings
-          .runCompiledModel(_compiledModel, 0, 1, inBufPtr, 1, outBufPtr)
-          .check('LiteRtRunCompiledModel');
-
-      final outFloat = outAlloc.aligned.cast<Float>();
-      return List<double>.generate(dim, (i) => outFloat[i]);
-    } finally {
-      _bindings.destroyTensorBuffer(inBufPtr.value);
-      _bindings.destroyTensorBuffer(outBufPtr.value);
-      calloc.free(inBufPtr);
-      calloc.free(outBufPtr);
-      calloc.free(inAlloc.raw);
-      calloc.free(outAlloc.raw);
-      inType.free();
-      outType.free();
-    }
-  }
-
   @override
   Future<void> close() async {
     if (_isClosed) return;
     _isClosed = true;
     try {
-      _bindings.destroyCompiledModel(_compiledModel);
-      _bindings.destroyOptions(_options);
-      _bindings.destroyModel(_model);
-      _bindings.destroyEnvironment(_environment);
+      await _worker.close();
     } finally {
       onClose();
     }
   }
 }
-
-/// Signature for the `onClose` callback. Same name Flutter uses.
-typedef VoidCallback = void Function();

--- a/lib/core/litert/litert_embedding_model.dart
+++ b/lib/core/litert/litert_embedding_model.dart
@@ -21,17 +21,14 @@ import 'litert_embedding_worker.dart';
 /// Signature for the `onClose` callback. Same name Flutter uses.
 typedef VoidCallback = void Function();
 
-EmbeddingBackend _backendFor(PreferredBackend? backend) {
-  switch (backend) {
-    case PreferredBackend.gpu:
-      return EmbeddingBackend.gpu;
-    case PreferredBackend.npu:
-      return EmbeddingBackend.npu;
-    case PreferredBackend.cpu:
-    case null:
-      return EmbeddingBackend.cpu;
-  }
-}
+// Embeddings run on CPU only. The GPU/NPU plumbing exists end-to-end
+// (EmbeddingBackend + the LiteRT accelerator flag + the Lock(Read) device→host
+// sync), but the GPU delegate currently compiles and then returns all-zero
+// vectors (verified on macOS Metal) — so we do NOT expose it yet. The
+// `preferredBackend` argument is accepted but ignored for embeddings until the
+// GPU path produces correct output. Tracked separately; do NOT silently route
+// embeddings onto a broken accelerator.
+EmbeddingBackend _backendFor(PreferredBackend? backend) => EmbeddingBackend.cpu;
 
 class LitertEmbeddingModel extends EmbeddingModel {
   LitertEmbeddingModel._(this._worker, this.onClose);
@@ -52,10 +49,11 @@ class LitertEmbeddingModel extends EmbeddingModel {
   ///
   /// [modelPath] points at a `.tflite` file (Gecko 64, EmbeddingGemma 256,
   /// etc.). [tokenizerPath] is the matching SentencePiece `.model` or exported
-  /// `.json`. [preferredBackend] selects the LiteRT HW accelerator (CPU by
-  /// default; GPU delegates are bundled). Input sequence length and output
-  /// dimension are auto-detected from the compiled model's tensor layouts;
-  /// pass them to override (rare).
+  /// `.json`. [preferredBackend] is accepted for API symmetry but currently
+  /// ignored — embeddings run on CPU (the GPU delegate returns zero vectors;
+  /// see `_backendFor`). Input sequence length and output dimension are
+  /// auto-detected from the compiled model's tensor layouts; pass them to
+  /// override (rare).
   ///
   /// Caller owns the returned instance and must call [close] when done.
   static Future<LitertEmbeddingModel> create({

--- a/lib/core/litert/litert_embedding_model_stub.dart
+++ b/lib/core/litert/litert_embedding_model_stub.dart
@@ -6,6 +6,7 @@
 // dart2js builds the mobile entry point.
 
 import '../../flutter_gemma_interface.dart' show EmbeddingModel, TaskType;
+import '../../pigeon.g.dart' show PreferredBackend;
 
 typedef VoidCallback = void Function();
 
@@ -15,6 +16,7 @@ class LitertEmbeddingModel extends EmbeddingModel {
   static Future<LitertEmbeddingModel> create({
     required String modelPath,
     required String tokenizerPath,
+    PreferredBackend? preferredBackend,
     int? inputSequenceLength,
     int? outputDimension,
     VoidCallback? onClose,

--- a/lib/core/litert/litert_embedding_worker.dart
+++ b/lib/core/litert/litert_embedding_worker.dart
@@ -59,6 +59,12 @@ class _Close {
   const _Close();
 }
 
+/// Ack the worker sends after [EmbeddingCore.dispose] completes, so the main
+/// isolate can kill the isolate without racing native teardown.
+class _CloseAck {
+  const _CloseAck();
+}
+
 /// Parameters needed to boot the worker isolate. Must be fully sendable.
 class _WorkerInit {
   _WorkerInit({
@@ -101,6 +107,7 @@ class EmbeddingWorker {
   final _pending = <int, Completer<List<double>>>{};
   int _nextId = 0;
   bool _closed = false;
+  Completer<void>? _closeAck;
 
   /// Spawn the worker and wait until the native model is loaded.
   static Future<EmbeddingWorker> spawn({
@@ -113,7 +120,10 @@ class EmbeddingWorker {
     final fromWorker = ReceivePort();
     final readyCompleter = Completer<_Ready>();
 
-    // First message from the worker is either _Ready or a String error.
+    // First message from the worker is either _Ready or a String error. A
+    // `null` is the isolate's onExit signal — if it arrives before _Ready, the
+    // worker died during load (e.g. a native crash compiling a corrupt model),
+    // so fail the completer instead of hanging forever.
     late final StreamSubscription sub;
     sub = fromWorker.listen((msg) {
       if (msg is _Ready) {
@@ -121,6 +131,11 @@ class EmbeddingWorker {
       } else if (msg is String) {
         if (!readyCompleter.isCompleted) {
           readyCompleter.completeError(StateError(msg));
+        }
+      } else if (msg == null) {
+        if (!readyCompleter.isCompleted) {
+          readyCompleter.completeError(
+              StateError('Embedding worker isolate exited during load'));
         }
       }
     });
@@ -135,6 +150,8 @@ class EmbeddingWorker {
         inputSequenceLength: inputSequenceLength,
         outputDimension: outputDimension,
       ),
+      // onExit posts `null` to fromWorker so we never wait on a dead isolate.
+      onExit: fromWorker.sendPort,
       debugName: 'litert-embedding-worker',
     );
 
@@ -161,20 +178,37 @@ class EmbeddingWorker {
   }
 
   void _onReply(dynamic msg) {
-    if (msg is! _EmbedReply) return;
-    final completer = _pending.remove(msg.id);
-    if (completer == null) return;
-    if (msg.error != null) {
-      completer.completeError(StateError(msg.error!));
-    } else {
-      completer.complete(msg.vector!);
+    if (msg is _EmbedReply) {
+      final completer = _pending.remove(msg.id);
+      if (completer == null) return;
+      if (msg.error != null) {
+        completer.completeError(StateError(msg.error!));
+      } else {
+        completer.complete(msg.vector!);
+      }
+    } else if (msg is _CloseAck) {
+      _closeAck?.complete();
+    } else if (msg == null) {
+      // onExit: the worker isolate died. If this is part of a normal close,
+      // the ack path already handled it; otherwise it's an unexpected crash —
+      // fail every in-flight request rather than leave callers hanging.
+      _failAllPending('Embedding worker isolate exited unexpectedly');
+      _closed = true;
+      _closeAck?.complete();
     }
+  }
+
+  void _failAllPending(String reason) {
+    for (final c in _pending.values) {
+      if (!c.isCompleted) c.completeError(StateError(reason));
+    }
+    _pending.clear();
   }
 
   /// Embed one text. The forward runs in the worker; the UI isolate stays free.
   Future<List<double>> embed(String text, {required String prefix}) {
     if (_closed) {
-      throw StateError('EmbeddingWorker is closed');
+      return Future.error(StateError('EmbeddingWorker is closed'));
     }
     final id = _nextId++;
     final completer = Completer<List<double>>();
@@ -183,21 +217,24 @@ class EmbeddingWorker {
     return completer.future;
   }
 
-  /// Tear down the native model and stop the isolate.
+  /// Tear down the native model and stop the isolate. Waits for the worker to
+  /// finish native teardown (a _CloseAck, or the isolate's onExit) before
+  /// killing it, so handles are never freed mid-dispose.
   Future<void> close() async {
     if (_closed) return;
     _closed = true;
+    _closeAck = Completer<void>();
     _commandPort.send(const _Close());
-    // Give the worker a moment to free native resources before killing.
-    await Future<void>.delayed(const Duration(milliseconds: 50));
+    // Wait for the worker's dispose ack / exit; cap the wait so a wedged
+    // native teardown can't hang close() forever.
+    try {
+      await _closeAck!.future.timeout(const Duration(seconds: 5));
+    } catch (_) {
+      // Timed out or errored — fall through to a forced kill below.
+    }
     _fromWorker.close();
     _isolate.kill(priority: Isolate.beforeNextEvent);
-    for (final c in _pending.values) {
-      if (!c.isCompleted) {
-        c.completeError(StateError('EmbeddingWorker closed mid-request'));
-      }
-    }
-    _pending.clear();
+    _failAllPending('EmbeddingWorker closed mid-request');
   }
 }
 
@@ -222,18 +259,24 @@ Future<void> _workerEntry(_WorkerInit init) async {
   init.replyTo.send(_Ready(
       commandPort.sendPort, core.inputSequenceLength, core.outputDimension));
 
-  await for (final msg in commandPort) {
-    if (msg is _EmbedRequest) {
-      try {
-        final vector = core.embed(msg.text, prefix: msg.prefix);
-        init.replyTo.send(_EmbedReply(msg.id, vector, null));
-      } catch (e) {
-        init.replyTo.send(_EmbedReply(msg.id, null, e.toString()));
+  try {
+    await for (final msg in commandPort) {
+      if (msg is _EmbedRequest) {
+        try {
+          final vector = core.embed(msg.text, prefix: msg.prefix);
+          init.replyTo.send(_EmbedReply(msg.id, vector, null));
+        } catch (e) {
+          init.replyTo.send(_EmbedReply(msg.id, null, e.toString()));
+        }
+      } else if (msg is _Close) {
+        commandPort.close();
+        break;
       }
-    } else if (msg is _Close) {
-      core.dispose();
-      commandPort.close();
-      break;
     }
+  } finally {
+    // Always free native handles, even if the loop exits unexpectedly, then
+    // ack so the main isolate can kill us without racing teardown.
+    core.dispose();
+    init.replyTo.send(const _CloseAck());
   }
 }

--- a/lib/core/litert/litert_embedding_worker.dart
+++ b/lib/core/litert/litert_embedding_worker.dart
@@ -1,0 +1,239 @@
+// Long-lived background isolate that owns the entire LiteRT embedding native
+// lifecycle (lib open, model compile, forward pass, teardown) and the
+// SentencePiece tokenizer. The forward pass (`LiteRtRunCompiledModel`) is a
+// blocking synchronous FFI call; running it here keeps the UI isolate's event
+// loop free (issue #299).
+//
+// Why a long-lived worker and not `Isolate.run` per call:
+//   - The compiled model costs ~570-780ms to build but only ~80ms to run, so
+//     it MUST be compiled once and reused — `Isolate.run` would recompile
+//     every call.
+//   - FFI `Pointer`/`DynamicLibrary` cannot cross isolate boundaries
+//     (flutter/flutter#169431; passing a pointer as an int is officially
+//     "risky and unsupported"). Keeping all handles inside the one worker
+//     means nothing crosses the boundary, and a (future) GPU command queue —
+//     which is thread-affine — is created and used on the same isolate.
+//
+// Only sendable values cross the port: file paths + backend (setup), text +
+// task-type prefix (request), and `List<double>` vectors (reply).
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import 'litert_embedding_core.dart';
+
+/// Backend selector mirrored across the isolate boundary as a plain int
+/// (the `PreferredBackend` enum lives in pigeon-generated code; we map it to
+/// the LiteRT HW accelerator bit in the worker).
+enum EmbeddingBackend { cpu, gpu, npu }
+
+/// Handshake payload the worker sends back once the native model is loaded.
+class _Ready {
+  _Ready(this.commandPort, this.seqLen, this.dim);
+  final SendPort commandPort;
+  final int seqLen;
+  final int dim;
+}
+
+/// Request: embed [text] with the given task-type [prefix]. [id] correlates
+/// the reply.
+class _EmbedRequest {
+  _EmbedRequest(this.id, this.text, this.prefix);
+  final int id;
+  final String text;
+  final String prefix;
+}
+
+/// Reply carrying the embedding vector (or an error message).
+class _EmbedReply {
+  _EmbedReply(this.id, this.vector, this.error);
+  final int id;
+  final List<double>? vector;
+  final String? error;
+}
+
+/// Sentinel asking the worker to tear down the native model and exit.
+class _Close {
+  const _Close();
+}
+
+/// Parameters needed to boot the worker isolate. Must be fully sendable.
+class _WorkerInit {
+  _WorkerInit({
+    required this.replyTo,
+    required this.modelPath,
+    required this.tokenizerPath,
+    required this.backend,
+    required this.inputSequenceLength,
+    required this.outputDimension,
+  });
+  final SendPort replyTo;
+  final String modelPath;
+  final String tokenizerPath;
+  final EmbeddingBackend backend;
+  final int? inputSequenceLength;
+  final int? outputDimension;
+}
+
+/// Main-isolate handle to the embedding worker. Spawns the isolate, performs
+/// the load handshake, and multiplexes concurrent requests by id.
+class EmbeddingWorker {
+  EmbeddingWorker._(
+    this._isolate,
+    this._commandPort,
+    this._fromWorker,
+    this.inputSequenceLength,
+    this.outputDimension,
+  );
+
+  final Isolate _isolate;
+  final SendPort _commandPort;
+  final ReceivePort _fromWorker;
+
+  /// Sequence length the model was compiled for.
+  final int inputSequenceLength;
+
+  /// Output embedding dimension.
+  final int outputDimension;
+
+  final _pending = <int, Completer<List<double>>>{};
+  int _nextId = 0;
+  bool _closed = false;
+
+  /// Spawn the worker and wait until the native model is loaded.
+  static Future<EmbeddingWorker> spawn({
+    required String modelPath,
+    required String tokenizerPath,
+    EmbeddingBackend backend = EmbeddingBackend.cpu,
+    int? inputSequenceLength,
+    int? outputDimension,
+  }) async {
+    final fromWorker = ReceivePort();
+    final readyCompleter = Completer<_Ready>();
+
+    // First message from the worker is either _Ready or a String error.
+    late final StreamSubscription sub;
+    sub = fromWorker.listen((msg) {
+      if (msg is _Ready) {
+        readyCompleter.complete(msg);
+      } else if (msg is String) {
+        if (!readyCompleter.isCompleted) {
+          readyCompleter.completeError(StateError(msg));
+        }
+      }
+    });
+
+    final isolate = await Isolate.spawn(
+      _workerEntry,
+      _WorkerInit(
+        replyTo: fromWorker.sendPort,
+        modelPath: modelPath,
+        tokenizerPath: tokenizerPath,
+        backend: backend,
+        inputSequenceLength: inputSequenceLength,
+        outputDimension: outputDimension,
+      ),
+      debugName: 'litert-embedding-worker',
+    );
+
+    final _Ready ready;
+    try {
+      ready = await readyCompleter.future;
+    } catch (_) {
+      await sub.cancel();
+      fromWorker.close();
+      isolate.kill(priority: Isolate.immediate);
+      rethrow;
+    }
+
+    final worker = EmbeddingWorker._(
+      isolate,
+      ready.commandPort,
+      fromWorker,
+      ready.seqLen,
+      ready.dim,
+    );
+    // Re-point the subscription at the steady-state reply handler.
+    sub.onData(worker._onReply);
+    return worker;
+  }
+
+  void _onReply(dynamic msg) {
+    if (msg is! _EmbedReply) return;
+    final completer = _pending.remove(msg.id);
+    if (completer == null) return;
+    if (msg.error != null) {
+      completer.completeError(StateError(msg.error!));
+    } else {
+      completer.complete(msg.vector!);
+    }
+  }
+
+  /// Embed one text. The forward runs in the worker; the UI isolate stays free.
+  Future<List<double>> embed(String text, {required String prefix}) {
+    if (_closed) {
+      throw StateError('EmbeddingWorker is closed');
+    }
+    final id = _nextId++;
+    final completer = Completer<List<double>>();
+    _pending[id] = completer;
+    _commandPort.send(_EmbedRequest(id, text, prefix));
+    return completer.future;
+  }
+
+  /// Tear down the native model and stop the isolate.
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _commandPort.send(const _Close());
+    // Give the worker a moment to free native resources before killing.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    _fromWorker.close();
+    _isolate.kill(priority: Isolate.beforeNextEvent);
+    for (final c in _pending.values) {
+      if (!c.isCompleted) {
+        c.completeError(StateError('EmbeddingWorker closed mid-request'));
+      }
+    }
+    _pending.clear();
+  }
+}
+
+/// Isolate entry point. Loads the model, then serves requests until _Close.
+Future<void> _workerEntry(_WorkerInit init) async {
+  final EmbeddingCore core;
+  try {
+    core = await EmbeddingCore.load(
+      modelPath: init.modelPath,
+      tokenizerPath: init.tokenizerPath,
+      backend: init.backend,
+      inputSequenceLength: init.inputSequenceLength,
+      outputDimension: init.outputDimension,
+    );
+  } catch (e, st) {
+    debugPrint('[EmbeddingWorker] load failed: $e\n$st');
+    init.replyTo.send('Embedding worker failed to load: $e');
+    return;
+  }
+
+  final commandPort = ReceivePort();
+  init.replyTo.send(_Ready(
+      commandPort.sendPort, core.inputSequenceLength, core.outputDimension));
+
+  await for (final msg in commandPort) {
+    if (msg is _EmbedRequest) {
+      try {
+        final vector = core.embed(msg.text, prefix: msg.prefix);
+        init.replyTo.send(_EmbedReply(msg.id, vector, null));
+      } catch (e) {
+        init.replyTo.send(_EmbedReply(msg.id, null, e.toString()));
+      }
+    } else if (msg is _Close) {
+      core.dispose();
+      commandPort.close();
+      break;
+    }
+  }
+}

--- a/lib/desktop/flutter_gemma_desktop.dart
+++ b/lib/desktop/flutter_gemma_desktop.dart
@@ -260,6 +260,7 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
           _initializedEmbeddingModel = await LitertEmbeddingModel.create(
         modelPath: modelPath,
         tokenizerPath: tokenizerPath,
+        preferredBackend: preferredBackend,
         onClose: () {
           _initializedEmbeddingModel = null;
           _initEmbeddingCompleter = null;

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -766,6 +766,7 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
           _initializedEmbeddingModel = await LitertEmbeddingModel.create(
         modelPath: modelPath,
         tokenizerPath: tokenizerPath,
+        preferredBackend: preferredBackend,
         onClose: () {
           _initializedEmbeddingModel = null;
           _initEmbeddingCompleter = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.16.3
+version: 0.16.4
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -19,6 +19,16 @@ add_library(${PLUGIN_NAME} SHARED
 
 apply_standard_settings(${PLUGIN_NAME})
 
+# Read sources as UTF-8 regardless of the system locale. Flutter's
+# apply_standard_settings enables /WX, so on non-UTF-8 code pages (e.g. CP949
+# Korean) MSVC promotes C4819 ("character cannot be represented in the current
+# code page") to a hard error for any UTF-8 byte in the headers, breaking the
+# build for the plugin and the app runner. /utf-8 fixes it for every locale
+# (#212).
+if(MSVC)
+  target_compile_options(${PLUGIN_NAME} PRIVATE /utf-8)
+endif()
+
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 

--- a/windows/include/flutter_gemma/flutter_gemma_plugin.h
+++ b/windows/include/flutter_gemma/flutter_gemma_plugin.h
@@ -29,7 +29,7 @@ FLUTTER_PLUGIN_EXPORT void FlutterGemmaPluginRegisterWithRegistrar(
 
 namespace flutter_gemma {
 
-// Placeholder plugin class — actual implementation is in Dart over dart:ffi
+// Placeholder plugin class -- actual implementation is in Dart over dart:ffi
 class FlutterGemmaPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);


### PR DESCRIPTION
## Summary
Release 0.16.4 — bug fixes, no native dylib changes.

### Embedding no longer freezes the UI thread (#299)
The LiteRT embedding forward (`LiteRtRunCompiledModel`) is a blocking synchronous FFI call that ran on the calling (UI) isolate, freezing the event loop for the whole pass (~80 ms/call, more on mobile). Regression from 0.15.2.

- New `EmbeddingCore` — synchronous native lifecycle, extracted unchanged (vectors byte-identical).
- New `EmbeddingWorker` — long-lived background isolate, compiles once, serves forwards over a `SendPort`, fails loudly on isolate death, acks teardown before kill.
- `LitertEmbeddingModel` is now a thin facade; **public API unchanged**.
- Embeddings stay CPU-only (the GPU delegate returns zero vectors — kept the plumbing, ignored for now).

### Windows build on non-UTF-8 locales (#212)
`/utf-8` on the MSVC plugin target + ASCII-only header, so CP949/etc. builds don't hit C4819→C2220.

### macOS "Cycle inside Flutter Assemble" (#300, @fotiDim)
Merged via #301 — stages native dylibs out of the cache dir.

### Intel NPU example models
Gemma 4 E2B Intel-compiled inference entries (Lunar Lake + Panther Lake).

## Verification
- [x] #299 non-blocking: macOS (44980 ticks) + Android emulator (68110 ticks)
- [x] Vectors byte-identical (smoke green, both families, macOS + Android)
- [x] Intel NPU inference on real Lunar Lake: engine_create + generation + determinism
- [x] Windows build with /utf-8 (libs = native-v0.12.0-a)
- [x] Builds: web, apk --release, macos, ios
- [x] 386 unit tests, dry-run 0 warnings
- [x] 10-agent review — CRITICAL (isolate-death hang) + native leaks fixed
- [ ] iPhone device (mobile + seq512) — pending hardware
