### PR TITLE
Show downloaded models list

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "example",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "example (profile mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "example (release mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/example/integration_test/active_model_restore_test.dart
+++ b/example/integration_test/active_model_restore_test.dart
@@ -18,7 +18,6 @@ import 'dart:io';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
-import 'package:flutter_gemma/core/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path_provider/path_provider.dart';

--- a/example/lib/chat_screen.dart
+++ b/example/lib/chat_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma_example/chat_widget.dart';
 import 'package:flutter_gemma_example/loading_widget.dart';
 import 'package:flutter_gemma_example/models/model.dart';
-import 'package:flutter_gemma_example/model_selection_screen.dart';
 import 'package:flutter_gemma_example/services/auth_token_service.dart';
 
 class ChatScreen extends StatefulWidget {
@@ -24,7 +23,7 @@ class ChatScreenState extends State<ChatScreen> {
   bool _isStreaming = false; // Track streaming state
   String? _error;
   Color _backgroundColor = const Color(0xFF0b2351);
-  String _appTitle = 'Flutter Gemma Example'; // Track the current app title
+  late String _appTitle; // App bar title; tool calls can override after load
 
   // Toggle for sync/async mode
   bool _useSyncMode = false;
@@ -82,6 +81,7 @@ class ChatScreenState extends State<ChatScreen> {
   @override
   void initState() {
     super.initState();
+    _appTitle = widget.model.displayName;
     _initializeModel();
   }
 
@@ -314,27 +314,31 @@ class ChatScreenState extends State<ChatScreen> {
         backgroundColor: _backgroundColor,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () {
-            Navigator.pushAndRemoveUntil(
-              context,
-              MaterialPageRoute<void>(
-                builder: (context) => const ModelSelectionScreen(),
-              ),
-              (route) => false,
-            );
-          },
+          onPressed: () => Navigator.of(context).maybePop(),
+          tooltip: 'Back',
         ),
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              _appTitle,
+              widget.model.displayName,
               style: const TextStyle(fontSize: 18),
               softWrap: true,
               overflow: TextOverflow.ellipsis,
               maxLines: 1,
             ),
-            if (chat?.supportsImages == true)
+            if (_appTitle != widget.model.displayName)
+              Text(
+                _appTitle,
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Colors.white70,
+                  fontWeight: FontWeight.normal,
+                ),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+              )
+            else if (chat?.supportsImages == true)
               const Text(
                 'Image support enabled',
                 style: TextStyle(

--- a/example/lib/chat_screen.dart
+++ b/example/lib/chat_screen.dart
@@ -337,8 +337,8 @@ class ChatScreenState extends State<ChatScreen> {
                 ),
                 overflow: TextOverflow.ellipsis,
                 maxLines: 1,
-              )
-            else if (chat?.supportsImages == true)
+              ),
+            if (chat?.supportsImages == true)
               const Text(
                 'Image support enabled',
                 style: TextStyle(

--- a/example/lib/downloaded_models_screen.dart
+++ b/example/lib/downloaded_models_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma_example/chat_screen.dart';
+import 'package:flutter_gemma_example/services/downloaded_model_deleter.dart';
 import 'package:flutter_gemma_example/services/downloaded_model_loader.dart';
 import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
 
@@ -31,6 +32,7 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
   List<_DownloadedModelEntry> _entries = [];
   Set<String> _loadedIds = {};
   String? _loadingId;
+  String? _deletingId;
 
   @override
   void initState() {
@@ -76,6 +78,7 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
         _entries = entries;
         _loadedIds = loadedIds;
         _loadingId = null;
+        _deletingId = null;
         _loading = false;
       });
     } catch (e) {
@@ -104,6 +107,59 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
       ),
       body: _buildBody(),
     );
+  }
+
+  Future<void> _confirmDelete(_DownloadedModelEntry entry) async {
+    if (_loadingId != null || _deletingId != null) return;
+
+    final match = resolveCatalog(entry.id);
+    final deletesTokenizerToo =
+        match is EmbeddingMatch && !match.isTokenizer;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete model?'),
+        content: Text(
+          deletesTokenizerToo
+              ? 'Remove ${entry.displayName} and its tokenizer from this device?'
+              : 'Remove ${entry.displayName} from this device?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    setState(() {
+      _deletingId = entry.id;
+    });
+
+    try {
+      await DownloadedModelDeleter.delete(entry.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Deleted ${entry.displayName}')),
+      );
+      await _load();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _deletingId = null;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to delete model: $e')),
+      );
+    }
   }
 
   Future<void> _loadEntry(_DownloadedModelEntry entry) async {
@@ -209,26 +265,44 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
         final entry = _entries[index];
         final isLoaded = _loadedIds.contains(entry.id);
         final isLoading = _loadingId == entry.id;
+        final isDeleting = _deletingId == entry.id;
+        final isBusy = _loadingId != null || _deletingId != null;
         final showSubtitle = entry.displayName != entry.id || entry.isTokenizer;
+        final canDelete = !entry.isTokenizer;
 
-        Widget? trailing;
-        if (isLoading) {
-          trailing = const SizedBox(
-            width: 20,
-            height: 20,
-            child: CircularProgressIndicator(strokeWidth: 2),
+        final trailingChildren = <Widget>[];
+        if (isLoading || isDeleting) {
+          trailingChildren.add(
+            const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
           );
-        } else if (isLoaded) {
-          trailing = const Chip(
-            label: Text('Loaded'),
-            backgroundColor: Color(0xFF1a5c3a),
-            labelStyle: TextStyle(color: Colors.white, fontSize: 12),
-          );
+        } else {
+          if (isLoaded) {
+            trailingChildren.add(
+              const Chip(
+                label: Text('Loaded'),
+                backgroundColor: Color(0xFF1a5c3a),
+                labelStyle: TextStyle(color: Colors.white, fontSize: 12),
+              ),
+            );
+          }
+          if (canDelete) {
+            trailingChildren.add(
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Delete',
+                onPressed: isBusy ? null : () => _confirmDelete(entry),
+              ),
+            );
+          }
         }
 
         return ListTile(
-          enabled: entry.loadable && _loadingId == null,
-          onTap: entry.loadable ? () => _loadEntry(entry) : null,
+          enabled: entry.loadable && !isBusy,
+          onTap: entry.loadable && !isBusy ? () => _loadEntry(entry) : null,
           title: Text(entry.displayName),
           subtitle: showSubtitle
               ? Text(
@@ -238,7 +312,12 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
                   style: const TextStyle(color: Colors.white54, fontSize: 12),
                 )
               : null,
-          trailing: trailing,
+          trailing: trailingChildren.isEmpty
+              ? null
+              : Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: trailingChildren,
+                ),
         );
       },
     );

