### PR TITLE
Enable function calls for Gemma 4 E2B/E4B in example (#303)

### DIFF
--- a/example/lib/models/model.dart
+++ b/example/lib/models/model.dart
@@ -44,6 +44,7 @@ enum Model implements InferenceModelInterface {
     maxTokens: 4096,
     maxNumImages: 4,
     isThinking: true,
+    supportsFunctionCalls: true,
   ),
   gemma4_E4B(
     baseUrl:
@@ -68,6 +69,7 @@ enum Model implements InferenceModelInterface {
     maxTokens: 4096,
     maxNumImages: 4,
     isThinking: true,
+    supportsFunctionCalls: true,
   ),
 
   // Gemma 4 E2B compiled for Intel NPU (Windows only, PreferredBackend.npu).


### PR DESCRIPTION
Fixes #303.

The example model list never set `supportsFunctionCalls` for the Gemma 4 entries, so it defaulted to `false` — Gemma 4 was hidden under the "Function Calls" filter even though it supports native function-call tokens (and the README lists it as Full function-calling).

Added `supportsFunctionCalls: true` to `gemma4_E2B` and `gemma4_E4B`.

Verified on macOS: a Gemma 4 chat created with both tools and an image returns a `FunctionCallResponse` (`change_color{color: blue}` from an image+text prompt) — function calling and multimodal don't conflict.
