### PR TITLE
fix(ffi): give each createSession a fresh conversation handle (#308)

### DIFF
--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -101,6 +101,17 @@ class FfiInferenceModel extends InferenceModel {
     final sessionSw = Stopwatch()..start();
 
     try {
+      // Legacy singleton lane: close the previous conversation BEFORE
+      // opening a fresh one. The engine holds at most one live
+      // conversation (upstream litert-lm #966), so closing first never
+      // leaves two alive — matching the delete-before-create order the
+      // virtual-session multiplexer already uses. It also means a
+      // teardown error can't leak a handle that was created first and
+      // then left unwrapped: each session owns its own conversation
+      // pointer, so closing the old one can't touch the not-yet-created
+      // new one. See PR #310 review.
+      await _session?.close();
+
       // For Gemma 4, push tools into the SDK conversation config so it can
       // render native `<|tool>declaration:...<tool|>` tokens via minja. Other
       // model types still use Dart-side prompt injection in chat.dart.
@@ -109,8 +120,6 @@ class FfiInferenceModel extends InferenceModel {
           : null;
 
       final beforeConv = sessionSw.elapsedMilliseconds;
-      // Legacy singleton lane: close the previous conversation (if any) and
-      // open a fresh one. Mirrors the pre-multi-session overwrite contract.
       final handle = ffiClient.createConversationHandle(
         systemMessage: systemInstruction,
         toolsJson: toolsJson,
@@ -119,7 +128,6 @@ class FfiInferenceModel extends InferenceModel {
         topP: topP,
         seed: randomSeed,
       );
-      await _session?.close();
       debugPrint(
           '[FfiInferenceModel/perf] createConversation (FFI): ${sessionSw.elapsedMilliseconds - beforeConv}ms');
 

--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -85,6 +85,14 @@ class FfiInferenceModel extends InferenceModel {
       );
     }
 
+    // Single-flight guard for genuinely *concurrent* callers only. The
+    // completer is cleared in the `finally` below once creation settles,
+    // so a *sequential* second call falls through and opens a fresh
+    // conversation handle (closing the prior session first) instead of
+    // returning the cached session. Without this, the cached completer
+    // made every later createChat reuse the first session, so the
+    // previous conversation's KV cache bled into the next chat. This is
+    // the litert/FFI sibling of the MediaPipe fix in #309 (issue #308).
     if (_createCompleter case Completer<InferenceModelSession> completer) {
       return completer.future;
     }
@@ -115,28 +123,39 @@ class FfiInferenceModel extends InferenceModel {
       debugPrint(
           '[FfiInferenceModel/perf] createConversation (FFI): ${sessionSw.elapsedMilliseconds - beforeConv}ms');
 
-      final session = _session = FfiInferenceModelSession(
+      late final FfiInferenceModelSession session;
+      session = FfiInferenceModelSession(
         handle: handle,
         modelType: modelType,
         fileType: fileType,
         supportImage: enableVisionModality ?? supportImage,
         supportAudio: enableAudioModality ?? supportAudio,
         enableThinking: enableThinking,
+        // Identity-guarded so a late close of a superseded session can't
+        // null a newer `_session`. Does NOT touch `_createCompleter` —
+        // that is owned by the `finally` below, not by session teardown.
         onClose: () {
-          _session = null;
-          _createCompleter = null;
+          if (identical(_session, session)) _session = null;
         },
       );
+      _session = session;
 
       completer.complete(session);
       debugPrint(
           '[FfiInferenceModel/perf] createSession total: ${sessionSw.elapsedMilliseconds}ms');
-      return session;
     } catch (e, st) {
       completer.completeError(e, st);
+    } finally {
+      // Pure in-flight guard: clear once creation settles (success OR
+      // failure) so the next call isn't blocked by a cached completer
+      // (the issue #308 KV-cache bleed on success; a permanently cached
+      // rejected future on failure).
       _createCompleter = null;
-      rethrow;
     }
+    // Return `completer.future` (rather than the session / a rethrow) so
+    // the caller stays the error listener after the completer field is
+    // cleared above, and concurrent callers share the same result.
+    return completer.future;
   }
 
   @override
@@ -496,6 +515,11 @@ class FfiInferenceModelSession extends InferenceModelSession
 
   @override
   Future<void> close() async {
+    // Idempotent: a superseded singleton session and the live one can both
+    // be closed by a caller, and createSession also closes the prior
+    // session before opening a new one — a second close must not re-run
+    // handle.close() / onClose(). See the createSession comment and #308.
+    if (_isClosed) return;
     _isClosed = true;
     _queryBuffer.clear();
     _pendingImages.clear();

--- a/test/core/ffi/session_creation_reuse_test.dart
+++ b/test/core/ffi/session_creation_reuse_test.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression coverage for issue #308 on the litert/FFI path —
+/// `FfiInferenceModel.createSession` short-circuits on a cached
+/// `_createCompleter`, so every `createChat` after the first reuses the
+/// same conversation handle and the previous conversation's KV cache
+/// bleeds into the next chat. This is the FFI sibling of the MediaPipe
+/// fix in #309.
+/// https://github.com/DenisovAV/flutter_gemma/issues/308
+///
+/// Mirrors the distilled-logic style of `test/mobile/session_creation_reuse_test.dart`
+/// (the #309 MediaPipe regression) and `model_creation_failure_test.dart`
+/// (#170, the model-level version of this completer bug): the completer /
+/// session lifecycle is modelled in a `Buggy`/`Fixed` pair so the bug and
+/// the fix are asserted directly against the logic that changed, without
+/// needing a real FFI client (whose `createConversationHandle` returns a
+/// concrete handle type that can't be faked through the public surface).
+///
+/// FFI specifics modelled here:
+///   * each session owns its OWN `ConversationHandle` (not a shared native
+///     session), created by `ffiClient.createConversationHandle`;
+///   * `createSession` already closes the prior session before opening the
+///     next — but the cached-completer short-circuit means the second call
+///     never reaches that close, so it hands back the stale session.
+
+class MockFfiClient {
+  int createHandleCallCount = 0;
+  bool shouldFail = false;
+
+  MockHandle createConversationHandle() {
+    createHandleCallCount++;
+    if (shouldFail) {
+      throw Exception('Conversation handle creation failed');
+    }
+    return MockHandle(id: createHandleCallCount);
+  }
+}
+
+class MockHandle {
+  MockHandle({required this.id});
+
+  final int id;
+  bool closed = false;
+
+  void close() {
+    closed = true;
+  }
+}
+
+/// The current (buggy) `createSession` completer logic: the completer is a
+/// permanent cache — once a session is created it is returned for every
+/// subsequent call until that session is closed.
+class BuggyFfiSessionCreator {
+  BuggyFfiSessionCreator(this.client);
+
+  final MockFfiClient client;
+  FakeFfiSession? _session;
+  Completer<FakeFfiSession>? _createCompleter;
+
+  Future<FakeFfiSession> createSession() async {
+    // BUG: cached completer short-circuits across *sequential* calls, so
+    // the new handle + prior-session-close below never run for call 2+.
+    if (_createCompleter case final completer?) {
+      return completer.future;
+    }
+    final completer = _createCompleter = Completer<FakeFfiSession>();
+    try {
+      final handle = client.createConversationHandle();
+      await _session?.close();
+      final session = FakeFfiSession(
+        handle: handle,
+        onClose: () {
+          _session = null;
+          _createCompleter = null; // only cleared on close
+        },
+      );
+      _session = session;
+      completer.complete(session);
+      return session;
+    } catch (e, st) {
+      completer.completeError(e, st);
+      _createCompleter = null;
+      rethrow;
+    }
+  }
+}
+
+/// The fixed logic: completer is a pure in-flight guard (cleared once
+/// creation settles), the prior session is closed before the next is
+/// created, `onClose` is identity-guarded, and `completer.future` is
+/// returned so the caller stays the error listener.
+class FixedFfiSessionCreator {
+  FixedFfiSessionCreator(this.client);
+
+  final MockFfiClient client;
+  FakeFfiSession? _session;
+  Completer<FakeFfiSession>? _createCompleter;
+
+  Future<FakeFfiSession> createSession() async {
+    if (_createCompleter case final completer?) {
+      return completer.future;
+    }
+    final completer = _createCompleter = Completer<FakeFfiSession>();
+    try {
+      final handle = client.createConversationHandle();
+      await _session?.close();
+      late final FakeFfiSession session;
+      session = FakeFfiSession(
+        handle: handle,
+        onClose: () {
+          if (identical(_session, session)) _session = null;
+        },
+      );
+      _session = session;
+      completer.complete(session);
+    } catch (e, st) {
+      completer.completeError(e, st);
+    } finally {
+      _createCompleter = null;
+    }
+    return completer.future;
+  }
+}
+
+class FakeFfiSession {
+  FakeFfiSession({required this.handle, required this.onClose});
+
+  final MockHandle handle;
+  final void Function() onClose;
+  bool _isClosed = false;
+
+  Future<void> close() async {
+    if (_isClosed) return; // idempotent
+    _isClosed = true;
+    handle.close();
+    onClose();
+  }
+}
+
+void main() {
+  late MockFfiClient client;
+
+  setUp(() => client = MockFfiClient());
+
+  group('Issue #308 (FFI) — createSession reuses the cached session (bug)', () {
+    test(
+        'BUG: second createSession returns the SAME session, no fresh '
+        'handle — KV cache bleeds', () async {
+      final creator = BuggyFfiSessionCreator(client);
+
+      final a = await creator.createSession();
+      final b = await creator.createSession();
+
+      expect(client.createHandleCallCount, 1,
+          reason: 'BUG: no fresh conversation handle for the 2nd chat');
+      expect(identical(a, b), isTrue);
+      expect(a.handle.id, b.handle.id,
+          reason: 'BUG: same handle → prior KV cache is reused');
+    });
+
+    // NOTE: unlike the MediaPipe original (#309), the FFI buggy path
+    // already clears `_createCompleter` in its catch, so a *failed*
+    // createSession does not block retry here — the cache-on-success
+    // bleed above is the only FFI bug. The fix preserves that
+    // already-correct failure behaviour (see the FIX retry test below).
+  });
+
+  group('Issue #308 (FFI) — createSession yields a fresh session (fix)', () {
+    test('FIX: second createSession opens a FRESH handle', () async {
+      final creator = FixedFfiSessionCreator(client);
+
+      final a = await creator.createSession();
+      final b = await creator.createSession();
+
+      expect(client.createHandleCallCount, 2);
+      expect(identical(a, b), isFalse);
+      expect(a.handle.id != b.handle.id, isTrue,
+          reason: 'FIX: distinct handles → no KV-cache bleed');
+    });
+
+    test('FIX: the prior session is closed before the next is created',
+        () async {
+      final creator = FixedFfiSessionCreator(client);
+
+      final a = await creator.createSession();
+      expect(a.handle.closed, isFalse);
+
+      await creator.createSession();
+      expect(a.handle.closed, isTrue,
+          reason: 'FIX: old handle closed so its KV cache is released');
+    });
+
+    test('FIX: a failed createSession does not block retry', () async {
+      final creator = FixedFfiSessionCreator(client);
+
+      client.shouldFail = true;
+      await expectLater(creator.createSession(), throwsException);
+      client.shouldFail = false;
+      final session = await creator.createSession();
+      expect(session.handle.id, greaterThan(0));
+      expect(client.createHandleCallCount, 2,
+          reason: 'FIX: completer cleared on failure → retry runs');
+    });
+
+    test('FIX: concurrent createSession calls dedupe to one handle', () async {
+      final creator = FixedFfiSessionCreator(client);
+
+      final results = await Future.wait([
+        creator.createSession(),
+        creator.createSession(),
+        creator.createSession(),
+      ]);
+
+      expect(client.createHandleCallCount, 1,
+          reason: 'concurrent callers share one in-flight creation');
+      expect(identical(results[0], results[1]), isTrue);
+      expect(identical(results[1], results[2]), isTrue);
+    });
+
+    test(
+        'FIX: idempotent close — closing a superseded session does not '
+        'double-close its handle', () async {
+      final creator = FixedFfiSessionCreator(client);
+
+      final a = await creator.createSession(); // handle 1
+      await creator.createSession(); // handle 2 (a closed once)
+      expect(a.handle.closed, isTrue);
+
+      // A consumer that still holds the old session closes it again —
+      // must be a no-op, not a second handle.close()/onClose().
+      await a.close();
+      expect(a.handle.closed, isTrue);
+    });
+  });
+}

--- a/test/core/ffi/session_creation_reuse_test.dart
+++ b/test/core/ffi/session_creation_reuse_test.dart
@@ -104,8 +104,12 @@ class FixedFfiSessionCreator {
     }
     final completer = _createCompleter = Completer<FakeFfiSession>();
     try {
-      final handle = client.createConversationHandle();
+      // Close the prior session BEFORE creating the new handle — the
+      // engine holds one live conversation at a time, and close-first
+      // can't leak a freshly created handle if the close throws. See the
+      // close-first rationale in FfiInferenceModel.createSession (PR #310).
       await _session?.close();
+      final handle = client.createConversationHandle();
       late final FakeFfiSession session;
       session = FakeFfiSession(
         handle: handle,


### PR DESCRIPTION
## Description

Follow-up to #309 (as requested in that thread) — the same `createSession` cached-completer fix for the **litert/FFI** path.

`FfiInferenceModel.createSession` cached its `_createCompleter` and only cleared it from the session's `onClose`, so on **success** the completer acted as a permanent cache: every `createChat` after the first short-circuited on the cached completer and returned the *same* `FfiInferenceModelSession` — never reaching the `await _session?.close()` + fresh `createConversationHandle()` lines below. The result is the same KV-cache bleed #309 fixed for MediaPipe: the previous conversation's context leaks into the next chat.

> Note: unlike the MediaPipe path, the FFI path already cleared the completer in its `catch`, so a *failed* `createSession` did **not** block retry here — the cache-on-success bleed was the only FFI bug.

### The fix (mirrors #309)

- The completer is now a pure in-flight guard, cleared in a `finally` once creation settles, so a sequential second call opens a fresh conversation handle (closing the prior session first).
- `onClose` is identity-guarded so a late close of a superseded session can't null a newer `_session`, and no longer touches `_createCompleter`.
- `FfiInferenceModelSession.close()` is now idempotent — a second close (a consumer closing a superseded session; `createSession` also closes the prior one) must not re-run `handle.close()` / `onClose()`.
- `createSession` returns `completer.future` so the caller stays the error listener after the completer field is cleared.

## Type of Change
- [x] Bug fix
- [x] Test addition

## Testing
- [ ] Tested on Android
- [ ] Tested on iOS
- [ ] Tested on Web
- [ ] Tested on Desktop (macOS/Windows)

Logic is covered by a unit test rather than device testing. `test/core/ffi/session_creation_reuse_test.dart` is a distilled Buggy/Fixed logic pair mirroring `test/mobile/session_creation_reuse_test.dart` from #309 (the FFI client's `createConversationHandle` returns a concrete handle type that can't be faked through the public surface, so the same distilled approach is used). It asserts the cache-on-success bleed (shared handle across `createChat`) and the fix (fresh handle per chat, prior session closed first, retry after failure still works, concurrent dedupe preserved, idempotent close). The full `test/core/ffi` suite passes (25 tests); `flutter analyze` is clean on the changed files.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated (no public API change)
- [x] No new warnings
- [x] Tests added/updated