--- a/example/lib/downloaded_models_screen.dart
+++ b/example/lib/downloaded_models_screen.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_example/chat_screen.dart';
+import 'package:flutter_gemma_example/services/downloaded_model_loader.dart';
+import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
+
+class _DownloadedModelEntry {
+  const _DownloadedModelEntry({
+    required this.id,
+    required this.displayName,
+    required this.loadable,
+    required this.isTokenizer,
+  });
+
+  final String id;
+  final String displayName;
+  final bool loadable;
+  final bool isTokenizer;
+}
+
+class DownloadedModelsScreen extends StatefulWidget {
+  const DownloadedModelsScreen({super.key});
+
+  @override
+  State<DownloadedModelsScreen> createState() => _DownloadedModelsScreenState();
+}
+
+class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
+  bool _loading = true;
+  String? _error;
+  List<_DownloadedModelEntry> _entries = [];
+  Set<String> _loadedIds = {};
+  String? _loadingId;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final installed = await FlutterGemma.listInstalledModels();
+      final loadedIds = loadedModelIds();
+
+      final entries = installed
+          .where(isDownloadedModelArtifact)
+          .map(
+            (id) {
+              final match = resolveCatalog(id);
+              return _DownloadedModelEntry(
+                id: id,
+                displayName: match?.displayName ?? id,
+                loadable: isLoadableArtifact(id),
+                isTokenizer: match is EmbeddingMatch && match.isTokenizer,
+              );
+            },
+          )
+          .toList();
+
+      entries.sort((a, b) {
+        final aLoaded = loadedIds.contains(a.id);
+        final bLoaded = loadedIds.contains(b.id);
+        if (aLoaded && !bLoaded) return -1;
+        if (bLoaded && !aLoaded) return 1;
+        return a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase());
+      });
+
+      if (!mounted) return;
+      setState(() {
+        _entries = entries;
+        _loadedIds = loadedIds;
+        _loadingId = null;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0b2351),
+      appBar: AppBar(
+        title: const Text('Downloaded Models'),
+        backgroundColor: const Color(0xFF0b2351),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _load,
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Future<void> _loadEntry(_DownloadedModelEntry entry) async {
+    if (_loadingId != null || !entry.loadable) return;
+    setState(() {
+      _loadingId = entry.id;
+    });
+
+    try {
+      final match = resolveCatalog(entry.id);
+      await DownloadedModelLoader.load(entry.id);
+      if (!mounted) return;
+      if (match case InferenceMatch(:final model)) {
+        await Navigator.push<void>(
+          context,
+          MaterialPageRoute<void>(
+            builder: (context) => ChatScreen(model: model),
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Loaded ${entry.displayName}')),
+        );
+      }
+      await _load();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loadingId = null;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to load model: $e')),
+      );
+    }
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, color: Colors.redAccent, size: 48),
+              const SizedBox(height: 16),
+              Text(
+                'Failed to load models',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.white70),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(onPressed: _load, child: const Text('Retry')),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_entries.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.download_outlined, size: 64, color: Colors.white54),
+              SizedBox(height: 16),
+              Text(
+                'No downloaded models yet',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 8),
+              Text(
+                'Download a model from Inference, Translation, or Embedding Models.',
+                style: TextStyle(fontSize: 14, color: Colors.white70),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: _entries.length,
+      itemBuilder: (context, index) {
+        final entry = _entries[index];
+        final isLoaded = _loadedIds.contains(entry.id);
+        final isLoading = _loadingId == entry.id;
+        final showSubtitle = entry.displayName != entry.id || entry.isTokenizer;
+
+        Widget? trailing;
+        if (isLoading) {
+          trailing = const SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          );
+        } else if (isLoaded) {
+          trailing = const Chip(
+            label: Text('Loaded'),
+            backgroundColor: Color(0xFF1a5c3a),
+            labelStyle: TextStyle(color: Colors.white, fontSize: 12),
+          );
+        }
+
+        return ListTile(
+          enabled: entry.loadable && _loadingId == null,
+          onTap: entry.loadable ? () => _loadEntry(entry) : null,
+          title: Text(entry.displayName),
+          subtitle: showSubtitle
+              ? Text(
+                  entry.isTokenizer
+                      ? '${entry.id} • Tokenizer file (loaded with embedding model)'
+                      : entry.id,
+                  style: const TextStyle(color: Colors.white54, fontSize: 12),
+                )
+              : null,
+          trailing: trailing,
+        );
+      },
+    );
+  }
+}

--- a/example/lib/downloaded_models_screen.dart
+++ b/example/lib/downloaded_models_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma_example/chat_screen.dart';
 import 'package:flutter_gemma_example/services/downloaded_model_deleter.dart';
@@ -162,6 +163,22 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
     }
   }
 
+  Future<void> _copyPath(_DownloadedModelEntry entry) async {
+    try {
+      final path = await resolveInstalledModelPath(entry.id);
+      await Clipboard.setData(ClipboardData(text: path));
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Copied path for ${entry.displayName}')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to copy path: $e')),
+      );
+    }
+  }
+
   Future<void> _loadEntry(_DownloadedModelEntry entry) async {
     if (_loadingId != null || !entry.loadable) return;
     setState(() {
@@ -279,25 +296,30 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
               child: CircularProgressIndicator(strokeWidth: 2),
             ),
           );
-        } else {
-          if (isLoaded) {
-            trailingChildren.add(
-              const Chip(
-                label: Text('Loaded'),
-                backgroundColor: Color(0xFF1a5c3a),
-                labelStyle: TextStyle(color: Colors.white, fontSize: 12),
-              ),
-            );
-          }
-          if (canDelete) {
-            trailingChildren.add(
-              IconButton(
-                icon: const Icon(Icons.delete_outline),
-                tooltip: 'Delete',
-                onPressed: isBusy ? null : () => _confirmDelete(entry),
-              ),
-            );
-          }
+        } else if (isLoaded) {
+          trailingChildren.add(
+            const Chip(
+              label: Text('Loaded'),
+              backgroundColor: Color(0xFF1a5c3a),
+              labelStyle: TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          );
+        }
+        trailingChildren.add(
+          IconButton(
+            icon: const Icon(Icons.copy_outlined),
+            tooltip: 'Copy path',
+            onPressed: () => _copyPath(entry),
+          ),
+        );
+        if (!isLoading && !isDeleting && canDelete) {
+          trailingChildren.add(
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Delete',
+              onPressed: isBusy ? null : () => _confirmDelete(entry),
+            ),
+          );
         }
 
         return ListTile(
@@ -312,12 +334,10 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
                   style: const TextStyle(color: Colors.white54, fontSize: 12),
                 )
               : null,
