### PR TITLE
fix(mobile): give each createSession a fresh native session (#308)

### DIFF
--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -239,6 +239,14 @@ class MobileInferenceModelSession extends InferenceModelSession {
 
   @override
   Future<void> close() async {
+    // Idempotent: a second close must not run native `closeSession()`
+    // again. With the singleton-session lifecycle (a fresh createSession
+    // supersedes the prior wrapper), a superseded wrapper and the live
+    // one can both be closed by a caller; without this guard the stale
+    // close would tear down the *current* native session (closeSession
+    // is argument-less and closes whatever session is active). See the
+    // createSession comment and issue #308.
+    if (_isClosed) return;
     _isClosed = true;
 
     // Cancel event subscription first to stop receiving events

--- a/lib/mobile/flutter_gemma_mobile_inference_model.dart
+++ b/lib/mobile/flutter_gemma_mobile_inference_model.dart
@@ -127,11 +127,35 @@ class MobileInferenceModel extends InferenceModel {
       throw StateError(
           'Model is closed. Create a new instance to use it again');
     }
+    // Single-flight guard for genuinely *concurrent* callers only. Unlike
+    // the model singleton, a session is NOT reused across calls: each
+    // createSession (and therefore each createChat) must yield a fresh
+    // native session with a clean KV cache. The completer is cleared in
+    // the `finally` below once creation settles, so a *sequential* second
+    // call falls through to the native createSession — which closes the
+    // prior session and creates a new one (FlutterGemmaPlugin.createSession
+    // does `session?.close(); session = engine.createSession(...)`) —
+    // instead of returning the stale wrapper. Without this, the cached
+    // completer made every later createChat reuse the first session, so
+    // the previous conversation's KV cache bled into the next chat (the
+    // app sends a clean prompt; the model still conditions on the old
+    // context). See https://github.com/DenisovAV/flutter_gemma/issues/308.
     if (_createCompleter case Completer<InferenceModelSession> completer) {
       return completer.future;
     }
     final completer = _createCompleter = Completer<InferenceModelSession>();
     try {
+      // Close any prior singleton session before creating the next so its
+      // Dart-side resources (event subscription, stream controller) are
+      // released and stray calls on the old wrapper throw `Model is
+      // closed` cleanly instead of silently hitting the new native
+      // session. The native layer also closes the old session, but doing
+      // it here keeps the orphaned wrapper's `_isClosed` flag honest and
+      // means at most one live wrapper maps to the single native session.
+      if (_session case final previous?) {
+        await previous.close();
+      }
+
       // LoRA support is fully integrated via Modern API (InferenceInstallationBuilder)
       final resolvedLoraPath = loraPath;
 
@@ -149,23 +173,41 @@ class MobileInferenceModel extends InferenceModel {
         enableThinking: enableThinking,
       );
 
-      final session = _session = MobileInferenceModelSession(
+      late final MobileInferenceModelSession session;
+      session = MobileInferenceModelSession(
         modelType: modelType,
         fileType: fileType,
         supportImage: enableVisionModality ?? supportImage,
         supportAudio: enableAudioModality ?? supportAudio,
         systemInstruction: systemInstruction,
+        // Identity-guarded so a late close of a superseded session can't
+        // null a newer `_session`. Does NOT touch `_createCompleter` —
+        // that is owned by the `finally` below, not by session teardown.
         onClose: () {
-          _session = null;
-          _createCompleter = null;
+          if (identical(_session, session)) _session = null;
         },
       );
+      _session = session;
       completer.complete(session);
-      return session;
     } catch (e, st) {
       completer.completeError(e, st);
-      Error.throwWithStackTrace(e, st);
+    } finally {
+      // Pure in-flight guard: clear once creation settles (success OR
+      // failure) so the next call isn't blocked by a cached completer.
+      // Previously the completer was only cleared by the session's
+      // onClose, which (a) made it a permanent cache across createChat
+      // calls — the issue #308 KV-cache bleed — and (b) left a failed
+      // creation permanently caching a rejected future, blocking retry
+      // (the same class as the model-level issue #170 fix).
+      _createCompleter = null;
     }
+    // Returning `completer.future` (rather than the session / a rethrow)
+    // keeps the caller as the error listener even after the completer is
+    // cleared above, and mirrors the createModel idiom (issue #170). A
+    // concurrent caller that hit the early `return completer.future`
+    // shares this exact future, so success and failure both fan out to
+    // every in-flight caller.
+    return completer.future;
   }
 
   @override

--- a/test/mobile/session_creation_reuse_test.dart
+++ b/test/mobile/session_creation_reuse_test.dart
@@ -1,0 +1,283 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression coverage for issue #308 — `MobileInferenceModel.createSession`
+/// short-circuits on a cached `_createCompleter`, so every `createChat`
+/// after the first reuses the same native session and the previous
+/// conversation's KV cache bleeds into the next chat.
+/// https://github.com/DenisovAV/flutter_gemma/issues/308
+///
+/// Mirrors the distilled-logic style of `model_creation_failure_test.dart`
+/// (issue #170, the model-level version of this same completer bug): rather
+/// than spin up the pigeon platform channel + native engine, the completer /
+/// session lifecycle is modelled in a `Buggy`/`Fixed` pair so the bug and
+/// the fix are asserted directly against the logic that changed.
+///
+/// The native contract being modelled (`FlutterGemmaPlugin.createSession`):
+///   session?.close();                       // close the prior session
+///   session = engine.createSession(config); // create a fresh one
+/// i.e. the native layer already gives every createSession a clean session.
+/// The bug is purely Dart-side: the cached completer means native
+/// createSession is never invoked the second time.
+
+/// Models the native `PlatformService` session calls. `createSession`
+/// closes any open native session and opens a fresh one (matching the
+/// Kotlin `session?.close(); session = engine.createSession(...)`).
+class MockPlatformService {
+  int createSessionCallCount = 0;
+  int closeSessionCallCount = 0;
+
+  /// Monotonic id of the currently-open native session, or 0 when none.
+  int activeNativeSessionId = 0;
+  int _nextNativeSessionId = 0;
+  bool shouldFail = false;
+
+  Future<void> createSession() async {
+    createSessionCallCount++;
+    if (shouldFail) {
+      throw Exception('Session creation failed');
+    }
+    // Native side closes the prior session and opens a new one.
+    activeNativeSessionId = ++_nextNativeSessionId;
+  }
+
+  Future<void> closeSession() async {
+    closeSessionCallCount++;
+    activeNativeSessionId = 0;
+  }
+
+  void reset() {
+    createSessionCallCount = 0;
+    closeSessionCallCount = 0;
+    activeNativeSessionId = 0;
+    _nextNativeSessionId = 0;
+    shouldFail = false;
+  }
+}
+
+/// A session wrapper that records which native session it was created
+/// against, so a test can assert "this wrapper's calls hit native session
+/// N" — the property KV-cache isolation depends on.
+class MockSession {
+  MockSession({
+    required this.platform,
+    required this.nativeSessionId,
+    required this.onClose,
+  });
+
+  final MockPlatformService platform;
+  final int nativeSessionId;
+  final void Function(MockSession session) onClose;
+  bool isClosed = false;
+
+  Future<void> close({bool idempotent = false}) async {
+    if (idempotent && isClosed) return;
+    isClosed = true;
+    onClose(this);
+    await platform.closeSession();
+  }
+}
+
+/// The current (buggy) `createSession` completer logic: the completer is a
+/// permanent cache — once a session is created it is returned for every
+/// subsequent call until that session is closed.
+class BuggySessionCreator {
+  BuggySessionCreator(this.platform);
+
+  final MockPlatformService platform;
+  Completer<MockSession>? _createCompleter;
+
+  Future<MockSession> createSession() async {
+    // BUG: cached completer short-circuits across *sequential* calls — and
+    // is only ever cleared by the session's onClose, so it acts as a
+    // permanent cache rather than an in-flight guard.
+    if (_createCompleter case final completer?) {
+      return completer.future;
+    }
+    final completer = _createCompleter = Completer<MockSession>();
+    try {
+      await platform.createSession();
+      final session = MockSession(
+        platform: platform,
+        nativeSessionId: platform.activeNativeSessionId,
+        onClose: (_) {
+          _createCompleter = null; // only cleared on close
+        },
+      );
+      completer.complete(session);
+      return session;
+    } catch (e, st) {
+      // BUG: completer not cleared on failure → permanent rejected cache.
+      completer.completeError(e, st);
+      rethrow;
+    }
+  }
+}
+
+/// The fixed `createSession` logic: the completer is a pure in-flight guard
+/// (cleared once creation settles), the prior session is closed before the
+/// next is created, and `onClose` is identity-guarded.
+class FixedSessionCreator {
+  FixedSessionCreator(this.platform);
+
+  final MockPlatformService platform;
+  MockSession? _session;
+  Completer<MockSession>? _createCompleter;
+
+  Future<MockSession> createSession() async {
+    // In-flight guard for concurrent callers only.
+    if (_createCompleter case final completer?) {
+      return completer.future;
+    }
+    final completer = _createCompleter = Completer<MockSession>();
+    try {
+      // Close any prior singleton session before creating the next.
+      if (_session case final previous?) {
+        await previous.close(idempotent: true);
+      }
+      await platform.createSession();
+      late final MockSession session;
+      session = MockSession(
+        platform: platform,
+        nativeSessionId: platform.activeNativeSessionId,
+        onClose: (_) {
+          if (identical(_session, session)) _session = null;
+        },
+      );
+      _session = session;
+      completer.complete(session);
+    } catch (e, st) {
+      completer.completeError(e, st);
+    } finally {
+      // Pure in-flight guard: cleared on success OR failure.
+      _createCompleter = null;
+    }
+    // Return the completer's future so the caller stays the error
+    // listener even after the completer field is cleared (mirrors the
+    // createModel idiom from issue #170).
+    return completer.future;
+  }
+}
+
+void main() {
+  late MockPlatformService platform;
+
+  setUp(() => platform = MockPlatformService());
+  tearDown(() => platform.reset());
+
+  group('Issue #308 — createSession reuses the cached session (bug)', () {
+    test(
+        'BUG: second createSession returns the SAME session, native '
+        'createSession never called again — KV cache bleeds', () async {
+      final creator = BuggySessionCreator(platform);
+
+      final a = await creator.createSession();
+      final b = await creator.createSession();
+
+      expect(platform.createSessionCallCount, 1,
+          reason: 'BUG: native createSession not called for the 2nd chat');
+      expect(identical(a, b), isTrue,
+          reason: 'BUG: both chats share one session');
+      expect(a.nativeSessionId, b.nativeSessionId,
+          reason: 'BUG: same native session → prior KV cache is reused');
+    });
+
+    test(
+        'BUG: a failed createSession permanently caches the rejected '
+        'future, blocking retry', () async {
+      final creator = BuggySessionCreator(platform);
+
+      platform.shouldFail = true;
+      await expectLater(creator.createSession(), throwsException);
+
+      platform.shouldFail = false;
+      await expectLater(creator.createSession(), throwsException,
+          reason: 'BUG: cached rejected completer blocks the retry');
+      expect(platform.createSessionCallCount, 1,
+          reason: 'BUG: native createSession not retried');
+    });
+  });
+
+  group('Issue #308 — createSession yields a fresh session (fix)', () {
+    test('FIX: second createSession creates a FRESH native session', () async {
+      final creator = FixedSessionCreator(platform);
+
+      final a = await creator.createSession();
+      final b = await creator.createSession();
+
+      expect(platform.createSessionCallCount, 2,
+          reason: 'FIX: native createSession runs for each chat');
+      expect(identical(a, b), isFalse,
+          reason: 'FIX: each chat gets its own wrapper');
+      expect(a.nativeSessionId != b.nativeSessionId, isTrue,
+          reason: 'FIX: distinct native sessions → no KV-cache bleed');
+    });
+
+    test('FIX: the prior session is closed before the next is created',
+        () async {
+      final creator = FixedSessionCreator(platform);
+
+      final a = await creator.createSession();
+      expect(a.isClosed, isFalse);
+
+      await creator.createSession();
+      expect(a.isClosed, isTrue,
+          reason: 'FIX: old wrapper is closed so stray use throws cleanly');
+      expect(platform.closeSessionCallCount, 1,
+          reason: 'FIX: exactly one close for the superseded session');
+    });
+
+    test('FIX: a failed createSession does not block retry', () async {
+      final creator = FixedSessionCreator(platform);
+
+      platform.shouldFail = true;
+      await expectLater(creator.createSession(), throwsException);
+
+      platform.shouldFail = false;
+      final session = await creator.createSession();
+      expect(session.nativeSessionId, greaterThan(0));
+      expect(platform.createSessionCallCount, 2,
+          reason: 'FIX: completer cleared on failure → retry runs');
+    });
+
+    test(
+        'FIX: concurrent createSession calls still dedupe to one native '
+        'session (in-flight guard preserved)', () async {
+      final creator = FixedSessionCreator(platform);
+
+      final results = await Future.wait([
+        creator.createSession(),
+        creator.createSession(),
+        creator.createSession(),
+      ]);
+
+      expect(platform.createSessionCallCount, 1,
+          reason: 'concurrent callers share one in-flight creation');
+      expect(identical(results[0], results[1]), isTrue);
+      expect(identical(results[1], results[2]), isTrue);
+    });
+
+    test(
+        'FIX: idempotent close — closing a superseded session does NOT '
+        'tear down the current native session', () async {
+      final creator = FixedSessionCreator(platform);
+
+      final a = await creator.createSession(); // native session 1
+      final b = await creator.createSession(); // native session 2 (a closed)
+
+      expect(a.isClosed, isTrue);
+      expect(b.isClosed, isFalse);
+      final closesAfterSupersede = platform.closeSessionCallCount;
+
+      // A consumer that still holds the old chat closes it. Idempotent
+      // close must NOT call native closeSession again (which would close
+      // session 2, since closeSession is argument-less).
+      await a.close(idempotent: true);
+
+      expect(platform.closeSessionCallCount, closesAfterSupersede,
+          reason: 'idempotent close on the stale wrapper is a no-op');
+      expect(b.isClosed, isFalse, reason: 'the current session stays open');
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes #308.

`MobileInferenceModel.createSession` cached its `_createCompleter` and only cleared it from the session's `onClose`, so the completer acted as a **permanent cache** rather than an in-flight guard. Every `createChat` after the first short-circuited on the cached completer and returned the *same* `MobileInferenceModelSession` wrapper — and crucially never re-invoked the native `createSession`, which is the call that closes the prior session and opens a fresh one:

```kotlin
// FlutterGemmaPlugin.createSession (Android)
session?.close()
session = currentEngine.createSession(config)
```

So a single `InferenceModel` driving two sequential chats shared one native session, and the first conversation's KV cache bled into the second. The app sends a clean prompt; the model still conditions on the previous context. Because `LlmPromptLog`-style logging captures the bytes sent to `addQueryChunk` (not the engine's KV cache), the bleed is invisible without inspecting native state — which is what made the original report hard to pin down.

### The fix

The completer is now a **pure in-flight guard**, cleared in a `finally` once creation settles (success *or* failure):

- **Sequential** `createSession` calls fall through to the native create-and-replace, so each chat gets a clean KV cache (the issue #308 fix).
- A **failed** creation no longer caches a rejected future that blocks retry — the same bug class already fixed at the model level in #170 (`model_creation_failure_test.dart`).
- **Concurrent** callers still dedupe onto one in-flight creation (the guard's original purpose is preserved).

Supporting changes for the singleton-session lifecycle:

- `createSession` closes the prior `_session` before creating the next, so the orphaned wrapper's Dart-side resources (event subscription, stream controller) are released and stray calls on it throw `Model is closed` cleanly instead of silently hitting the new native session.
- `onClose` is identity-guarded so a late close of a superseded session can't null a newer `_session`, and it no longer touches `_createCompleter` (owned by the `finally` now).
- `MobileInferenceModelSession.close()` is now **idempotent** — a second close (e.g. a consumer closing a superseded chat) must not run native `closeSession()` again, which would tear down the *current* session (`closeSession` is argument-less).
- `createSession` returns `completer.future` so the caller stays the error listener after the completer field is cleared (mirrors the `createModel` idiom from #170).

### Scope note

The FFI/litert legacy `createSession` (`lib/core/ffi/ffi_inference_model.dart`) has the same completer-cache shape. I left it out to keep this PR scoped to the issue (and the MediaPipe path is what #308 names) — happy to follow up with the same treatment if you'd like it in here or as a separate PR.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition

## Testing
- [ ] Tested on Android
- [ ] Tested on iOS
- [ ] Tested on Web
- [ ] Tested on Desktop (macOS/Windows)

Logic is covered by a new unit test rather than device testing — see below. The full existing suite (`flutter test`) passes (393 tests) and `flutter analyze` is clean on the changed files.

`test/mobile/session_creation_reuse_test.dart` is a distilled Buggy/Fixed logic pair mirroring `model_creation_failure_test.dart` (#170): it models the completer + session lifecycle (no platform channel needed) and asserts the bug (shared session across `createChat`, blocked retry after failure) and the fix (fresh native session per chat, prior session closed first, retry after failure works, concurrent dedupe preserved, idempotent close doesn't tear down the live session).

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated (no public API change)
- [x] No new warnings (`flutter analyze` clean on changed files)
- [x] Tests added/updated
