### PR TITLE
fix: neutralize U+FFFD in model-output logs to prevent flutter run crash (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.5
+- **Fix `debugPrint` crash on U+FFFD in model output** (#306, thanks @pchang0010): `safeDebugPrint` neutralizes `�` so it can't kill `flutter run`.
+- **Fix session KV-cache bleed across `createChat`** (#308, thanks @mtmanty): each MediaPipe session gets a fresh native session.
+
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.
 - **Fix Windows build on non-UTF-8 locales** (#212): add `/utf-8` to the MSVC plugin target.

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -7,6 +7,7 @@ import 'package:flutter_gemma/core/message.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 import 'package:flutter_gemma/core/parsing/sdk_response_parser.dart';
 import 'package:flutter_gemma/core/tool.dart';
+import 'package:flutter_gemma/core/utils/safe_debug_print.dart';
 import 'package:flutter_gemma/flutter_gemma_interface.dart';
 
 import 'model.dart';
@@ -31,7 +32,8 @@ class InferenceChat {
   final List<Tool> tools;
 
   final List<Message> _fullHistory = [];
-  final List<Message> _prefixes = []; // Prefix messages (tools prompt + context message) for replay across sessions
+  final List<Message> _prefixes =
+      []; // Prefix messages (tools prompt + context message) for replay across sessions
   final List<Message> _modelHistory = [];
   int _currentTokens = 0;
   bool _toolsInstructionSent =
@@ -73,7 +75,8 @@ class InferenceChat {
     await addQueryChunk(message);
   }
 
-  Future<void> addQueryChunk(Message message, [bool noTool = false, bool prefix = false]) async {
+  Future<void> addQueryChunk(Message message,
+      [bool noTool = false, bool prefix = false]) async {
     var messageToSend = message;
 
     // Only add tools prompt for the first user text message (not a tool response)
@@ -268,7 +271,7 @@ class InferenceChat {
     await for (final response in stopFilteredStream) {
       if (response is TextResponse) {
         final token = response.token;
-        debugPrint('InferenceChat: Received filtered token: "$token"');
+        safeDebugPrint('InferenceChat: Received filtered token: "$token"');
 
         // Track if this token should be added to buffer (default true)
         bool shouldAddToBuffer = true;
@@ -320,7 +323,8 @@ class InferenceChat {
                 final toolCallMessage = Message.toolCall(text: funcBuffer);
                 _fullHistory.add(toolCallMessage);
                 _modelHistory.add(toolCallMessage);
-                debugPrint('InferenceChat: Added function call to history before yielding');
+                debugPrint(
+                    'InferenceChat: Added function call to history before yielding');
                 if (allCalls.length == 1) {
                   yield allCalls.first;
                 } else {
@@ -362,7 +366,7 @@ class InferenceChat {
                   false; // Don't add to main buffer while we determine if it's JSON
             } else {
               // Normal text token - emit immediately
-              debugPrint('InferenceChat: Emitting text token: "$token"');
+              safeDebugPrint('InferenceChat: Emitting text token: "$token"');
               yield response;
               shouldAddToBuffer = true; // Add to main buffer for history
             }
@@ -387,7 +391,7 @@ class InferenceChat {
 
     debugPrint('InferenceChat: Native token stream ended');
     final response = buffer.toString();
-    debugPrint('InferenceChat: Complete response accumulated: "$response"');
+    safeDebugPrint('InferenceChat: Complete response accumulated: "$response"');
 
     // Gemma 4 path: streaming yielded plain text via the SDK passthrough
     // format. The tool calls live in the structured `lastRawResponse` JSON.
@@ -456,7 +460,8 @@ class InferenceChat {
             final toolCallMessage = Message.toolCall(text: contentToCheck);
             _fullHistory.add(toolCallMessage);
             _modelHistory.add(toolCallMessage);
-            debugPrint('InferenceChat: Added function call to history at end of stream');
+            debugPrint(
+                'InferenceChat: Added function call to history at end of stream');
             if (allCalls.length == 1) {
               yield allCalls.first;
             } else {
@@ -505,7 +510,8 @@ class InferenceChat {
         _modelHistory.add(chatMessage);
         debugPrint('InferenceChat: Added to model history');
       } else {
-        debugPrint('InferenceChat: Function call was already added to history when yielded');
+        debugPrint(
+            'InferenceChat: Function call was already added to history when yielded');
       }
       debugPrint('InferenceChat: Message added to history successfully');
 

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_gemma/core/utils/safe_debug_print.dart';
 import 'package:mutex/mutex.dart';
 
 import '../../flutter_gemma_interface.dart';
@@ -234,7 +235,7 @@ class LiteRtLmFfiClient {
       for (var i = 0; i < content.length; i += chunkSize) {
         final end =
             (i + chunkSize < content.length) ? i + chunkSize : content.length;
-        debugPrint(content.substring(i, end));
+        safeDebugPrint(content.substring(i, end));
       }
       debugPrint('[LiteRtLmFfi/native] === END native log ===');
       // Truncate so the next dump only shows new output. If truncation fails

--- a/lib/core/image_error_handler.dart
+++ b/lib/core/image_error_handler.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_gemma/core/utils/safe_debug_print.dart';
 import 'image_processor.dart';
 import 'image_tokenizer.dart';
 import 'vision_encoder_validator.dart';
@@ -444,19 +445,21 @@ class ImageErrorHandler {
   /// Sanitizes prompt for safe logging
   static String _sanitizePromptForLogging(String prompt) {
     if (prompt.length > _maxLogSize) {
-      return '${prompt.substring(0, _maxLogSize)}...[truncated]';
+      return sanitizeForLog(
+          '${prompt.substring(0, _maxLogSize)}...[truncated]');
     }
-    // Remove potentially sensitive Base64 data
-    return prompt.replaceAll(
-        RegExp(r'[A-Za-z0-9+/]{100,}={0,2}'), '[IMAGE_DATA]');
+    // Remove potentially sensitive Base64 data, then neutralize U+FFFD (#306)
+    return sanitizeForLog(prompt.replaceAll(
+        RegExp(r'[A-Za-z0-9+/]{100,}={0,2}'), '[IMAGE_DATA]'));
   }
 
   /// Sanitizes response for safe logging
   static String _sanitizeResponseForLogging(String response) {
     if (response.length > _maxLogSize) {
-      return '${response.substring(0, _maxLogSize)}...[truncated]';
+      return sanitizeForLog(
+          '${response.substring(0, _maxLogSize)}...[truncated]');
     }
-    return response;
+    return sanitizeForLog(response);
   }
 }
 

--- a/lib/core/utils/safe_debug_print.dart
+++ b/lib/core/utils/safe_debug_print.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+
+/// Drop-in [debugPrint] replacement that neutralizes the Unicode
+/// replacement character (U+FFFD, `�`) before printing.
+///
+/// When a U+FFFD byte sequence reaches the app's stdout, `flutter run`'s
+/// tool-side reader treats it as a malformed-output signal and calls
+/// `throwToolExit`, killing the dev session (see
+/// flutter_tools/lib/src/convert.dart). Model output can legitimately
+/// contain U+FFFD — e.g. when the model is asked about the replacement
+/// character itself, or emits a byte-fallback token — so logging raw model
+/// tokens crashes `flutter run` even though the app itself is fine.
+///
+/// This wrapper rewrites `�` to the literal text `U+FFFD` so the log stays
+/// visible (and the fact that a replacement char was present is still
+/// shown) without tripping the tool. Use it only where model-produced text
+/// is logged; ordinary plugin log lines never contain U+FFFD. Issue #306.
+void safeDebugPrint(String? message, {int? wrapWidth}) {
+  if (message == null) {
+    debugPrint(null, wrapWidth: wrapWidth);
+    return;
+  }
+  debugPrint(sanitizeForLog(message), wrapWidth: wrapWidth);
+}
+
+/// Replaces every U+FFFD (`�`) in [text] with the literal `U+FFFD` so the
+/// string is safe to send to stdout under `flutter run`. Exposed for call
+/// sites that build a log string by hand (e.g. truncating helpers) rather
+/// than calling [safeDebugPrint] directly.
+String sanitizeForLog(String text) => text.replaceAll('�', 'U+FFFD');

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -5,6 +5,7 @@ import 'dart:js_interop_unsafe';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_gemma/core/utils/safe_debug_print.dart';
 import 'package:mutex/mutex.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gemma/core/extensions.dart';
@@ -811,7 +812,7 @@ class WebModelSession extends InferenceModelSession {
       if (kDebugMode) {
         debugPrint(
             '✅ getResponse: Successfully generated response of length ${response.length}');
-        debugPrint(
+        safeDebugPrint(
             '✅ getResponse: Response preview: ${response.substring(0, math.min(100, response.length))}...');
       }
 
@@ -860,7 +861,7 @@ class WebModelSession extends InferenceModelSession {
               final complete = completeRaw.parseBool();
               final partial = partialJs.toDart;
               if (kDebugMode) {
-                debugPrint(
+                safeDebugPrint(
                     '📝 getResponseAsync: Received partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...');
               }
               _controller?.add(partial);
@@ -890,7 +891,7 @@ class WebModelSession extends InferenceModelSession {
               final complete = completeRaw.parseBool();
               final partial = partialJs.toDart;
               if (kDebugMode) {
-                debugPrint(
+                safeDebugPrint(
                     '🖼️ getResponseAsync: Received multimodal partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...');
               }
               _controller?.add(partial);

--- a/test/core/utils/safe_debug_print_test.dart
+++ b/test/core/utils/safe_debug_print_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gemma/core/utils/safe_debug_print.dart';
+
+/// Regression coverage for issue #306 — a U+FFFD (`�`) in model output
+/// reaching stdout makes `flutter run`'s tool-side reader throwToolExit and
+/// kill the dev session. [safeDebugPrint] / [sanitizeForLog] must rewrite it
+/// to the literal `U+FFFD` so the log is safe while staying visible.
+/// https://github.com/DenisovAV/flutter_gemma/issues/306
+void main() {
+  group('sanitizeForLog', () {
+    test('replaces a lone U+FFFD with the literal text', () {
+      expect(sanitizeForLog('a�b'), 'aU+FFFDb');
+    });
+
+    test('replaces every occurrence', () {
+      expect(sanitizeForLog('��'), 'U+FFFDU+FFFD');
+    });
+
+    test('leaves ordinary text untouched', () {
+      const s = 'The UTF-8 replacement character is...';
+      expect(sanitizeForLog(s), s);
+    });
+
+    test('leaves valid multi-byte / emoji text untouched', () {
+      const s = 'привет 🚀 你好';
+      expect(sanitizeForLog(s), s);
+    });
+
+    test('handles an empty string', () {
+      expect(sanitizeForLog(''), '');
+    });
+
+    test('matches the exact bytes from the #306 repro', () {
+      // The model answered with U+FFFD when asked about the replacement
+      // character (source bytes 0xEF 0xBF 0xBD in the issue log).
+      expect(sanitizeForLog('�** ('), 'U+FFFD** (');
+    });
+  });
+
+  group('safeDebugPrint', () {
+    late List<String?> printed;
+    DebugPrintCallback? original;
+
+    setUp(() {
+      printed = <String?>[];
+      original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) => printed.add(message);
+    });
+
+    tearDown(() {
+      debugPrint = original!;
+    });
+
+    test('sanitizes U+FFFD before forwarding to debugPrint', () {
+      safeDebugPrint('token: �');
+      expect(printed, ['token: U+FFFD']);
+    });
+
+    test('forwards ordinary text unchanged', () {
+      safeDebugPrint('plain log line');
+      expect(printed, ['plain log line']);
+    });
+
+    test('forwards null through to debugPrint', () {
+      safeDebugPrint(null);
+      expect(printed, [null]);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes #306.

Model output can legitimately contain the Unicode replacement character (U+FFFD, `�`) — e.g. when the model is asked about the replacement character itself (the issue's repro: *"What is the UTF-8 replacement character?"*), or when it emits a byte-fallback token. Logging that text via `debugPrint` sends `�` to the app's stdout, where `flutter run`'s tool-side reader treats it as a malformed-output signal and calls `throwToolExit`, **killing the dev session** (flutter_tools/lib/src/convert.dart). The app itself is fine — this only crashes `flutter run` at dev time.

### Fix

New `lib/core/utils/safe_debug_print.dart`:
- `safeDebugPrint(String?)` — drop-in `debugPrint` replacement that rewrites `�` → literal `U+FFFD` before printing.
- `sanitizeForLog(String)` — same rewrite for call sites that build a log string by hand (e.g. truncating helpers).

The replacement keeps the log visible (and still shows a replacement char was present) rather than dropping it — as suggested in the issue.

Applied **only at log sites that print model-produced text**, not globally (ordinary plugin log lines never contain U+FFFD):
- `lib/web/flutter_gemma_web.dart` — response preview + text/multimodal partials (the crash site from the repro)
- `lib/core/chat.dart` — filtered token, emitting token, accumulated response
- `lib/core/ffi/litert_lm_client.dart` — native-log chunk dump
- `lib/core/image_error_handler.dart` — prompt/response logging sanitizers

## Type of Change
- [x] Bug fix
- [x] Test addition

## Testing
`test/core/utils/safe_debug_print_test.dart` (9 tests, all pass) covers U+FFFD replacement, multiple occurrences, ordinary/emoji text untouched, the exact bytes from the #306 repro, and `safeDebugPrint` forwarding. `flutter analyze` clean; `flutter build web` succeeds.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added
- [x] No new warnings