-          trailing: trailingChildren.isEmpty
-              ? null
-              : Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: trailingChildren,
-                ),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: trailingChildren,
+          ),
         );
       },
     );

--- a/example/lib/downloaded_models_screen.dart
+++ b/example/lib/downloaded_models_screen.dart
@@ -113,9 +113,9 @@ class _DownloadedModelsScreenState extends State<DownloadedModelsScreen> {
   Future<void> _confirmDelete(_DownloadedModelEntry entry) async {
     if (_loadingId != null || _deletingId != null) return;
 
-    final match = resolveCatalog(entry.id);
     final deletesTokenizerToo =
-        match is EmbeddingMatch && !match.isTokenizer;
+        await DownloadedModelDeleter.willUninstallTokenizer(entry.id);
+    if (!mounted) return;
 
     final confirmed = await showDialog<bool>(
       context: context,

--- a/example/lib/home_screen.dart
+++ b/example/lib/home_screen.dart
@@ -1,10 +1,43 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gemma_example/model_selection_screen.dart';
+import 'package:flutter_gemma_example/downloaded_models_screen.dart';
 import 'package:flutter_gemma_example/embedding_models_screen.dart';
+import 'package:flutter_gemma_example/model_selection_screen.dart';
 import 'package:flutter_gemma_example/translate_models_screen.dart';
+import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  bool _downloadCheckComplete = false;
+  bool _hasDownloadedModels = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshDownloadedVisibility();
+  }
+
+  Future<void> _refreshDownloadedVisibility() async {
+    final hasDownloaded = await hasDownloadedModels();
+    if (!mounted) return;
+    setState(() {
+      _hasDownloadedModels = hasDownloaded;
+      _downloadCheckComplete = true;
+    });
+  }
+
+  Future<void> _push(Widget screen) async {
+    await Navigator.push<void>(
+      context,
+      MaterialPageRoute<void>(builder: (context) => screen),
+    );
+    await _refreshDownloadedVisibility();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,19 +73,37 @@ class HomeScreen extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 48),
+            if (_downloadCheckComplete && _hasDownloadedModels) ...[
+              const Padding(
+                padding: EdgeInsets.only(left: 4, bottom: 12),
+                child: Text(
+                  'On this device',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white54,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+              ),
+              _NavigationCard(
+                title: 'Downloaded Models',
+                subtitle:
+                    'View installed inference, translation, and embedding models',
+                icon: Icons.folder_open,
+                color: Colors.teal,
+                onTap: () => _push(const DownloadedModelsScreen()),
+              ),
+              const SizedBox(height: 32),
+              const Divider(color: Colors.white24, height: 1),
+              const SizedBox(height: 16),
+            ],
             _NavigationCard(
               title: 'Inference Models',
               subtitle: 'Browse and test all available Gemma models',
               icon: Icons.model_training,
               color: Colors.blue,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (context) => const ModelSelectionScreen(),
-                  ),
-                );
-              },
+              onTap: () => _push(const ModelSelectionScreen()),
             ),
             const SizedBox(height: 16),
             _NavigationCard(
@@ -60,14 +111,7 @@ class HomeScreen extends StatelessWidget {
               subtitle: 'On-device translation with TranslateGemma',
               icon: Icons.translate,
               color: Colors.orange,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (context) => const TranslateModelsScreen(),
-                  ),
-                );
-              },
+              onTap: () => _push(const TranslateModelsScreen()),
             ),
             const SizedBox(height: 16),
             _NavigationCard(
@@ -75,14 +119,7 @@ class HomeScreen extends StatelessWidget {
               subtitle: 'Download and test embedding models for RAG',
               icon: Icons.search,
               color: Colors.green,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (context) => const EmbeddingModelsScreen(),
-                  ),
-                );
-              },
+              onTap: () => _push(const EmbeddingModelsScreen()),
             ),
           ],
         ),

--- a/example/lib/model_download_screen.dart
+++ b/example/lib/model_download_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gemma/pigeon.g.dart';
 import 'package:flutter_gemma_example/chat_screen.dart';
 import 'package:flutter_gemma_example/services/model_download_service.dart';
+import 'package:flutter_gemma_example/utils/gated_model_access_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'models/model.dart';
@@ -78,9 +79,19 @@ class _ModelDownloadScreenState extends State<ModelDownloadScreen> {
         needToDownload = false;
       });
     } catch (e) {
-      scaffoldMessenger.showSnackBar(
-        const SnackBar(content: Text('Failed to download the model.')),
-      );
+      if (!mounted) return;
+      if (isGatedAccessError(e)) {
+        await showGatedModelAccessDialog(
+          context: context,
+          modelUrl: widget.model.url,
+          licenseUrl: widget.model.licenseUrl,
+          error: e,
+        );
+      } else {
+        scaffoldMessenger.showSnackBar(
+          const SnackBar(content: Text('Failed to download the model.')),
+        );
+      }
     } finally {
       if (mounted) {
         setState(() {

--- a/example/lib/model_selection_screen.dart
+++ b/example/lib/model_selection_screen.dart
@@ -110,6 +110,12 @@ class _ModelSelectionScreenState extends State<ModelSelectionScreen> {
       appBar: AppBar(
         title: const Text('Select a Model'),
         backgroundColor: const Color(0xFF0b2351),
+        foregroundColor: Colors.white,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+          tooltip: 'Back',
+        ),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/example/lib/services/downloaded_model_deleter.dart
+++ b/example/lib/services/downloaded_model_deleter.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_example/services/downloaded_model_loader.dart';
+import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
+
+class DownloadedModelDeleter {
+  const DownloadedModelDeleter._();
+
+  static Future<void> delete(String installedId) async {
+    if (loadedModelIds().contains(installedId)) {
+      await DownloadedModelLoader.unloadAllInMemory();
+    }
+
+    final match = resolveCatalog(installedId);
+    if (match is EmbeddingMatch && !match.isTokenizer) {
+      await FlutterGemma.uninstallModel(installedId);
+      final tokenizerId = match.model.tokenizerFilename;
+      if (tokenizerId != installedId &&
+          await FlutterGemma.isModelInstalled(tokenizerId)) {
+        await FlutterGemma.uninstallModel(tokenizerId);
+      }
+      return;
+    }
+
+    await FlutterGemma.uninstallModel(installedId);
+  }
+}

--- a/example/lib/services/downloaded_model_deleter.dart
+++ b/example/lib/services/downloaded_model_deleter.dart
@@ -5,6 +5,21 @@ import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
 class DownloadedModelDeleter {
   const DownloadedModelDeleter._();
 
+  /// Whether deleting [installedId] will also remove its shared tokenizer file.
+  static Future<bool> willUninstallTokenizer(String installedId) async {
+    final match = resolveCatalog(installedId);
+    if (match is! EmbeddingMatch || match.isTokenizer) return false;
+
+    final tokenizerId = match.model.tokenizerFilename;
+    if (tokenizerId == installedId) return false;
+    if (!await FlutterGemma.isModelInstalled(tokenizerId)) return false;
+
+    return !await isEmbeddingTokenizerStillNeeded(
+      tokenizerFilename: tokenizerId,
+      removedModelFilename: installedId,
+    );
+  }
+
   static Future<void> delete(String installedId) async {
     if (loadedModelIds().contains(installedId)) {
       await DownloadedModelLoader.unloadAllInMemory();
@@ -15,12 +30,27 @@ class DownloadedModelDeleter {
       await FlutterGemma.uninstallModel(installedId);
       final tokenizerId = match.model.tokenizerFilename;
       if (tokenizerId != installedId &&
-          await FlutterGemma.isModelInstalled(tokenizerId)) {
+          await FlutterGemma.isModelInstalled(tokenizerId) &&
+          !await isEmbeddingTokenizerStillNeeded(
+            tokenizerFilename: tokenizerId,
+            removedModelFilename: installedId,
+          )) {
         await FlutterGemma.uninstallModel(tokenizerId);
       }
+      await _clearActiveIdentityIfUninstalled(installedId);
       return;
     }
 
     await FlutterGemma.uninstallModel(installedId);
+    await _clearActiveIdentityIfUninstalled(installedId);
+  }
+
+  static Future<void> _clearActiveIdentityIfUninstalled(String installedId) async {
+    if (activeInferenceModelId() == installedId) {
+      await FlutterGemma.clearActiveInferenceIdentity();
+    }
+    if (isActiveEmbeddingArtifact(installedId)) {
+      await FlutterGemma.clearActiveEmbeddingIdentity();
+    }
   }
 }

--- a/example/lib/services/downloaded_model_loader.dart
+++ b/example/lib/services/downloaded_model_loader.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_example/models/base_model.dart';
+import 'package:flutter_gemma_example/services/auth_token_service.dart';
+import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
+
+class DownloadedModelLoader {
+  const DownloadedModelLoader._();
+
+  static Future<void> unloadAllInMemory() async {
+    final plugin = FlutterGemmaPlugin.instance;
+    await plugin.initializedModel?.close();
+    await plugin.initializedEmbeddingModel?.close();
+  }
+
+  static Future<void> load(String installedId) async {
+    final loaded = loadedModelIds();
+    if (loaded.length == 1 && loaded.contains(installedId)) {
+      return;
+    }
+
+    final match = resolveCatalog(installedId);
+    if (match == null) {
+      throw StateError('Cannot load unknown model: $installedId');
+    }
+
+    if (match is EmbeddingMatch && match.isTokenizer) {
+      throw StateError('Tokenizer files cannot be loaded directly');
+    }
+
+    await unloadAllInMemory();
+
+    if (match is InferenceMatch) {
+      await _loadInference(match);
+      return;
+    }
+    if (match is TranslationMatch) {
+      await _loadTranslation(match);
+      return;
+    }
+    if (match is EmbeddingMatch) {
+      await _loadEmbedding(match);
+      return;
+    }
+  }
+
+  static Future<void> _loadInference(InferenceMatch match) async {
+    final model = match.model;
+    final installer = FlutterGemma.installModel(
+      modelType: model.modelType,
+      fileType: model.fileType,
+    );
+
+    if (model.localModel) {
+      await installer.fromAsset(model.url).install();
+    } else {
+      String? token;
+      if (model.needsAuth) {
+        token = await AuthTokenService.loadToken();
+      }
+      await installer.fromNetwork(model.url, token: token).install();
+    }
+
+    await FlutterGemma.getActiveModel(
+      maxTokens: model.maxTokens,
+      preferredBackend: model.preferredBackend,
+      supportImage: model.supportImage,
+      supportAudio: model.supportAudio,
+      maxNumImages: model.maxNumImages,
+    );
+  }
+
+  static Future<void> _loadTranslation(TranslationMatch match) async {
+    final model = match.model;
+    String? token;
+    if (model.needsAuth) {
+      token = await AuthTokenService.loadToken();
+    }
+
+    await FlutterGemma.installModel(
+      modelType: model.modelType,
+      fileType: model.fileType,
+    ).fromNetwork(model.url, token: token).install();
+
+    await FlutterGemma.getActiveModel(
+      maxTokens: model.maxTokens,
+      preferredBackend: PreferredBackend.cpu,
+    );
+  }
+
+  static Future<void> _loadEmbedding(EmbeddingMatch match) async {
+    final model = match.model;
+    String? token;
+    if (model.needsAuth) {
+      token = await AuthTokenService.loadToken();
+    }
+
+    var builder = FlutterGemma.installEmbedder();
+
+    switch (model.sourceType) {
+      case ModelSourceType.network:
+        builder = builder.modelFromNetwork(model.url, token: token);
+      case ModelSourceType.asset:
+        builder = builder.modelFromAsset(model.url);
+      case ModelSourceType.bundled:
+        builder = builder.modelFromBundled(model.url);
+    }
+
+    switch (model.sourceType) {
+      case ModelSourceType.network:
+        builder = builder.tokenizerFromNetwork(model.tokenizerUrl, token: token);
+      case ModelSourceType.asset:
+        builder = builder.tokenizerFromAsset(model.tokenizerUrl);
+      case ModelSourceType.bundled:
+        builder = builder.tokenizerFromBundled(model.tokenizerUrl);
+    }
+
+    await builder.install();
+    await FlutterGemma.getActiveEmbedder(preferredBackend: PreferredBackend.gpu);
+
+    if (kDebugMode) {
+      debugPrint('[DownloadedModelLoader] Loaded embedding model: ${model.filename}');
+    }
+  }
+}

--- a/example/lib/universal_download_screen.dart
+++ b/example/lib/universal_download_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_gemma_example/models/translate_model.dart';
 import 'package:flutter_gemma_example/services/model_download_service.dart';
 import 'package:flutter_gemma_example/services/embedding_download_service.dart';
 import 'package:flutter_gemma_example/translate_screen.dart';
+import 'package:flutter_gemma_example/utils/gated_model_access_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UniversalDownloadScreen extends StatefulWidget {
@@ -159,7 +160,7 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
         needToDownload = false;
       });
     } catch (e) {
-      _showErrorDialog(e.toString());
+      await _handleDownloadError(e);
     }
   }
 
@@ -178,7 +179,21 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
         _tokenizerProgress = 0.0;
       });
     } catch (e) {
-      _showErrorDialog(e.toString());
+      await _handleDownloadError(e);
+    }
+  }
+
+  Future<void> _handleDownloadError(Object error) async {
+    if (!mounted) return;
+    if (isGatedAccessError(error)) {
+      await showGatedModelAccessDialog(
+        context: context,
+        modelUrl: widget.model.url,
+        licenseUrl: widget.model.licenseUrl,
+        error: error,
+      );
+    } else {
+      _showErrorDialog(error.toString());
     }
   }
 

--- a/example/lib/universal_download_screen.dart
+++ b/example/lib/universal_download_screen.dart
@@ -494,9 +494,9 @@ class _UniversalDownloadScreenState extends State<UniversalDownloadScreen> {
         );
         break;
       case ModelKind.inference:
-        Navigator.push(
+        Navigator.pushReplacement(
           context,
-          MaterialPageRoute(
+          MaterialPageRoute<void>(
             builder: (context) => ChatScreen(
               model: widget.model as Model,
               selectedBackend: widget.selectedBackend ?? PreferredBackend.cpu,

--- a/example/lib/utils/gated_model_access_dialog.dart
+++ b/example/lib/utils/gated_model_access_dialog.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+final _accessToModelPattern = RegExp(
+  r'Access to model ([\w.-]+/[\w.-]+)',
+  caseSensitive: false,
+);
+
+Object? _exceptionCause(Object error) {
+  try {
+    final dynamic exception = error;
+    final cause = exception.cause;
+    if (cause is Object) return cause;
+  } catch (_) {}
+  return null;
+}
+
+/// Returns true when the download failed due to missing/invalid HF auth or
+/// gated-repo access (HTTP 401/403).
+bool isGatedAccessError(Object error) {
+  Object? current = error;
+  final seen = <int>{};
+
+  while (current != null) {
+    final identity = identityHashCode(current);
+    if (!seen.add(identity)) break;
+
+    if (current is DownloadException) {
+      return switch (current.error) {
+        UnauthorizedError() || ForbiddenError() => true,
+        _ => false,
+      };
+    }
+
+    final cause = _exceptionCause(current);
+    if (cause != null) {
+      current = cause;
+      continue;
+    }
+
+    break;
+  }
+
+  final message = error.toString().toLowerCase();
+  final hasAuthStatus =
+      message.contains('401') || message.contains('403') || message.contains('unauthorized');
+  final looksGated = message.contains('restricted') ||
+      message.contains('authenticated') ||
+      message.contains('access denied') ||
+      message.contains('authentication failed') ||
+      message.contains('access forbidden');
+  return hasAuthStatus && looksGated;
+}
+
+/// Resolves the Hugging Face model repo page for [modelUrl] and [error].
+String huggingFaceModelPageUrl({
+  required String modelUrl,
+  String? licenseUrl,
+  Object? error,
+}) {
+  final fromUrl = _repoPageFromHuggingFaceUrl(modelUrl);
+  if (fromUrl != null) return fromUrl;
+
+  if (error != null) {
+    final match = _accessToModelPattern.firstMatch(error.toString());
+    if (match != null) {
+      return 'https://huggingface.co/${match.group(1)}';
+    }
+  }
+
+  if (licenseUrl != null && licenseUrl.isNotEmpty) {
+    return licenseUrl;
+  }
+
+  return 'https://huggingface.co/settings/tokens';
+}
+
+String? _repoPageFromHuggingFaceUrl(String url) {
+  try {
+    final uri = Uri.parse(url);
+    if (!uri.host.contains('huggingface.co')) return null;
+    if (uri.pathSegments.length < 2) return null;
+
+    final org = uri.pathSegments[0];
+    final repo = uri.pathSegments[1];
+    if (org == 'resolve' || org == 'api' || org == 'datasets') return null;
+    return 'https://huggingface.co/$org/$repo';
+  } catch (_) {
+    return null;
+  }
+}
+
+bool _isForbidden(Object error) {
+  Object? current = error;
+  final seen = <int>{};
+
+  while (current != null) {
+    final identity = identityHashCode(current);
+    if (!seen.add(identity)) break;
+
+    if (current is DownloadException) {
+      return current.error is ForbiddenError;
+    }
+
+    final cause = _exceptionCause(current);
+    if (cause != null) {
+      current = cause;
+      continue;
+    }
+
+    break;
+  }
+
+  final message = error.toString().toLowerCase();
+  return message.contains('403') || message.contains('forbidden') || message.contains('access denied');
+}
+
+/// Shows a dialog explaining gated-model access with a link to the HF repo page.
+Future<void> showGatedModelAccessDialog({
+  required BuildContext context,
+  required String modelUrl,
+  String? licenseUrl,
+  required Object error,
+}) {
+  final modelPageUrl = huggingFaceModelPageUrl(
+    modelUrl: modelUrl,
+    licenseUrl: licenseUrl,
+    error: error,
+  );
+  final isForbidden = _isForbidden(error);
+
+  return showDialog<void>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(isForbidden ? 'Model access required' : 'Authentication required'),
+      content: Text(
+        isForbidden
+            ? 'This model is gated on Hugging Face. Open the model page, sign in, '
+                'accept the license if prompted, and request access. Then retry the '
+                'download with a token that has read access to the repository.'
+            : 'Download failed because Hugging Face rejected the request. Save a valid '
+                'access token with read-repo permission, accept the model license on '
+                'Hugging Face if required, then try again.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(dialogContext),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () async {
+            final uri = Uri.parse(modelPageUrl);
+            if (await canLaunchUrl(uri)) {
+              await launchUrl(uri, mode: LaunchMode.externalApplication);
+            }
+            if (dialogContext.mounted) {
+              Navigator.pop(dialogContext);
+            }
+          },
+          child: const Text('Open on Hugging Face'),
+        ),
+      ],
+    ),
+  );
+}

--- a/example/lib/utils/gated_model_access_dialog.dart
+++ b/example/lib/utils/gated_model_access_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -151,8 +152,28 @@ Future<void> showGatedModelAccessDialog({
         FilledButton(
           onPressed: () async {
             final uri = Uri.parse(modelPageUrl);
-            if (await canLaunchUrl(uri)) {
-              await launchUrl(uri, mode: LaunchMode.externalApplication);
+            var launched = false;
+            try {
+              if (await canLaunchUrl(uri)) {
+                launched = await launchUrl(
+                  uri,
+                  mode: LaunchMode.externalApplication,
+                );
+              }
+            } catch (_) {
+              launched = false;
+            }
+            if (!launched) {
+              await Clipboard.setData(ClipboardData(text: modelPageUrl));
+              if (dialogContext.mounted) {
+                ScaffoldMessenger.of(dialogContext).showSnackBar(
+                  const SnackBar(
+                    content: Text(
+                      'Could not open browser. URL copied to clipboard.',
+                    ),
+                  ),
+                );
+              }
             }
             if (dialogContext.mounted) {
               Navigator.pop(dialogContext);

--- a/example/lib/utils/installed_model_lookup.dart
+++ b/example/lib/utils/installed_model_lookup.dart
@@ -56,20 +56,47 @@ Future<bool> hasDownloadedModels() async {
   return installed.any(isDownloadedModelArtifact);
 }
 
+String? _inferenceModelFilenameFromSpec(InferenceModelSpec spec) {
+  final files = spec.files;
+  if (files.isEmpty) return null;
+
+  for (final file in files) {
+    if (file.isRequired) return file.filename;
+  }
+  // Legacy/corrupt specs with no required entry: avoid LoRA-only identity.
+  return files.first.filename;
+}
+
+String? _embeddingModelFilenameFromSpec(EmbeddingModelSpec spec) {
+  final files = spec.files;
+  if (files.isEmpty) return null;
+
+  for (final file in files) {
+    if (file.filename.toLowerCase().endsWith('.tflite')) {
+      return file.filename;
+    }
+  }
+  // Non-.tflite model weights (exclude tokenizer sidecar files).
+  for (final file in files) {
+    final lower = file.filename.toLowerCase();
+    if (lower.endsWith('.model') || lower.endsWith('.json')) continue;
+    return file.filename;
+  }
+  return null;
+}
+
 String? activeInferenceModelId() {
   if (!FlutterGemma.hasActiveModel()) return null;
   final spec = FlutterGemmaPlugin.instance.modelManager.activeInferenceModel;
   if (spec is! InferenceModelSpec) return null;
-  return spec.files.firstWhere((f) => f.isRequired).filename;
+  return _inferenceModelFilenameFromSpec(spec);
 }
 
 String? activeEmbeddingModelId() {
   if (!FlutterGemma.hasActiveEmbedder()) return null;
   final spec = FlutterGemmaPlugin.instance.modelManager.activeEmbeddingModel;
   if (spec is! EmbeddingModelSpec) return null;
-  return spec.files
-      .map((f) => f.filename)
-      .firstWhere((name) => name.toLowerCase().endsWith('.tflite'));
+  return _embeddingModelFilenameFromSpec(spec);
 }
 
 /// Filenames marked active in the plugin (inference + embedding).
@@ -218,4 +245,26 @@ DownloadedCatalogMatch? resolveCatalog(String installedId) {
   }
 
   return null;
+}
+
+/// True if [tokenizerFilename] should stay installed after removing [removedModelFilename].
+Future<bool> isEmbeddingTokenizerStillNeeded({
+  required String tokenizerFilename,
+  required String removedModelFilename,
+}) async {
+  final installed = await FlutterGemma.listInstalledModels();
+  for (final model in example_embedding.EmbeddingModel.values) {
+    if (model.tokenizerFilename != tokenizerFilename) continue;
+    if (model.filename == removedModelFilename) continue;
+    if (installed.contains(model.filename)) return true;
+  }
+  return false;
+}
+
+/// Whether uninstalling [installedId] clears the active embedding identity.
+bool isActiveEmbeddingArtifact(String installedId) {
+  if (!FlutterGemma.hasActiveEmbedder()) return false;
+  final spec = FlutterGemmaPlugin.instance.modelManager.activeEmbeddingModel;
+  if (spec is! EmbeddingModelSpec) return false;
+  return spec.files.any((file) => file.filename == installedId);
 }

--- a/example/lib/utils/installed_model_lookup.dart
+++ b/example/lib/utils/installed_model_lookup.dart
@@ -1,0 +1,195 @@
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_example/models/embedding_model.dart' as example_embedding;
+import 'package:flutter_gemma_example/models/model.dart';
+import 'package:flutter_gemma_example/models/translate_model.dart';
+
+bool isInferenceOrTranslationArtifact(String id) {
+  final lower = id.toLowerCase();
+  return lower.endsWith('.task') ||
+      lower.endsWith('.bin') ||
+      lower.endsWith('.litertlm');
+}
+
+bool isEmbeddingArtifact(String id) {
+  final lower = id.toLowerCase();
+  return lower.endsWith('.tflite') || lower.endsWith('.model');
+}
+
+bool isDownloadedModelArtifact(String id) {
+  return isInferenceOrTranslationArtifact(id) || isEmbeddingArtifact(id);
+}
+
+bool isLoadableArtifact(String id) {
+  final lower = id.toLowerCase();
+  return isInferenceOrTranslationArtifact(id) || lower.endsWith('.tflite');
+}
+
+/// Whether any inference, translation, or embedding model files are installed.
+Future<bool> hasDownloadedModels() async {
+  final installed = await FlutterGemma.listInstalledModels();
+  return installed.any(isDownloadedModelArtifact);
+}
+
+String? activeInferenceModelId() {
+  if (!FlutterGemma.hasActiveModel()) return null;
+  final spec = FlutterGemmaPlugin.instance.modelManager.activeInferenceModel;
+  if (spec is! InferenceModelSpec) return null;
+  return spec.files.firstWhere((f) => f.isRequired).filename;
+}
+
+String? activeEmbeddingModelId() {
+  if (!FlutterGemma.hasActiveEmbedder()) return null;
+  final spec = FlutterGemmaPlugin.instance.modelManager.activeEmbeddingModel;
+  if (spec is! EmbeddingModelSpec) return null;
+  return spec.files
+      .map((f) => f.filename)
+      .firstWhere((name) => name.toLowerCase().endsWith('.tflite'));
+}
+
+/// Filenames marked active in the plugin (inference + embedding).
+Set<String> activeModelIds() {
+  final ids = <String>{};
+  final inferenceId = activeInferenceModelId();
+  if (inferenceId != null) {
+    ids.add(inferenceId);
+  }
+  if (FlutterGemma.hasActiveEmbedder()) {
+    final spec = FlutterGemmaPlugin.instance.modelManager.activeEmbeddingModel;
+    if (spec is EmbeddingModelSpec) {
+      for (final file in spec.files) {
+        ids.add(file.filename);
+      }
+    }
+  }
+  return ids;
+}
+
+Set<String> loadedModelIds() {
+  final ids = <String>{};
+  final plugin = FlutterGemmaPlugin.instance;
+
+  if (plugin.initializedModel != null) {
+    final inferenceId = activeInferenceModelId();
+    if (inferenceId != null) {
+      ids.add(inferenceId);
+    }
+  }
+
+  if (plugin.initializedEmbeddingModel != null) {
+    final embeddingId = activeEmbeddingModelId();
+    if (embeddingId != null) {
+      ids.add(embeddingId);
+    }
+  }
+
+  return ids;
+}
+
+sealed class DownloadedCatalogMatch {
+  const DownloadedCatalogMatch();
+
+  String get displayName;
+}
+
+final class InferenceMatch extends DownloadedCatalogMatch {
+  const InferenceMatch(this.model);
+
+  final Model model;
+
+  @override
+  String get displayName => model.displayName;
+}
+
+final class TranslationMatch extends DownloadedCatalogMatch {
+  const TranslationMatch(this.model);
+
+  final TranslateModel model;
+
+  @override
+  String get displayName => model.displayName;
+}
+
+final class EmbeddingMatch extends DownloadedCatalogMatch {
+  const EmbeddingMatch({
+    required this.model,
+    required this.isTokenizer,
+  });
+
+  final example_embedding.EmbeddingModel model;
+  final bool isTokenizer;
+
+  @override
+  String get displayName =>
+      isTokenizer ? '${model.displayName} (tokenizer)' : model.displayName;
+}
+
+String? _urlLastSegment(String url) {
+  if (url.isEmpty) return null;
+  final segments = Uri.parse(url).pathSegments;
+  return segments.isNotEmpty ? segments.last : null;
+}
+
+bool _matchesInstalledId(
+  String installedId, {
+  required String filename,
+  required String url,
+  String? webUrl,
+  String? desktopUrl,
+}) {
+  if (installedId == filename) return true;
+  if (_urlLastSegment(url) == installedId) return true;
+  final web = webUrl;
+  if (web != null && web.isNotEmpty && _urlLastSegment(web) == installedId) {
+    return true;
+  }
+  final desktop = desktopUrl;
+  if (desktop != null &&
+      desktop.isNotEmpty &&
+      _urlLastSegment(desktop) == installedId) {
+    return true;
+  }
+  return false;
+}
+
+DownloadedCatalogMatch? resolveCatalog(String installedId) {
+  for (final model in Model.values) {
+    if (_matchesInstalledId(
+      installedId,
+      filename: model.filename,
+      url: model.url,
+      webUrl: model.webUrl,
+      desktopUrl: model.desktopUrl,
+    )) {
+      return InferenceMatch(model);
+    }
+  }
+
+  for (final model in TranslateModel.values) {
+    if (_matchesInstalledId(
+      installedId,
+      filename: model.filename,
+      url: model.url,
+    )) {
+      return TranslationMatch(model);
+    }
+  }
+
+  for (final model in example_embedding.EmbeddingModel.values) {
+    if (_matchesInstalledId(
+      installedId,
+      filename: model.filename,
+      url: model.url,
+    )) {
+      return EmbeddingMatch(model: model, isTokenizer: false);
+    }
+    if (_matchesInstalledId(
+      installedId,
+      filename: model.tokenizerFilename,
+      url: model.tokenizerUrl,
+    )) {
+      return EmbeddingMatch(model: model, isTokenizer: true);
+    }
+  }
+
+  return null;
+}

--- a/example/lib/utils/installed_model_lookup.dart
+++ b/example/lib/utils/installed_model_lookup.dart
@@ -1,7 +1,33 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_gemma/core/di/service_registry.dart';
+import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma_example/models/embedding_model.dart' as example_embedding;
 import 'package:flutter_gemma_example/models/model.dart';
 import 'package:flutter_gemma_example/models/translate_model.dart';
+
+/// Resolves the on-disk path (or web URL) for an installed model file.
+Future<String> resolveInstalledModelPath(String installedId) async {
+  final registry = ServiceRegistry.instance;
+  final info = await registry.modelRepository.loadModel(installedId);
+  final source = info?.source;
+  if (source != null) {
+    switch (source) {
+      case FileSource(:final path):
+        return path;
+      case NetworkSource(:final url) when kIsWeb:
+        return url;
+      case AssetSource(:final path) when kIsWeb:
+        return path;
+      case BundledSource(:final resourceName):
+        return registry.fileSystemService.getBundledResourcePath(resourceName);
+      case NetworkSource():
+      case AssetSource():
+        break;
+    }
+  }
+  return registry.fileSystemService.getReadTargetPath(installedId);
+}
 
 bool isInferenceOrTranslationArtifact(String id) {
   final lower = id.toLowerCase();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.16.2"
+    version: "0.16.4"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/core/api/flutter_gemma.dart
+++ b/lib/core/api/flutter_gemma.dart
@@ -357,6 +357,14 @@ class FlutterGemma {
     return manager.activeEmbeddingModel is EmbeddingModelSpec;
   }
 
+  /// Clears the active inference identity (in-memory spec + persisted prefs).
+  static Future<void> clearActiveInferenceIdentity() =>
+      FlutterGemmaPlugin.instance.modelManager.clearActiveInferenceIdentity();
+
+  /// Clears the active embedding identity (in-memory spec + persisted prefs).
+  static Future<void> clearActiveEmbeddingIdentity() =>
+      FlutterGemmaPlugin.instance.modelManager.clearActiveEmbeddingIdentity();
+
   /// Uninstall a model
   ///
   /// Removes model metadata and files (if not protected).

--- a/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/lib/core/model_management/managers/mobile_model_manager.dart
@@ -784,6 +784,38 @@ class MobileModelManager extends ModelFileManager {
     debugPrint('Model cache cleared');
   }
 
+  @override
+  Future<void> clearActiveInferenceIdentity() async {
+    await _ensureInitialized();
+    _activeInferenceModel = null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(PreferencesKeys.activeInferenceModelType);
+      await prefs.remove(PreferencesKeys.activeInferenceFileType);
+      await prefs.remove(PreferencesKeys.activeInferenceFilename);
+      await prefs.remove(PreferencesKeys.activeInferenceSource);
+    } catch (e) {
+      debugPrint('[ModelManager] clearActiveInferenceIdentity failed: $e');
+    }
+    debugPrint('Active inference identity cleared');
+  }
+
+  @override
+  Future<void> clearActiveEmbeddingIdentity() async {
+    await _ensureInitialized();
+    _activeEmbeddingModel = null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(PreferencesKeys.activeEmbeddingFilename);
+      await prefs.remove(PreferencesKeys.activeEmbeddingTokenizerFilename);
+      await prefs.remove(PreferencesKeys.activeEmbeddingSource);
+      await prefs.remove(PreferencesKeys.activeEmbeddingTokenizerSource);
+    } catch (e) {
+      debugPrint('[ModelManager] clearActiveEmbeddingIdentity failed: $e');
+    }
+    debugPrint('Active embedding identity cleared');
+  }
+
   // === Active Model Management ===
 
   ModelSpec? _activeInferenceModel;

--- a/lib/core/model_management/managers/web_model_manager.dart
+++ b/lib/core/model_management/managers/web_model_manager.dart
@@ -762,6 +762,38 @@ class WebModelManager extends ModelFileManager {
     debugPrint('WebModelManager: Model cache cleared (active models reset)');
   }
 
+  @override
+  Future<void> clearActiveInferenceIdentity() async {
+    await _ensureInitialized();
+    _activeInferenceModel = null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(PreferencesKeys.activeInferenceModelType);
+      await prefs.remove(PreferencesKeys.activeInferenceFileType);
+      await prefs.remove(PreferencesKeys.activeInferenceFilename);
+      await prefs.remove(PreferencesKeys.activeInferenceSource);
+    } catch (e) {
+      debugPrint('[WebModelManager] clearActiveInferenceIdentity failed: $e');
+    }
+    debugPrint('WebModelManager: active inference identity cleared');
+  }
+
+  @override
+  Future<void> clearActiveEmbeddingIdentity() async {
+    await _ensureInitialized();
+    _activeEmbeddingModel = null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(PreferencesKeys.activeEmbeddingFilename);
+      await prefs.remove(PreferencesKeys.activeEmbeddingTokenizerFilename);
+      await prefs.remove(PreferencesKeys.activeEmbeddingSource);
+      await prefs.remove(PreferencesKeys.activeEmbeddingTokenizerSource);
+    } catch (e) {
+      debugPrint('[WebModelManager] clearActiveEmbeddingIdentity failed: $e');
+    }
+    debugPrint('WebModelManager: active embedding identity cleared');
+  }
+
   // === Legacy LoRA Management Methods Implementation ===
 
   @override

--- a/lib/flutter_gemma.dart
+++ b/lib/flutter_gemma.dart
@@ -34,6 +34,10 @@ export 'core/api/embedding_installation_builder.dart';
 // Export Web-specific types
 export 'core/domain/web_storage_mode.dart';
 
+// Download error types (401/403 gated models, etc.)
+export 'core/domain/download_error.dart';
+export 'core/domain/download_exception.dart';
+
 // Export Model Specs (needed for advanced use cases)
 export 'mobile/flutter_gemma_mobile.dart'
     show

--- a/lib/model_file_manager_interface.dart
+++ b/lib/model_file_manager_interface.dart
@@ -75,6 +75,12 @@ abstract class ModelFileManager {
   /// Clears current model cache/state
   Future<void> clearModelCache();
 
+  /// Clears the active inference identity (in-memory spec + persisted prefs).
+  Future<void> clearActiveInferenceIdentity();
+
+  /// Clears the active embedding identity (in-memory spec + persisted prefs).
+  Future<void> clearActiveEmbeddingIdentity();
+
   /// Legacy API: Sets path to LoRA weights for current model
   @Deprecated('Use FlutterGemma.installModel().withLoraFromFile() instead')
   Future<void> setLoraWeightsPath(String path);


### PR DESCRIPTION
Making the example app a bit more intuitive by:
- Showing a list of downloaded models
- Showing a dialog for gated models that need to be granted permission through Huggingface
- Highlighting the currently loaded model
- Adding a lauch.json
- Allowing to easily copy the model path so that you can easily download and copy it in your own app
- Fixing a bug in the model download screen where the back arrow would not appear
- Adjusting back-navigation logic


<img width="912" height="1154" alt="Screenshot 2026-06-03 at 13 48 14" src="https://github.com/user-attachments/assets/7de38152-6fe6-4524-bf72-9aa27ef2d9ce" />
<img width="912" height="1267" alt="Screenshot 2026-06-03 at 12 09 21" src="https://github.com/user-attachments/assets/a7df52bc-d5a3-4a50-b251-402ae97dadaf" />
<img width="912" height="1267" alt="Screenshot 2026-06-03 at 12 09 31" src="https://github.com/user-attachments/assets/a1a17f82-a0f6-47ad-ae32-234f7876178b" />

