### PR TITLE
0.16.5: logging system, init/session fixes, review follow-up

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -261,6 +261,7 @@ gh release view v0.14.1
 
 ## Common gotchas
 
+- **iOS dylib `minos` MUST equal the Flutter wrapper plist (13.0) — for EVERY native bundle, not just LiteRT-LM.** Flutter Native Assets hardcodes `MinimumOSVersion 13.0` into each generated `*.framework/Info.plist`; if a bundled dylib's binary `minos` is higher, App Store Connect rejects the archive with **ITMS-90208**. Both `litert_lm/build_ios.sh` and `qdrant_edge/build_local.sh` normalize to 13.0 via `vtool -set-build-version <ios|iossim> 13.0 18.5`. **After building ANY iOS dylib (current or a future new artifact), verify:** `vtool -show <dylib> | grep minos` → must be `13.0`. The real iOS 16+ floor is enforced by the podspec, not this metadata. Regressed in 0.16.3 when qdrant un-vendoring shipped a 16.0 dylib (#286) — the check was only in the LiteRT-LM script, not a release-wide rule.
 - **`native/litert_lm/prebuilt/` excluded from pub package** (`.pubignore`) — end users get dylibs from GitHub Release, NOT from the pub package. Updating local prebuilts without re-uploading them is invisible to users.
 - **iOS dylib must be built from commit `5e0d86b`** (post-v0.10.2). v0.10.2 tag predates `libLiteRtMetalAccelerator.dylib` → ABI mismatch → EXC_BAD_ACCESS in `litert_lm_engine_create` on iPhone GPU. `build_ios.sh` defaults to it; do not override unless you know what you're doing.
 - **`bazelisk clean --expunge` is NOT free** — it forces a full rebuild (~25 min for one platform). Only do it when WORKSPACE patch_cmds changed; otherwise incremental rebuild.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.16.5
-- **Internal logs gated + silent in release** (#306): `FlutterGemma.logLevel` controls verbosity; model output/prompts no longer leak to logcat, and U+FFFD can't crash `flutter run`.
+- **Internal logs silent in release + `FlutterGemma.logLevel`** (#306): no PII in logcat, U+FFFD safe.
 
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.16.5
+- **Internal logs gated + silent in release** (#306): `FlutterGemma.logLevel` controls verbosity; model output/prompts no longer leak to logcat, and U+FFFD can't crash `flutter run`.
+
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.
 - **Fix Windows build on non-UTF-8 locales** (#212): add `/utf-8` to the MSVC plugin target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - **Internal logs silent in release + `FlutterGemma.logLevel`** (#306): no PII in logcat, U+FFFD safe.
 - **Fix `getActiveModel()` StateError on startup** (#314, thanks @alan-insam): manager init now single-flight, awaited in `FlutterGemma.initialize()`.
 - **Fix App Store ITMS-90208 on iOS** (#286, thanks @remingtonc): qdrant-edge iOS dylib minos normalized to 13.0 (0.7.2).
+- **Fix KV-cache bleed between sequential chats** (#308, thanks @mtmanty): each createSession opens a fresh native session + conversation handle.
+- **Enable function calling for Gemma 4 E2B/E4B** (#303): example sets supportsFunctionCalls; FC + multimodal verified together.
 
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.16.5
 - **Internal logs silent in release + `FlutterGemma.logLevel`** (#306): no PII in logcat, U+FFFD safe.
+- **Fix `getActiveModel()` StateError on startup** (#314, thanks @alan-insam): manager init now single-flight, awaited in `FlutterGemma.initialize()`.
 
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.16.5
 - **Internal logs silent in release + `FlutterGemma.logLevel`** (#306): no PII in logcat, U+FFFD safe.
 - **Fix `getActiveModel()` StateError on startup** (#314, thanks @alan-insam): manager init now single-flight, awaited in `FlutterGemma.initialize()`.
+- **Fix App Store ITMS-90208 on iOS** (#286, thanks @remingtonc): qdrant-edge iOS dylib minos normalized to 13.0 (0.7.2).
 
 ## 0.16.4
 - **Fix embedding freezing the UI thread** (#299): forward pass runs on a background isolate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,9 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 
 ### ⚠️ `lib/pigeon.g.dart` is generated — DO NOT EDIT MANUALLY
 
+### ⚠️ Use `gemmaLog`, not `debugPrint` (0.16.5+)
+All `lib/` logging goes through `gemmaLog(message, {level})` in `lib/core/utils/gemma_log.dart` — silent in release, `kDebugMode`-gated, U+FFFD-sanitized (#306). Never add a raw `debugPrint` in `lib/`. Model output / prompts / history must be `level: GemmaLogLevel.verbose` (hidden by default, opt-in via `FlutterGemma.logLevel`); hot per-token sites also wrap the call in `if (kDebugMode)` so the string isn't built in release. The top-level `gemmaLogLevel` is per-isolate — propagate it into any spawned isolate via its init payload.
+
 ## Versions & Dependencies
 
 - **Flutter**: `>=3.24.0`
@@ -120,7 +123,7 @@ Check `lib/flutter_gemma_interface.dart`, implementation files, and `example/` b
 - **iOS**: Minimum 16.0
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.12.0` GitHub Release. Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` on Intel LunarLake/PantherLake silicon. MTP (speculative decoding) support for Gemma 4.
-- **Current Version**: 0.16.4
+- **Current Version**: 0.16.5
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There is an example of using:
 - ⚡ **LiteRT-LM v0.12.0** (0.16.1) — NPU dispatch now available on Linux and macOS as well as Windows.
 - 🌐 **Web `.litertlm` inference** (0.16.2) — Gemma 4 E2B/E4B `.litertlm` models run in the browser via `@litert-lm/core` (WebGPU + WASM, **early preview**). See [Web `.litertlm` support & limitations](#web-litertlm-support--limitations) — text-only, no vision/audio/thinking, no LoRA, no function calling yet.
 - 🧵 **Concurrent sessions** (0.16.2, #226) — `openSession()` / `openChat()` run independent dialogues on one loaded model (isolated history per session). **Concurrent contexts, serialized inference**: only one session generates at a time. Works on `.litertlm` (all native + web) and `.task` (MediaPipe Android/iOS). See [Concurrent sessions](#concurrent-sessions-opensession).
+- 🔇 **Logging silent in release** (0.16.5, #306) — internal logs no longer print in release builds, so model output / prompts never reach logcat or syslog. In debug, control verbosity with `FlutterGemma.logLevel` (`info` by default; `verbose` to see model output, `none` to silence). See [Logging](#logging).
 
 See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
@@ -683,6 +684,30 @@ FlutterGemma.initialize(
 - 🌐 [Platform Support](#platform-support-details) - Web vs Mobile differences
 - 🔄 [Migration Guide](#migration-from-legacy-to-modern-api) - Upgrade from Legacy API
 - 📚 [Legacy API Documentation](#usage-legacy-api) - For backwards compatibility
+
+## Logging
+
+The plugin's internal logs are **silent in release builds** — model output, prompts, and conversation history are never written to logcat / syslog. In debug builds they're shown according to `FlutterGemma.logLevel`:
+
+| Level | What it prints (debug only) |
+|-------|------------------------------|
+| `GemmaLogLevel.none` | Nothing — fully silent. |
+| `GemmaLogLevel.info` *(default)* | Lifecycle, errors, diagnostics. **No** model output / prompts. |
+| `GemmaLogLevel.verbose` | Everything above **plus** model output, prompts, and conversation history. |
+
+```dart
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+// See the model's generated tokens and prompts while debugging:
+FlutterGemma.logLevel = GemmaLogLevel.verbose;
+
+// Or silence the plugin entirely:
+FlutterGemma.logLevel = GemmaLogLevel.none;
+```
+
+Notes:
+- Release builds are always silent regardless of this setting — there is no way to leak PII into a production log.
+- The level is process-global and per-isolate; set it once at startup. Background isolates (e.g. the embedding worker) snapshot the value when they start.
 
 ## HuggingFace Authentication 🔐
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -262,29 +262,32 @@ const _litertlmBundle = _NativeBundle(
 /// Vendored fork dropped; built directly from crates.io qdrant-edge 0.7.1.
 const _qdrantEdgeBundle = _NativeBundle(
   namespace: 'qdrant_edge',
-  version: '0.7.1',
+  version: '0.7.2',
   releaseTagPrefix: 'qdrant-edge-v',
   archivePrefix: 'qdrant-edge',
   mainLibName: 'qdrant_edge_ffi',
   // Namespaced layout: <cacheBase>/qdrant_edge/macos_arm64/...
   // No Podfile/Xcode integration needed — qdrant lives entirely behind FFI,
   // companion-free, registered as a single CodeAsset.
+  // 0.7.2: bump from 0.7.1; iOS device + sim dylibs now patched to minos 13.0
+  // via vtool in build_local.sh so App Store Connect accepts the archive
+  // (ITMS-90208). The un-vendored 0.7.1 shipped minos 16.0 and regressed #286.
   markerFileName: '.version',
   checksums: {
     'qdrant-edge-linux_x86_64.tar.gz':
-        'beda966f379fae26e37a574eb4803d22f97b02c399143cc839368e1247a6bd20',
+        '212f35e10619e8eea51319a1ab07e07ea013aaf31dfc6c5abb49c8631c0acfa3',
     'qdrant-edge-linux_arm64.tar.gz':
-        '08f3cc59f7983d71b7993f7f3abcf81e2a912a35befafab5907ff227aaf57164',
+        '7b18777bb7aa7c5ec164666bd03b9c630737fad0f62c32ca85931928f7259ca2',
     'qdrant-edge-windows_x86_64.tar.gz':
-        'b0034a10ced68470cb489058667e94c69ce2d56bc417006c559d1a0259dac005',
+        '234dcfe36243139e2ec6fa86a61487032632ee18f18088917fb2714d49cad559',
     'qdrant-edge-macos_arm64.tar.gz':
-        'e2af47625eb48109e71e7a67abdce12f772fe503f7944cb6d9088c5c3b09b7dc',
+        'a916e3fcc9fe0b79f4d32438c52037be75d2844288425e52d7a6f0a17f449b3e',
     'qdrant-edge-ios_arm64.tar.gz':
-        'a7ce2779542bada085027423ed0a719287f3ef8ce8136a201b50b78aa0b569ed',
+        'a74d808cbffe8e34555fb64d775a1bad490253be6e56d90f7646d352e9b9c57e',
     'qdrant-edge-ios_sim_arm64.tar.gz':
-        '6f99ffc6b9e82c40e23824607b17dd1d69fba1b2b412528a75afb87f41cc97c5',
+        '09579375e4fbf7bea4b43d98b613cc020b1890381f28bbcc416ec8482cdbfc53',
     'qdrant-edge-android_arm64.tar.gz':
-        '1719a6188c054ccbc11aeed2ac7d2ca89d496b5a181767e23827ba339522835c',
+        '957431c31dc01811feef2231141ba40cf1bb1991c42aab2dc800eb75d937de1d',
   },
 );
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -257,9 +257,9 @@ const _litertlmBundle = _NativeBundle(
 /// native platform (no Web — qdrant-edge depends on mmap/parking_lot which
 /// don't compile to WebAssembly; Web continues to use wa-sqlite).
 ///
-/// 0.7.1: upstream qdrant-edge now natively supports `wal_options` in
+/// 0.7.x: upstream qdrant-edge now natively supports `wal_options` in
 /// EdgeConfig (merged via https://github.com/qdrant/qdrant/pull/9067).
-/// Vendored fork dropped; built directly from crates.io qdrant-edge 0.7.1.
+/// Vendored fork dropped; built directly from crates.io qdrant-edge.
 const _qdrantEdgeBundle = _NativeBundle(
   namespace: 'qdrant_edge',
   version: '0.7.2',

--- a/ios/flutter_gemma.podspec
+++ b/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.16.4'
+  s.version          = '0.16.5'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Run Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3, Qwen 2.5, DeepSeek R1,

--- a/lib/core/api/embedding_installation_builder.dart
+++ b/lib/core/api/embedding_installation_builder.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/utils/file_name_utils.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:path/path.dart' as path;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Fluent builder for embedding model installation
 ///
@@ -169,14 +169,14 @@ class EmbeddingInstallationBuilder {
         await repository.isInstalled(tokenizerFilename);
 
     if (isModelInstalled && isTokenizerInstalled) {
-      debugPrint(
+      gemmaLog(
           'ℹ️  Embedding model already installed: $modelFilename + $tokenizerFilename (skipping download)');
     } else {
       final handlerRegistry = registry.sourceHandlerRegistry;
 
       // Install model file if not already installed
       if (!isModelInstalled) {
-        debugPrint('📥 Installing embedding model...');
+        gemmaLog('📥 Installing embedding model...');
         final modelHandler = handlerRegistry.getHandler(_modelSource!);
         if (_onModelProgress != null) {
           await for (final progress in modelHandler!.installWithProgress(
@@ -192,13 +192,12 @@ class EmbeddingInstallationBuilder {
           );
         }
       } else {
-        debugPrint(
-            'ℹ️  Embedding model file already installed: $modelFilename');
+        gemmaLog('ℹ️  Embedding model file already installed: $modelFilename');
       }
 
       // Install tokenizer file if not already installed
       if (!isTokenizerInstalled) {
-        debugPrint('📥 Installing tokenizer...');
+        gemmaLog('📥 Installing tokenizer...');
         final tokenizerHandler =
             handlerRegistry.getHandler(effectiveTokenizerSource);
         if (_onTokenizerProgress != null) {
@@ -215,7 +214,7 @@ class EmbeddingInstallationBuilder {
           );
         }
       } else {
-        debugPrint('ℹ️  Tokenizer file already installed: $tokenizerFilename');
+        gemmaLog('ℹ️  Tokenizer file already installed: $tokenizerFilename');
       }
     }
 
@@ -223,7 +222,7 @@ class EmbeddingInstallationBuilder {
     final manager = FlutterGemmaPlugin.instance.modelManager;
     manager.setActiveModel(spec);
 
-    debugPrint('✅ Embedding model installed and set as active: ${spec.name}');
+    gemmaLog('✅ Embedding model installed and set as active: ${spec.name}');
 
     return EmbeddingInstallation(spec: spec);
   }

--- a/lib/core/api/flutter_gemma.dart
+++ b/lib/core/api/flutter_gemma.dart
@@ -132,6 +132,10 @@ class FlutterGemma {
       maxDownloadRetries: maxDownloadRetries,
       webStorageMode: effectiveStorageMode,
     );
+
+    // Restore active model/embedder state from storage before returning, so
+    // getActiveModel()/hasActiveModel() (sync) see a hydrated manager (#314).
+    await FlutterGemmaPlugin.instance.modelManager.ensureInitialized();
   }
 
   /// Start building an inference model installation

--- a/lib/core/api/flutter_gemma.dart
+++ b/lib/core/api/flutter_gemma.dart
@@ -7,6 +7,7 @@ import 'package:flutter_gemma/core/domain/web_storage_mode.dart';
 import 'package:flutter_gemma/core/infrastructure/web_download_service_stub.dart'
     if (dart.library.js_interop) 'package:flutter_gemma/core/infrastructure/web_download_service.dart';
 import 'package:flutter_gemma/core/model.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma/flutter_gemma_interface.dart';
 import 'package:flutter_gemma/mobile/flutter_gemma_mobile.dart';
 import 'package:flutter_gemma/pigeon.g.dart';
@@ -70,6 +71,18 @@ import 'package:flutter_gemma/pigeon.g.dart';
 /// final response = await session.getResponse();
 /// ```
 class FlutterGemma {
+  /// Controls flutter_gemma's internal log verbosity.
+  ///
+  /// Debug builds only -- release builds are always silent regardless of this
+  /// value (no model output / prompts leak into logcat/syslog). Default
+  /// [GemmaLogLevel.info]. Use [GemmaLogLevel.verbose] to see model output and
+  /// prompts while debugging, or [GemmaLogLevel.none] to silence the plugin.
+  ///
+  /// Note: this is a process-global, per-isolate setting; set it once at
+  /// startup. Background isolates snapshot the value at spawn time.
+  static GemmaLogLevel get logLevel => gemmaLogLevel;
+  static set logLevel(GemmaLogLevel value) => gemmaLogLevel = value;
+
   /// Initialize Flutter Gemma
   ///
   /// Call this once at app startup before using any other API.

--- a/lib/core/api/inference_installation_builder.dart
+++ b/lib/core/api/inference_installation_builder.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/utils/file_name_utils.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:path/path.dart' as path;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Fluent builder for inference model installation
 ///
@@ -182,7 +182,7 @@ class InferenceInstallationBuilder {
     final isInstalled = await repository.isInstalled(filename);
 
     if (isInstalled) {
-      debugPrint('ℹ️  Model already installed: $filename (skipping download)');
+      gemmaLog('ℹ️  Model already installed: $filename (skipping download)');
     } else {
       // Install model file
       final handlerRegistry = registry.sourceHandlerRegistry;
@@ -215,7 +215,7 @@ class InferenceInstallationBuilder {
     final manager = FlutterGemmaPlugin.instance.modelManager;
     manager.setActiveModel(spec);
 
-    debugPrint('✅ Inference model installed and set as active: ${spec.name}');
+    gemmaLog('✅ Inference model installed and set as active: ${spec.name}');
 
     return InferenceInstallation(spec: spec);
   }

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -121,8 +121,9 @@ class InferenceChat {
     // --- DETAILED LOGGING ---
     final historyForLogging = _modelHistory.map((m) => m.text).join('\n');
     gemmaLog('--- Sending to Native ---');
-    gemmaLog('History:\n$historyForLogging');
-    gemmaLog('Current Message:\n${messageToSend.text}');
+    gemmaLog('History:\n$historyForLogging', level: GemmaLogLevel.verbose);
+    gemmaLog('Current Message:\n${messageToSend.text}',
+        level: GemmaLogLevel.verbose);
     gemmaLog('-------------------------');
     // --- END LOGGING ---
 
@@ -182,7 +183,8 @@ class InferenceChat {
     }
 
     gemmaLog(
-        'InferenceChat: Raw response from native model:\n--- START ---\n$cleanedResponse\n--- END ---');
+        'InferenceChat: Raw response from native model:\n--- START ---\n$cleanedResponse\n--- END ---',
+        level: GemmaLogLevel.verbose);
 
     // Try to parse as function call if tools are available and model supports function calls
     if (tools.isNotEmpty &&
@@ -199,7 +201,8 @@ class InferenceChat {
         _fullHistory.add(toolCallMessage);
         _modelHistory.add(toolCallMessage);
         gemmaLog(
-            'InferenceChat: Added tool call to history: ${toolCallMessage.text}');
+            'InferenceChat: Added tool call to history: ${toolCallMessage.text}',
+            level: GemmaLogLevel.verbose);
         if (allCalls.length == 1) {
           return allCalls.first;
         }
@@ -271,7 +274,10 @@ class InferenceChat {
     await for (final response in stopFilteredStream) {
       if (response is TextResponse) {
         final token = response.token;
-        gemmaLog('InferenceChat: Received filtered token: "$token"');
+        if (kDebugMode) {
+          gemmaLog('InferenceChat: Received filtered token: "$token"',
+              level: GemmaLogLevel.verbose);
+        }
 
         // Track if this token should be added to buffer (default true)
         bool shouldAddToBuffer = true;
@@ -284,8 +290,11 @@ class InferenceChat {
           if (funcBuffer.isNotEmpty) {
             // We're already buffering - add token and check for completion
             funcBuffer += token;
-            gemmaLog(
-                'InferenceChat: Buffering token: "$token", total: ${funcBuffer.length} chars');
+            if (kDebugMode) {
+              gemmaLog(
+                  'InferenceChat: Buffering token: "$token", total: ${funcBuffer.length} chars',
+                  level: GemmaLogLevel.verbose);
+            }
 
             // Check if we now have a complete JSON
             if (FunctionCallParser.isFunctionCallComplete(funcBuffer,
@@ -297,8 +306,11 @@ class InferenceChat {
                     jsonData.containsKey('message')) {
                   // Found JSON with message field - extract and display the message
                   final message = jsonData['message'] as String;
-                  gemmaLog(
-                      'InferenceChat: Extracted message from JSON: "$message"');
+                  if (kDebugMode) {
+                    gemmaLog(
+                        'InferenceChat: Extracted message from JSON: "$message"',
+                        level: GemmaLogLevel.verbose);
+                  }
                   yield TextResponse(message);
                   funcBuffer = '';
                   shouldAddToBuffer = false; // Don't add JSON tokens to buffer
@@ -359,22 +371,31 @@ class InferenceChat {
             // Not currently buffering - check if this token starts a function call
             if (FunctionCallParser.isFunctionCallStart(token,
                 modelType: modelType)) {
-              gemmaLog(
-                  'InferenceChat: Found potential function call start in token: "$token"');
+              if (kDebugMode) {
+                gemmaLog(
+                    'InferenceChat: Found potential function call start in token: "$token"',
+                    level: GemmaLogLevel.verbose);
+              }
               funcBuffer = token;
               shouldAddToBuffer =
                   false; // Don't add to main buffer while we determine if it's JSON
             } else {
               // Normal text token - emit immediately
-              gemmaLog('InferenceChat: Emitting text token: "$token"');
+              if (kDebugMode) {
+                gemmaLog('InferenceChat: Emitting text token: "$token"',
+                    level: GemmaLogLevel.verbose);
+              }
               yield response;
               shouldAddToBuffer = true; // Add to main buffer for history
             }
           }
         } else {
           // No function processing happening - emit token directly
-          gemmaLog(
-              'InferenceChat: No function processing, emitting token as text: "$token"');
+          if (kDebugMode) {
+            gemmaLog(
+                'InferenceChat: No function processing, emitting token as text: "$token"',
+                level: GemmaLogLevel.verbose);
+          }
           yield response;
           shouldAddToBuffer = true; // Add to main buffer for history
         }
@@ -391,7 +412,8 @@ class InferenceChat {
 
     gemmaLog('InferenceChat: Native token stream ended');
     final response = buffer.toString();
-    gemmaLog('InferenceChat: Complete response accumulated: "$response"');
+    gemmaLog('InferenceChat: Complete response accumulated: "$response"',
+        level: GemmaLogLevel.verbose);
 
     // Gemma 4 path: streaming yielded plain text via the SDK passthrough
     // format. The tool calls live in the structured `lastRawResponse` JSON.
@@ -441,7 +463,8 @@ class InferenceChat {
                 jsonData.containsKey('message')) {
               final message = jsonData['message'] as String;
               gemmaLog(
-                  'InferenceChat: Extracted message from end-of-stream JSON: "$message"');
+                  'InferenceChat: Extracted message from end-of-stream JSON: "$message"',
+                  level: GemmaLogLevel.verbose);
               yield TextResponse(message);
               return;
             }
@@ -504,7 +527,8 @@ class InferenceChat {
       if (!emittedFunctionCall) {
         final chatMessage = Message(text: response, isUser: false);
         gemmaLog(
-            'InferenceChat: Created text message object: ${chatMessage.text}');
+            'InferenceChat: Created text message object: ${chatMessage.text}',
+            level: GemmaLogLevel.verbose);
         _fullHistory.add(chatMessage);
         gemmaLog('InferenceChat: Added to full history');
         _modelHistory.add(chatMessage);

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -119,12 +119,14 @@ class InferenceChat {
     }
 
     // --- DETAILED LOGGING ---
-    final historyForLogging = _modelHistory.map((m) => m.text).join('\n');
-    gemmaLog('--- Sending to Native ---');
-    gemmaLog('History:\n$historyForLogging', level: GemmaLogLevel.verbose);
-    gemmaLog('Current Message:\n${messageToSend.text}',
-        level: GemmaLogLevel.verbose);
-    gemmaLog('-------------------------');
+    if (kDebugMode) {
+      final historyForLogging = _modelHistory.map((m) => m.text).join('\n');
+      gemmaLog('--- Sending to Native ---');
+      gemmaLog('History:\n$historyForLogging', level: GemmaLogLevel.verbose);
+      gemmaLog('Current Message:\n${messageToSend.text}',
+          level: GemmaLogLevel.verbose);
+      gemmaLog('-------------------------');
+    }
     // --- END LOGGING ---
 
     await session.addQueryChunk(messageToSend);

--- a/lib/core/chat.dart
+++ b/lib/core/chat.dart
@@ -10,6 +10,7 @@ import 'package:flutter_gemma/core/tool.dart';
 import 'package:flutter_gemma/flutter_gemma_interface.dart';
 
 import 'model.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Default maximum length for function call buffer before flushing as text.
 /// Must accommodate verbose formats (DeepSeek tags, parallel calls).
@@ -31,7 +32,8 @@ class InferenceChat {
   final List<Tool> tools;
 
   final List<Message> _fullHistory = [];
-  final List<Message> _prefixes = []; // Prefix messages (tools prompt + context message) for replay across sessions
+  final List<Message> _prefixes =
+      []; // Prefix messages (tools prompt + context message) for replay across sessions
   final List<Message> _modelHistory = [];
   int _currentTokens = 0;
   bool _toolsInstructionSent =
@@ -73,7 +75,8 @@ class InferenceChat {
     await addQueryChunk(message);
   }
 
-  Future<void> addQueryChunk(Message message, [bool noTool = false, bool prefix = false]) async {
+  Future<void> addQueryChunk(Message message,
+      [bool noTool = false, bool prefix = false]) async {
     var messageToSend = message;
 
     // Only add tools prompt for the first user text message (not a tool response)
@@ -105,7 +108,7 @@ class InferenceChat {
       _prefixes.add(toolsPromptMessage);
     } else if (!supportsFunctionCalls && tools.isNotEmpty && !noTool) {
       // Log warning if model doesn't support function calls but tools are provided
-      debugPrint(
+      gemmaLog(
           'WARNING: Model does not support function calls, but tools were provided. Tools will be ignored.');
     }
 
@@ -117,10 +120,10 @@ class InferenceChat {
 
     // --- DETAILED LOGGING ---
     final historyForLogging = _modelHistory.map((m) => m.text).join('\n');
-    debugPrint('--- Sending to Native ---');
-    debugPrint('History:\n$historyForLogging');
-    debugPrint('Current Message:\n${messageToSend.text}');
-    debugPrint('-------------------------');
+    gemmaLog('--- Sending to Native ---');
+    gemmaLog('History:\n$historyForLogging');
+    gemmaLog('Current Message:\n${messageToSend.text}');
+    gemmaLog('-------------------------');
     // --- END LOGGING ---
 
     await session.addQueryChunk(messageToSend);
@@ -140,7 +143,7 @@ class InferenceChat {
   }
 
   Future<ModelResponse> generateChatResponse() async {
-    debugPrint('InferenceChat: Getting response from native model...');
+    gemmaLog('InferenceChat: Getting response from native model...');
     final response = await session.getResponse();
     final cleanedResponse = ModelThinkingFilter.cleanResponse(response,
         isThinking: isThinking, modelType: modelType, fileType: fileType);
@@ -157,7 +160,7 @@ class InferenceChat {
       if (raw != null) {
         final allCalls = SdkResponseParser.extractToolCalls(raw);
         if (allCalls.isNotEmpty) {
-          debugPrint(
+          gemmaLog(
               'InferenceChat: Detected ${allCalls.length} SDK-parsed tool call(s)');
           // Strip Gemma 4 escape tokens (`<|"|>`) before persisting to history.
           // Keeping raw lets the SDK echo those tokens back into the next
@@ -173,12 +176,12 @@ class InferenceChat {
     }
 
     if (cleanedResponse.isEmpty) {
-      debugPrint(
+      gemmaLog(
           'InferenceChat: Raw response from native model is EMPTY after cleaning.');
       return const TextResponse(''); // Return TextResponse instead of String
     }
 
-    debugPrint(
+    gemmaLog(
         'InferenceChat: Raw response from native model:\n--- START ---\n$cleanedResponse\n--- END ---');
 
     // Try to parse as function call if tools are available and model supports function calls
@@ -190,12 +193,12 @@ class InferenceChat {
         modelType: modelType,
       );
       if (allCalls.isNotEmpty) {
-        debugPrint(
+        gemmaLog(
             'InferenceChat: Detected ${allCalls.length} function call(s) in sync response');
         final toolCallMessage = Message.toolCall(text: cleanedResponse);
         _fullHistory.add(toolCallMessage);
         _modelHistory.add(toolCallMessage);
-        debugPrint(
+        gemmaLog(
             'InferenceChat: Added tool call to history: ${toolCallMessage.text}');
         if (allCalls.length == 1) {
           return allCalls.first;
@@ -211,7 +214,7 @@ class InferenceChat {
 
     // Clear model history for single-turn models (e.g., FunctionGemma)
     if (_isSingleTurnModel) {
-      debugPrint(
+      gemmaLog(
           'InferenceChat: Single-turn model detected, clearing model history...');
       _modelHistory.clear();
       _prefixes.clear();
@@ -221,7 +224,7 @@ class InferenceChat {
       // Recreate session to clear native state
       await session.close();
       session = await sessionCreator!();
-      debugPrint('InferenceChat: Model history cleared and session recreated');
+      gemmaLog('InferenceChat: Model history cleared and session recreated');
     }
 
     return TextResponse(
@@ -229,13 +232,13 @@ class InferenceChat {
   }
 
   Stream<ModelResponse> generateChatResponseAsync() async* {
-    debugPrint('InferenceChat: Starting async stream generation');
+    gemmaLog('InferenceChat: Starting async stream generation');
     final buffer = StringBuffer();
 
     // Smart function handling mode - continuous scanning for JSON patterns
     String funcBuffer = '';
 
-    debugPrint('InferenceChat: Starting to iterate over native tokens...');
+    gemmaLog('InferenceChat: Starting to iterate over native tokens...');
 
     // Track if we emitted a function call (to record correct history and skip session clearing)
     bool emittedFunctionCall = false;
@@ -268,7 +271,7 @@ class InferenceChat {
     await for (final response in stopFilteredStream) {
       if (response is TextResponse) {
         final token = response.token;
-        debugPrint('InferenceChat: Received filtered token: "$token"');
+        gemmaLog('InferenceChat: Received filtered token: "$token"');
 
         // Track if this token should be added to buffer (default true)
         bool shouldAddToBuffer = true;
@@ -281,7 +284,7 @@ class InferenceChat {
           if (funcBuffer.isNotEmpty) {
             // We're already buffering - add token and check for completion
             funcBuffer += token;
-            debugPrint(
+            gemmaLog(
                 'InferenceChat: Buffering token: "$token", total: ${funcBuffer.length} chars');
 
             // Check if we now have a complete JSON
@@ -294,7 +297,7 @@ class InferenceChat {
                     jsonData.containsKey('message')) {
                   // Found JSON with message field - extract and display the message
                   final message = jsonData['message'] as String;
-                  debugPrint(
+                  gemmaLog(
                       'InferenceChat: Extracted message from JSON: "$message"');
                   yield TextResponse(message);
                   funcBuffer = '';
@@ -302,7 +305,7 @@ class InferenceChat {
                   continue;
                 }
               } catch (e) {
-                debugPrint(
+                gemmaLog(
                     'InferenceChat: Failed to parse JSON for message extraction: $e');
               }
 
@@ -312,7 +315,7 @@ class InferenceChat {
                 modelType: modelType,
               );
               if (allCalls.isNotEmpty) {
-                debugPrint(
+                gemmaLog(
                     'InferenceChat: Found ${allCalls.length} function call(s) in complete buffer!');
                 emittedFunctionCall = true;
                 // Add function call to history IMMEDIATELY (before yielding)
@@ -320,7 +323,8 @@ class InferenceChat {
                 final toolCallMessage = Message.toolCall(text: funcBuffer);
                 _fullHistory.add(toolCallMessage);
                 _modelHistory.add(toolCallMessage);
-                debugPrint('InferenceChat: Added function call to history before yielding');
+                gemmaLog(
+                    'InferenceChat: Added function call to history before yielding');
                 if (allCalls.length == 1) {
                   yield allCalls.first;
                 } else {
@@ -331,7 +335,7 @@ class InferenceChat {
                 continue;
               } else {
                 // Not a valid function call - emit as text and clear buffer
-                debugPrint('InferenceChat: Invalid JSON, emitting as text');
+                gemmaLog('InferenceChat: Invalid JSON, emitting as text');
                 yield TextResponse(funcBuffer);
                 funcBuffer = '';
                 shouldAddToBuffer = false;
@@ -341,7 +345,7 @@ class InferenceChat {
 
             // If buffer gets too long without completing, flush as text
             if (funcBuffer.length > maxFunctionBufferLength) {
-              debugPrint(
+              gemmaLog(
                   'InferenceChat: Buffer too long without completion, flushing as text');
               yield TextResponse(funcBuffer);
               funcBuffer = '';
@@ -355,21 +359,21 @@ class InferenceChat {
             // Not currently buffering - check if this token starts a function call
             if (FunctionCallParser.isFunctionCallStart(token,
                 modelType: modelType)) {
-              debugPrint(
+              gemmaLog(
                   'InferenceChat: Found potential function call start in token: "$token"');
               funcBuffer = token;
               shouldAddToBuffer =
                   false; // Don't add to main buffer while we determine if it's JSON
             } else {
               // Normal text token - emit immediately
-              debugPrint('InferenceChat: Emitting text token: "$token"');
+              gemmaLog('InferenceChat: Emitting text token: "$token"');
               yield response;
               shouldAddToBuffer = true; // Add to main buffer for history
             }
           }
         } else {
           // No function processing happening - emit token directly
-          debugPrint(
+          gemmaLog(
               'InferenceChat: No function processing, emitting token as text: "$token"');
           yield response;
           shouldAddToBuffer = true; // Add to main buffer for history
@@ -385,9 +389,9 @@ class InferenceChat {
       }
     }
 
-    debugPrint('InferenceChat: Native token stream ended');
+    gemmaLog('InferenceChat: Native token stream ended');
     final response = buffer.toString();
-    debugPrint('InferenceChat: Complete response accumulated: "$response"');
+    gemmaLog('InferenceChat: Complete response accumulated: "$response"');
 
     // Gemma 4 path: streaming yielded plain text via the SDK passthrough
     // format. The tool calls live in the structured `lastRawResponse` JSON.
@@ -401,7 +405,7 @@ class InferenceChat {
       if (raw != null) {
         final allCalls = SdkResponseParser.extractToolCalls(raw);
         if (allCalls.isNotEmpty) {
-          debugPrint(
+          gemmaLog(
               'InferenceChat: ${allCalls.length} SDK-parsed tool call(s) at end of stream');
           emittedFunctionCall = true;
           if (allCalls.length == 1) {
@@ -415,7 +419,7 @@ class InferenceChat {
 
     // Handle end of stream - process any remaining buffer
     if (funcBuffer.isNotEmpty) {
-      debugPrint(
+      gemmaLog(
           'InferenceChat: Processing remaining buffer at end of stream: ${funcBuffer.length} chars');
 
       // For FunctionGemma, the function call spans response + funcBuffer
@@ -436,7 +440,7 @@ class InferenceChat {
             if (jsonData is Map<String, dynamic> &&
                 jsonData.containsKey('message')) {
               final message = jsonData['message'] as String;
-              debugPrint(
+              gemmaLog(
                   'InferenceChat: Extracted message from end-of-stream JSON: "$message"');
               yield TextResponse(message);
               return;
@@ -449,14 +453,15 @@ class InferenceChat {
             modelType: modelType,
           );
           if (allCalls.isNotEmpty) {
-            debugPrint(
+            gemmaLog(
                 'InferenceChat: ${allCalls.length} function call(s) found at end of stream');
             emittedFunctionCall = true;
             // Add function call to history IMMEDIATELY (before yielding)
             final toolCallMessage = Message.toolCall(text: contentToCheck);
             _fullHistory.add(toolCallMessage);
             _modelHistory.add(toolCallMessage);
-            debugPrint('InferenceChat: Added function call to history at end of stream');
+            gemmaLog(
+                'InferenceChat: Added function call to history at end of stream');
             if (allCalls.length == 1) {
               yield allCalls.first;
             } else {
@@ -466,53 +471,54 @@ class InferenceChat {
             yield TextResponse(funcBuffer);
           }
         } catch (e) {
-          debugPrint('InferenceChat: Failed to parse end-of-stream JSON: $e');
+          gemmaLog('InferenceChat: Failed to parse end-of-stream JSON: $e');
           yield TextResponse(funcBuffer);
         }
       } else {
-        debugPrint(
+        gemmaLog(
             'InferenceChat: No complete JSON at end of stream, emitting remaining as text');
         yield TextResponse(funcBuffer);
       }
     }
 
     try {
-      debugPrint('InferenceChat: Calculating response tokens...');
+      gemmaLog('InferenceChat: Calculating response tokens...');
       final responseTokens = await session.sizeInTokens(response);
-      debugPrint('InferenceChat: Response tokens: $responseTokens');
+      gemmaLog('InferenceChat: Response tokens: $responseTokens');
       _currentTokens += responseTokens;
-      debugPrint('InferenceChat: Current total tokens: $_currentTokens');
+      gemmaLog('InferenceChat: Current total tokens: $_currentTokens');
 
       if (_currentTokens >= (maxTokens - tokenBuffer)) {
-        debugPrint('InferenceChat: Token limit reached, recreating session...');
+        gemmaLog('InferenceChat: Token limit reached, recreating session...');
         await _recreateSessionWithReducedChunks();
-        debugPrint('InferenceChat: Session recreated successfully');
+        gemmaLog('InferenceChat: Session recreated successfully');
       }
     } catch (e) {
-      debugPrint('InferenceChat: Error during token calculation: $e');
+      gemmaLog('InferenceChat: Error during token calculation: $e');
     }
 
     try {
-      debugPrint('InferenceChat: Adding message to history...');
+      gemmaLog('InferenceChat: Adding message to history...');
       // For function calls: already added to history when yielded (above)
       // For text responses: add now since they weren't added during streaming
       if (!emittedFunctionCall) {
         final chatMessage = Message(text: response, isUser: false);
-        debugPrint(
+        gemmaLog(
             'InferenceChat: Created text message object: ${chatMessage.text}');
         _fullHistory.add(chatMessage);
-        debugPrint('InferenceChat: Added to full history');
+        gemmaLog('InferenceChat: Added to full history');
         _modelHistory.add(chatMessage);
-        debugPrint('InferenceChat: Added to model history');
+        gemmaLog('InferenceChat: Added to model history');
       } else {
-        debugPrint('InferenceChat: Function call was already added to history when yielded');
+        gemmaLog(
+            'InferenceChat: Function call was already added to history when yielded');
       }
-      debugPrint('InferenceChat: Message added to history successfully');
+      gemmaLog('InferenceChat: Message added to history successfully');
 
       // Clear model history for single-turn models (e.g., FunctionGemma)
       // BUT only if this was NOT a function call - we need context for tool response
       if (_isSingleTurnModel && !emittedFunctionCall) {
-        debugPrint(
+        gemmaLog(
             'InferenceChat: Single-turn model detected (text response), clearing model history...');
         _modelHistory.clear();
         _prefixes.clear();
@@ -522,19 +528,17 @@ class InferenceChat {
         // Recreate session to clear native state
         await session.close();
         session = await sessionCreator!();
-        debugPrint(
-            'InferenceChat: Model history cleared and session recreated');
+        gemmaLog('InferenceChat: Model history cleared and session recreated');
       } else if (_isSingleTurnModel && emittedFunctionCall) {
-        debugPrint(
+        gemmaLog(
             'InferenceChat: Single-turn model with function call - keeping history for tool response');
       }
     } catch (e) {
-      debugPrint('InferenceChat: Error adding message to history: $e');
+      gemmaLog('InferenceChat: Error adding message to history: $e');
       rethrow;
     }
 
-    debugPrint(
-        'InferenceChat: generateChatResponseAsync completed successfully');
+    gemmaLog('InferenceChat: generateChatResponseAsync completed successfully');
   }
 
   Future<void> _recreateSessionWithReducedChunks() async {

--- a/lib/core/di/service_registry.dart
+++ b/lib/core/di/service_registry.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gemma/core/domain/web_storage_mode.dart';
 import 'package:flutter_gemma/core/services/download_service.dart';
@@ -39,6 +39,7 @@ import 'platform/mobile_service_factory.dart'
     if (dart.library.js_interop) 'platform/web_service_factory.dart'
     as platform;
 import 'package:flutter_gemma/core/infrastructure/shared_preferences_protected_registry.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Dependency Injection Container for managing service lifecycle
 ///
@@ -428,12 +429,12 @@ class ServiceRegistry {
     if (_instance != null) {
       // Warn if critical parameters changed
       if (_instance!.webStorageMode != webStorageMode) {
-        debugPrint(
+        gemmaLog(
             'WARNING: webStorageMode cannot be changed after initialization.\n'
             'Current: ${_instance!.webStorageMode}, Requested: $webStorageMode\n'
             'Restart the application to change this setting.');
       }
-      debugPrint(
+      gemmaLog(
           'ServiceRegistry: Already initialized, skipping re-initialization');
       return;
     }
@@ -465,7 +466,7 @@ class ServiceRegistry {
     try {
       await _vectorStoreRepository.close();
     } catch (e) {
-      debugPrint('Warning: Failed to close VectorStore: $e');
+      gemmaLog('Warning: Failed to close VectorStore: $e');
     }
   }
 

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -41,8 +41,10 @@ extension MessageExtension on Message {
       {ModelType type = ModelType.general,
       ModelFileType fileType = ModelFileType.binary}) {
     // DEBUG LOG
-    gemmaLog(
-        '[transformToChatPrompt] modelType=$type, fileType=$fileType, messageType=${this.type}, isUser=$isUser');
+    if (kDebugMode) {
+      gemmaLog(
+          '[transformToChatPrompt] modelType=$type, fileType=$fileType, messageType=${this.type}, isUser=$isUser');
+    }
 
     // System messages should not be sent to the model
     if (this.type == MessageType.systemInfo) {
@@ -53,8 +55,10 @@ extension MessageExtension on Message {
     // EXCEPT FunctionGemma which needs manual formatting (no prefix/suffix in .task)
     if (fileType == ModelFileType.task && type != ModelType.functionGemma) {
       final result = _formatToolResponseContent();
-      gemmaLog(
-          '[transformToChatPrompt] Using _formatToolResponseContent, result length=${result.length}');
+      if (kDebugMode) {
+        gemmaLog(
+            '[transformToChatPrompt] Using _formatToolResponseContent, result length=${result.length}');
+      }
       return result;
     }
 
@@ -66,8 +70,10 @@ extension MessageExtension on Message {
         // Fall through to manual formatting below
       } else {
         final result = _formatToolResponseContent();
-        gemmaLog(
-            '[transformToChatPrompt] litertlm non-iOS, using raw text, result length=${result.length}');
+        if (kDebugMode) {
+          gemmaLog(
+              '[transformToChatPrompt] litertlm non-iOS, using raw text, result length=${result.length}');
+        }
         return result;
       }
     }

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/message.dart';
 import 'package:flutter_gemma/core/model.dart';
 import 'package:flutter_gemma/core/model_response.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 const userPrefix = "user";
 const modelPrefix = "model";
@@ -40,7 +41,7 @@ extension MessageExtension on Message {
       {ModelType type = ModelType.general,
       ModelFileType fileType = ModelFileType.binary}) {
     // DEBUG LOG
-    debugPrint(
+    gemmaLog(
         '[transformToChatPrompt] modelType=$type, fileType=$fileType, messageType=${this.type}, isUser=$isUser');
 
     // System messages should not be sent to the model
@@ -52,7 +53,7 @@ extension MessageExtension on Message {
     // EXCEPT FunctionGemma which needs manual formatting (no prefix/suffix in .task)
     if (fileType == ModelFileType.task && type != ModelType.functionGemma) {
       final result = _formatToolResponseContent();
-      debugPrint(
+      gemmaLog(
           '[transformToChatPrompt] Using _formatToolResponseContent, result length=${result.length}');
       return result;
     }
@@ -65,7 +66,7 @@ extension MessageExtension on Message {
         // Fall through to manual formatting below
       } else {
         final result = _formatToolResponseContent();
-        debugPrint(
+        gemmaLog(
             '[transformToChatPrompt] litertlm non-iOS, using raw text, result length=${result.length}');
         return result;
       }

--- a/lib/core/ffi/ffi_inference_model.dart
+++ b/lib/core/ffi/ffi_inference_model.dart
@@ -11,6 +11,7 @@ import '../extensions.dart';
 import '../parsing/sdk_response_parser.dart';
 import 'litert_lm_client.dart';
 import '../../pigeon.g.dart';
+import '../utils/gemma_log.dart';
 
 /// FFI implementation of InferenceModel using dart:ffi → LiteRT-LM C API.
 /// Shared between desktop and mobile (iOS) for .litertlm models.
@@ -112,7 +113,7 @@ class FfiInferenceModel extends InferenceModel {
         seed: randomSeed,
       );
       await _session?.close();
-      debugPrint(
+      gemmaLog(
           '[FfiInferenceModel/perf] createConversation (FFI): ${sessionSw.elapsedMilliseconds - beforeConv}ms');
 
       final session = _session = FfiInferenceModelSession(
@@ -129,7 +130,7 @@ class FfiInferenceModel extends InferenceModel {
       );
 
       completer.complete(session);
-      debugPrint(
+      gemmaLog(
           '[FfiInferenceModel/perf] createSession total: ${sessionSw.elapsedMilliseconds}ms');
       return session;
     } catch (e, st) {
@@ -376,7 +377,7 @@ class FfiInferenceModelSession extends InferenceModelSession
       )) {
         if (firstChunkMs == null) {
           firstChunkMs = genSw.elapsedMilliseconds;
-          debugPrint(
+          gemmaLog(
               '[FfiInferenceModelSession/perf] time-to-first-chunk (prefill): ${firstChunkMs}ms');
         }
         chunkCount++;
@@ -398,7 +399,7 @@ class FfiInferenceModelSession extends InferenceModelSession
     )) {
       if (firstChunkMs == null) {
         firstChunkMs = genSw.elapsedMilliseconds;
-        debugPrint(
+        gemmaLog(
             '[FfiInferenceModelSession/perf] time-to-first-chunk (prefill): ${firstChunkMs}ms');
       }
       chunkCount++;
@@ -411,7 +412,7 @@ class FfiInferenceModelSession extends InferenceModelSession
   void _logGenerationStats(Stopwatch sw, int? firstChunkMs, int chunks) {
     final total = sw.elapsedMilliseconds;
     if (firstChunkMs == null || chunks == 0) {
-      debugPrint(
+      gemmaLog(
           '[FfiInferenceModelSession/perf] generation total: ${total}ms (no chunks emitted)');
       return;
     }
@@ -419,7 +420,7 @@ class FfiInferenceModelSession extends InferenceModelSession
     final decodeRate = chunks > 1 && decodeMs > 0
         ? ((chunks - 1) * 1000.0 / decodeMs).toStringAsFixed(1)
         : 'n/a';
-    debugPrint('[FfiInferenceModelSession/perf] generation total: ${total}ms '
+    gemmaLog('[FfiInferenceModelSession/perf] generation total: ${total}ms '
         '(prefill ${firstChunkMs}ms + decode ${decodeMs}ms over $chunks chunks, '
         '~$decodeRate chunks/sec)');
   }
@@ -449,7 +450,7 @@ class FfiInferenceModelSession extends InferenceModelSession
       )) {
         if (firstChunkMs == null) {
           firstChunkMs = genSw.elapsedMilliseconds;
-          debugPrint(
+          gemmaLog(
               '[FfiInferenceModelSession/perf] (async) time-to-first-chunk (prefill): ${firstChunkMs}ms');
         }
         chunkCount++;
@@ -470,7 +471,7 @@ class FfiInferenceModelSession extends InferenceModelSession
     )) {
       if (firstChunkMs == null) {
         firstChunkMs = genSw.elapsedMilliseconds;
-        debugPrint(
+        gemmaLog(
             '[FfiInferenceModelSession/perf] (async) time-to-first-chunk (prefill): ${firstChunkMs}ms');
       }
       chunkCount++;

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -547,8 +547,10 @@ class LiteRtLmFfiClient {
       gemmaLog(
           '[LiteRtLmFfi/perf] === START litert_lm_engine_create (native — model load + accelerator init + KV cache prefill) ===');
       final settingsAddr = settings.address;
+      final isolateLogLevel = gemmaLogLevel;
       final sw = Stopwatch()..start();
       final engineAddr = await Isolate.run(() {
+        gemmaLogLevel = isolateLogLevel;
         final isolateSw = Stopwatch()..start();
         final lib = Platform.isIOS
             ? DynamicLibrary.open(
@@ -558,20 +560,20 @@ class LiteRtLmFfiClient {
                 : (Platform.isLinux || Platform.isAndroid)
                     ? DynamicLibrary.open('libLiteRtLm.so')
                     : DynamicLibrary.open('LiteRtLm.dll');
-        // ignore: avoid_print
-        print(
-            '[LiteRtLmFfi/perf]   isolate: DynamicLibrary.open: ${isolateSw.elapsedMilliseconds}ms');
+        gemmaLog(
+            '[LiteRtLmFfi/perf]   isolate: DynamicLibrary.open: ${isolateSw.elapsedMilliseconds}ms',
+            level: GemmaLogLevel.verbose);
         final lookupStart = isolateSw.elapsedMilliseconds;
         final create = lib.lookupFunction<Pointer Function(Pointer),
             Pointer Function(Pointer)>('litert_lm_engine_create');
-        // ignore: avoid_print
-        print(
-            '[LiteRtLmFfi/perf]   isolate: lookupFunction: ${isolateSw.elapsedMilliseconds - lookupStart}ms');
+        gemmaLog(
+            '[LiteRtLmFfi/perf]   isolate: lookupFunction: ${isolateSw.elapsedMilliseconds - lookupStart}ms',
+            level: GemmaLogLevel.verbose);
         final createStart = isolateSw.elapsedMilliseconds;
         final ptr = create(Pointer.fromAddress(settingsAddr)).address;
-        // ignore: avoid_print
-        print(
-            '[LiteRtLmFfi/perf]   isolate: native litert_lm_engine_create: ${isolateSw.elapsedMilliseconds - createStart}ms');
+        gemmaLog(
+            '[LiteRtLmFfi/perf]   isolate: native litert_lm_engine_create: ${isolateSw.elapsedMilliseconds - createStart}ms',
+            level: GemmaLogLevel.verbose);
         return ptr;
       });
       _engine = Pointer<LiteRtLmEngine>.fromAddress(engineAddr);

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -235,7 +235,7 @@ class LiteRtLmFfiClient {
       for (var i = 0; i < content.length; i += chunkSize) {
         final end =
             (i + chunkSize < content.length) ? i + chunkSize : content.length;
-        gemmaLog(content.substring(i, end));
+        gemmaLog(content.substring(i, end), level: GemmaLogLevel.verbose);
       }
       gemmaLog('[LiteRtLmFfi/native] === END native log ===');
       // Truncate so the next dump only shows new output. If truncation fails

--- a/lib/core/ffi/litert_lm_client.dart
+++ b/lib/core/ffi/litert_lm_client.dart
@@ -12,6 +12,7 @@ import 'package:mutex/mutex.dart';
 import '../../flutter_gemma_interface.dart';
 import '../parsing/sdk_text_extractor.dart';
 import 'litert_lm_bindings.dart';
+import '../utils/gemma_log.dart';
 
 /// Callback typedef with Uint8 for bool (C _Bool = 1 byte)
 typedef _StreamCallbackNative = Void Function(Pointer<Void> callbackData,
@@ -220,30 +221,30 @@ class LiteRtLmFfiClient {
     try {
       final f = File(p);
       if (!f.existsSync()) {
-        debugPrint('[LiteRtLmFfi/native] log file missing: $p');
+        gemmaLog('[LiteRtLmFfi/native] log file missing: $p');
         return;
       }
       final content = f.readAsStringSync();
       if (content.isEmpty) {
-        debugPrint('[LiteRtLmFfi/native] (no new native log output)');
+        gemmaLog('[LiteRtLmFfi/native] (no new native log output)');
         return;
       }
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi/native] === BEGIN native log ($p, ${content.length} bytes) ===');
       const chunkSize = 800;
       for (var i = 0; i < content.length; i += chunkSize) {
         final end =
             (i + chunkSize < content.length) ? i + chunkSize : content.length;
-        debugPrint(content.substring(i, end));
+        gemmaLog(content.substring(i, end));
       }
-      debugPrint('[LiteRtLmFfi/native] === END native log ===');
+      gemmaLog('[LiteRtLmFfi/native] === END native log ===');
       // Truncate so the next dump only shows new output. If truncation fails
       // (read-only fs etc.), next dump just re-prints — non-fatal.
       try {
         f.writeAsStringSync('');
       } catch (_) {}
     } catch (e) {
-      debugPrint('[LiteRtLmFfi/native] failed to read $p: $e');
+      gemmaLog('[LiteRtLmFfi/native] failed to read $p: $e');
     }
   }
 
@@ -259,7 +260,7 @@ class LiteRtLmFfiClient {
     if (_bindings != null) return;
 
     final loadSw = Stopwatch()..start();
-    debugPrint('[LiteRtLmFfi] Loading native libraries...');
+    gemmaLog('[LiteRtLmFfi] Loading native libraries...');
     final DynamicLibrary lib;
     final DynamicLibrary proxyLib;
     if (Platform.isIOS) {
@@ -421,17 +422,17 @@ class LiteRtLmFfiClient {
       if (rc != 0) {
         // Log capture is best-effort but its failure makes _dumpNativeLog
         // useless. Surface it instead of silently continuing.
-        debugPrint('[LiteRtLmFfi] WARNING: stderr redirect failed (rc=$rc) — '
+        gemmaLog('[LiteRtLmFfi] WARNING: stderr redirect failed (rc=$rc) — '
             'native log dumps will be empty');
         _nativeLogPath = null;
       } else {
-        debugPrint('[LiteRtLmFfi] stderr redirected to $_nativeLogPath');
+        gemmaLog('[LiteRtLmFfi] stderr redirected to $_nativeLogPath');
       }
     }
 
-    debugPrint(
+    gemmaLog(
         '[LiteRtLmFfi/perf] _ensureBindings total: ${loadSw.elapsedMilliseconds}ms');
-    debugPrint('[LiteRtLmFfi] Libraries loaded');
+    gemmaLog('[LiteRtLmFfi] Libraries loaded');
   }
 
   /// Initialize the engine with model path and settings.
@@ -449,7 +450,7 @@ class LiteRtLmFfiClient {
     _ensureBindings();
     _backend = backend;
     final bindingsMs = initSw.elapsedMilliseconds;
-    debugPrint('[LiteRtLmFfi/perf] _ensureBindings: ${bindingsMs}ms');
+    gemmaLog('[LiteRtLmFfi/perf] _ensureBindings: ${bindingsMs}ms');
     final b = _bindings!;
 
     // Create engine settings
@@ -466,7 +467,7 @@ class LiteRtLmFfiClient {
         visionBackendPtr == nullptr ? nullptr : visionBackendPtr.cast(),
         audioBackendPtr == nullptr ? nullptr : audioBackendPtr.cast(),
       );
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi/perf] settings_create: ${initSw.elapsedMilliseconds - settingsCreateStart}ms');
 
       if (settings == nullptr) {
@@ -514,7 +515,7 @@ class LiteRtLmFfiClient {
             settings, dirPtr.cast());
         calloc.free(dirPtr);
         b.litert_lm_engine_settings_set_use_hw_masking_for_npu(settings, false);
-        debugPrint(
+        gemmaLog(
             '[LiteRtLmFfi] NPU Windows: dispatch_lib_dir=$exeDir, use_hw_masking_for_npu=false');
       }
 
@@ -536,14 +537,14 @@ class LiteRtLmFfiClient {
         b.litert_lm_engine_settings_set_litert_dispatch_lib_dir(
             settings, dirPtr.cast());
         calloc.free(dirPtr);
-        debugPrint('[LiteRtLmFfi] NPU Android: dispatch_lib_dir=$nativeLibDir');
+        gemmaLog('[LiteRtLmFfi] NPU Android: dispatch_lib_dir=$nativeLibDir');
       }
 
       // Create engine in a background isolate to avoid blocking UI.
       // Pass settings pointer as int address (Pointer can't cross isolates).
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi] Creating engine from $modelPath (backend=$backend, maxTokens=$maxTokens) ...');
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi/perf] === START litert_lm_engine_create (native — model load + accelerator init + KV cache prefill) ===');
       final settingsAddr = settings.address;
       final sw = Stopwatch()..start();
@@ -575,9 +576,9 @@ class LiteRtLmFfiClient {
       });
       _engine = Pointer<LiteRtLmEngine>.fromAddress(engineAddr);
       sw.stop();
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi/perf] === END litert_lm_engine_create: ${sw.elapsedMilliseconds}ms (includes isolate spawn ~50-200ms) ===');
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi] litert_lm_engine_create took ${sw.elapsedMilliseconds}ms');
       b.litert_lm_engine_settings_delete(settings);
 
@@ -588,9 +589,9 @@ class LiteRtLmFfiClient {
       }
 
       _isInitialized = true;
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmFfi/perf] initialize() total: ${initSw.elapsedMilliseconds}ms');
-      debugPrint('[LiteRtLmFfi] Engine initialized successfully');
+      gemmaLog('[LiteRtLmFfi] Engine initialized successfully');
 
       // Auto-dump the SDK's stderr log after successful engine_create so
       // users can see what happens inside the native call (model load time,
@@ -637,7 +638,7 @@ class LiteRtLmFfiClient {
       topP: topP,
       seed: seed,
     );
-    debugPrint('[LiteRtLmFfi] Conversation created');
+    gemmaLog('[LiteRtLmFfi] Conversation created');
     final handle = LiteRtLmConversationHandle._(this, conv);
     _handles.add(handle);
     return handle;
@@ -694,7 +695,7 @@ class LiteRtLmFfiClient {
           sessionConfig, samplerParams);
       calloc.free(samplerParams);
     } else {
-      debugPrint('[LiteRtLmFfi] NPU backend — sampler params '
+      gemmaLog('[LiteRtLmFfi] NPU backend — sampler params '
           '(temperature, topK, topP, seed) ignored, engine uses '
           'internal greedy sampling.');
     }
@@ -1235,7 +1236,7 @@ class LiteRtLmFfiClient {
   void _cancelOn(Pointer<LiteRtLmConversation> conv) {
     if (_bindings != null) {
       _bindings!.litert_lm_conversation_cancel_process(conv);
-      debugPrint('[LiteRtLmFfi] Generation cancelled');
+      gemmaLog('[LiteRtLmFfi] Generation cancelled');
     }
   }
 
@@ -1249,7 +1250,7 @@ class LiteRtLmFfiClient {
   void _deleteConversation(Pointer<LiteRtLmConversation> conv) {
     if (_bindings != null) {
       _bindings!.litert_lm_conversation_delete(conv);
-      debugPrint('[LiteRtLmFfi] Conversation closed');
+      gemmaLog('[LiteRtLmFfi] Conversation closed');
     }
   }
 
@@ -1280,7 +1281,7 @@ class LiteRtLmFfiClient {
     if (_engine != null && _engine != nullptr && _bindings != null) {
       _bindings!.litert_lm_engine_delete(_engine!);
       _engine = null;
-      debugPrint('[LiteRtLmFfi] Engine deleted');
+      gemmaLog('[LiteRtLmFfi] Engine deleted');
     }
 
     _isInitialized = false;
@@ -1352,7 +1353,7 @@ class LiteRtLmFfiClient {
         initTimeMs: initTime > 0 ? initTime * 1000 : null,
       );
     } catch (e) {
-      debugPrint('[LiteRtLmFfiClient] Error getting metrics: $e');
+      gemmaLog('[LiteRtLmFfiClient] Error getting metrics: $e');
       _bindings!.litert_lm_benchmark_info_delete(benchmarkInfo);
       return SessionMetrics();
     }

--- a/lib/core/function_call_parser.dart
+++ b/lib/core/function_call_parser.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 import 'package:flutter_gemma/core/parsing/function_call_format.dart';
 import 'package:flutter_gemma/core/parsing/function_call_format_factory.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Facade for backward compatibility.
 /// Delegates to model-specific [FunctionCallFormat] implementations.
@@ -43,7 +43,7 @@ class FunctionCallParser {
     try {
       return FunctionCallFormatFactory.create(modelType).parse(text);
     } catch (e) {
-      debugPrint('FunctionCallParser: Error parsing function call: $e');
+      gemmaLog('FunctionCallParser: Error parsing function call: $e');
       return null;
     }
   }
@@ -56,7 +56,7 @@ class FunctionCallParser {
     try {
       return FunctionCallFormatFactory.create(modelType).parseAll(text);
     } catch (e) {
-      debugPrint('FunctionCallParser: Error parsing function calls: $e');
+      gemmaLog('FunctionCallParser: Error parsing function calls: $e');
       return [];
     }
   }

--- a/lib/core/handlers/web_asset_source_handler.dart
+++ b/lib/core/handlers/web_asset_source_handler.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/handlers/source_handler.dart';
@@ -7,6 +6,7 @@ import 'package:flutter_gemma/core/infrastructure/web_file_system_service.dart';
 import 'package:flutter_gemma/core/infrastructure/web_cache_service.dart';
 import 'package:flutter_gemma/core/services/model_repository.dart';
 import 'package:path/path.dart' as path;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Handles installation of models from Flutter assets on web platform
 ///
@@ -69,7 +69,7 @@ class WebAssetSourceHandler implements SourceHandler {
       yield* cacheService.getOrCacheAndRegisterWithProgress(
         cacheKey: cacheKey,
         loader: (onProgress) async {
-          debugPrint(
+          gemmaLog(
               '[WebAssetSourceHandler] Loading asset: ${source.normalizedPath}');
 
           onProgress(0.0);
@@ -82,7 +82,7 @@ class WebAssetSourceHandler implements SourceHandler {
                 'Check that the file exists and is not corrupted.');
           }
 
-          debugPrint(
+          gemmaLog(
               '[WebAssetSourceHandler] Asset loaded: ${bytes.length} bytes');
           onProgress(1.0);
 
@@ -106,7 +106,7 @@ class WebAssetSourceHandler implements SourceHandler {
 
       await repository.saveModel(modelInfo);
     } catch (e) {
-      debugPrint('[WebAssetSourceHandler] ❌ Failed to install asset: $e');
+      gemmaLog('[WebAssetSourceHandler] ❌ Failed to install asset: $e');
       rethrow;
     }
   }

--- a/lib/core/handlers/web_bundled_source_handler.dart
+++ b/lib/core/handlers/web_bundled_source_handler.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/handlers/source_handler.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
@@ -6,6 +5,7 @@ import 'package:flutter_gemma/core/infrastructure/web_file_system_service.dart';
 import 'package:flutter_gemma/core/infrastructure/web_cache_service.dart';
 import 'package:flutter_gemma/core/infrastructure/web_js_interop.dart';
 import 'package:flutter_gemma/core/services/model_repository.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Handles installation of models from native bundled resources (WEB PLATFORM)
 ///
@@ -73,7 +73,7 @@ class WebBundledSourceHandler implements SourceHandler {
       yield* cacheService.getOrCacheAndRegisterWithProgress(
         cacheKey: cacheKey,
         loader: (onProgress) async {
-          debugPrint(
+          gemmaLog(
               '[WebBundledSourceHandler] Fetching bundled resource: $resourceName');
 
           onProgress(0.0);
@@ -85,7 +85,7 @@ class WebBundledSourceHandler implements SourceHandler {
                 'Check that the resource exists in the web bundle.');
           }
 
-          debugPrint(
+          gemmaLog(
               '[WebBundledSourceHandler] Resource fetched: ${response.data.length} bytes');
           onProgress(1.0);
 
@@ -109,7 +109,7 @@ class WebBundledSourceHandler implements SourceHandler {
 
       await repository.saveModel(modelInfo);
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           '[WebBundledSourceHandler] ❌ Failed to install bundled resource: $e');
       rethrow;
     }

--- a/lib/core/handlers/web_network_source_handler.dart
+++ b/lib/core/handlers/web_network_source_handler.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/domain/download_exception.dart';
 import 'package:flutter_gemma/core/domain/download_error.dart';
@@ -8,6 +7,7 @@ import 'package:flutter_gemma/core/services/download_service.dart';
 import 'package:flutter_gemma/core/services/model_repository.dart';
 import 'package:flutter_gemma/core/infrastructure/web_cache_service.dart';
 import 'package:path/path.dart' as path;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Handles installation of models from network URLs on web platform
 ///
@@ -103,7 +103,7 @@ class WebNetworkSourceHandler implements SourceHandler {
 
       await repository.saveModel(modelInfo);
     } on DownloadCancelledException {
-      debugPrint('[WebNetworkSourceHandler] ⏸️  Installation cancelled');
+      gemmaLog('[WebNetworkSourceHandler] ⏸️  Installation cancelled');
       rethrow;
     } on DownloadException catch (e) {
       final errorMsg = switch (e.error) {
@@ -116,10 +116,10 @@ class WebNetworkSourceHandler implements SourceHandler {
         CanceledError() => 'Canceled',
         UnknownError(:final message) => 'Unknown Error: $message',
       };
-      debugPrint('[WebNetworkSourceHandler] ❌ Download failed: $errorMsg');
+      gemmaLog('[WebNetworkSourceHandler] ❌ Download failed: $errorMsg');
       rethrow;
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           '[WebNetworkSourceHandler] ❌ Failed to install network model: $e');
       rethrow;
     }

--- a/lib/core/image_error_handler.dart
+++ b/lib/core/image_error_handler.dart
@@ -62,7 +62,8 @@ class ImageErrorHandler {
     gemmaLog('Expected Images: $expectedImageCount');
     gemmaLog('Prompt Length: ${prompt?.length ?? 0}');
     if (prompt != null && prompt.length < _maxLogSize) {
-      gemmaLog('Prompt Preview: ${_sanitizePromptForLogging(prompt)}');
+      gemmaLog('Prompt Preview: ${_sanitizePromptForLogging(prompt)}',
+          level: GemmaLogLevel.verbose);
     }
 
     final errorType = _categorizeTokenizationError(error, prompt);
@@ -134,7 +135,8 @@ class ImageErrorHandler {
       gemmaLog('=== DETECTING RESPONSE CORRUPTION ===');
       gemmaLog('Response Length: ${response.length}');
       if (response.length < _maxLogSize) {
-        gemmaLog('Response Preview: ${_sanitizeResponseForLogging(response)}');
+        gemmaLog('Response Preview: ${_sanitizeResponseForLogging(response)}',
+            level: GemmaLogLevel.verbose);
       }
 
       // Check for known corruption patterns

--- a/lib/core/image_error_handler.dart
+++ b/lib/core/image_error_handler.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'image_processor.dart';
 import 'image_tokenizer.dart';
 import 'vision_encoder_validator.dart';
+import 'utils/gemma_log.dart';
 
 /// Comprehensive error handling and debugging utilities for AI image processing
 /// to prevent corruption that causes repeating text patterns in model responses.
@@ -15,19 +16,19 @@ class ImageErrorHandler {
     Uint8List? imageBytes,
     String? context,
   }) {
-    debugPrint('=== IMAGE PROCESSING ERROR ===');
-    debugPrint('Context: $context');
-    debugPrint('Error: $error');
-    debugPrint('StackTrace: $stackTrace');
+    gemmaLog('=== IMAGE PROCESSING ERROR ===');
+    gemmaLog('Context: $context');
+    gemmaLog('Error: $error');
+    gemmaLog('StackTrace: $stackTrace');
 
     if (imageBytes != null) {
-      debugPrint('Image bytes: ${imageBytes.length} bytes');
+      gemmaLog('Image bytes: ${imageBytes.length} bytes');
       _logImageInfo(imageBytes);
     }
 
     // Categorize the error
     final errorType = _categorizeError(error);
-    debugPrint('Error Type: $errorType');
+    gemmaLog('Error Type: $errorType');
 
     // Generate recovery suggestions
     final suggestions = _generateRecoverySuggestions(errorType, imageBytes);
@@ -35,8 +36,8 @@ class ImageErrorHandler {
     // Create detailed error message
     final message = _createDetailedErrorMessage(error, errorType, context);
 
-    debugPrint('Recovery Suggestions: ${suggestions.join(', ')}');
-    debugPrint('================================');
+    gemmaLog('Recovery Suggestions: ${suggestions.join(', ')}');
+    gemmaLog('================================');
 
     return ErrorHandlingResult(
       isRecoverable: _isRecoverable(errorType),
@@ -56,16 +57,16 @@ class ImageErrorHandler {
     String? prompt,
     int? expectedImageCount,
   }) {
-    debugPrint('=== IMAGE TOKENIZATION ERROR ===');
-    debugPrint('Model Type: $modelType');
-    debugPrint('Expected Images: $expectedImageCount');
-    debugPrint('Prompt Length: ${prompt?.length ?? 0}');
+    gemmaLog('=== IMAGE TOKENIZATION ERROR ===');
+    gemmaLog('Model Type: $modelType');
+    gemmaLog('Expected Images: $expectedImageCount');
+    gemmaLog('Prompt Length: ${prompt?.length ?? 0}');
     if (prompt != null && prompt.length < _maxLogSize) {
-      debugPrint('Prompt Preview: ${_sanitizePromptForLogging(prompt)}');
+      gemmaLog('Prompt Preview: ${_sanitizePromptForLogging(prompt)}');
     }
 
     final errorType = _categorizeTokenizationError(error, prompt);
-    debugPrint('Tokenization Error Type: $errorType');
+    gemmaLog('Tokenization Error Type: $errorType');
 
     final suggestions = _generateTokenizationRecoverySuggestions(
       errorType,
@@ -76,8 +77,8 @@ class ImageErrorHandler {
     final message =
         _createTokenizationErrorMessage(error, errorType, modelType);
 
-    debugPrint('Tokenization Recovery: ${suggestions.join(', ')}');
-    debugPrint('================================');
+    gemmaLog('Tokenization Recovery: ${suggestions.join(', ')}');
+    gemmaLog('================================');
 
     return ErrorHandlingResult(
       isRecoverable: _isTokenizationRecoverable(errorType),
@@ -95,10 +96,10 @@ class ImageErrorHandler {
     Uint8List? imageBytes,
     VisionEncoderType? encoderType,
   }) {
-    debugPrint('=== VISION ENCODER VALIDATION ERROR ===');
-    debugPrint('Encoder: ${encoderType?.name ?? 'unknown'}');
-    debugPrint('Validation Result: ${validationResult.isValid}');
-    debugPrint('Message: ${validationResult.message}');
+    gemmaLog('=== VISION ENCODER VALIDATION ERROR ===');
+    gemmaLog('Encoder: ${encoderType?.name ?? 'unknown'}');
+    gemmaLog('Validation Result: ${validationResult.isValid}');
+    gemmaLog('Message: ${validationResult.message}');
 
     if (imageBytes != null) {
       _logImageInfo(imageBytes);
@@ -115,8 +116,8 @@ class ImageErrorHandler {
     final message =
         'Vision encoder validation failed: ${validationResult.message}';
 
-    debugPrint('Validation Recovery: ${suggestions.join(', ')}');
-    debugPrint('======================================');
+    gemmaLog('Validation Recovery: ${suggestions.join(', ')}');
+    gemmaLog('======================================');
 
     return ErrorHandlingResult(
       isRecoverable: true, // Validation errors are usually recoverable
@@ -130,11 +131,10 @@ class ImageErrorHandler {
   /// Detects and handles model response corruption patterns
   static CorruptionDetectionResult detectResponseCorruption(String response) {
     try {
-      debugPrint('=== DETECTING RESPONSE CORRUPTION ===');
-      debugPrint('Response Length: ${response.length}');
+      gemmaLog('=== DETECTING RESPONSE CORRUPTION ===');
+      gemmaLog('Response Length: ${response.length}');
       if (response.length < _maxLogSize) {
-        debugPrint(
-            'Response Preview: ${_sanitizeResponseForLogging(response)}');
+        gemmaLog('Response Preview: ${_sanitizeResponseForLogging(response)}');
       }
 
       // Check for known corruption patterns
@@ -147,9 +147,9 @@ class ImageErrorHandler {
       final confidence =
           _calculateCorruptionConfidence(hasCorruption, analysis);
 
-      debugPrint('Corruption Detected: $hasCorruption');
-      debugPrint('Confidence Level: ${confidence.toStringAsFixed(2)}');
-      debugPrint('Analysis: $analysis');
+      gemmaLog('Corruption Detected: $hasCorruption');
+      gemmaLog('Confidence Level: ${confidence.toStringAsFixed(2)}');
+      gemmaLog('Analysis: $analysis');
 
       return CorruptionDetectionResult(
         isCorrupted: hasCorruption,
@@ -158,7 +158,7 @@ class ImageErrorHandler {
         suggestedAction: _suggestCorruptionAction(confidence, analysis),
       );
     } catch (e) {
-      debugPrint('Error detecting corruption: $e');
+      gemmaLog('Error detecting corruption: $e');
       return CorruptionDetectionResult(
         isCorrupted: false,
         confidence: 0.0,
@@ -174,9 +174,9 @@ class ImageErrorHandler {
       final format = ImageProcessor.detectFormat(imageBytes);
       final sizeInKB = imageBytes.length / 1024;
 
-      debugPrint('Image Format: $format');
-      debugPrint('Image Size: ${sizeInKB.toStringAsFixed(2)}KB');
-      debugPrint('Image Bytes: ${imageBytes.length}');
+      gemmaLog('Image Format: $format');
+      gemmaLog('Image Size: ${sizeInKB.toStringAsFixed(2)}KB');
+      gemmaLog('Image Bytes: ${imageBytes.length}');
 
       // Log first few bytes for signature analysis
       if (imageBytes.length >= 8) {
@@ -184,10 +184,10 @@ class ImageErrorHandler {
             .sublist(0, 8)
             .map((b) => '0x${b.toRadixString(16).padLeft(2, '0')}')
             .join(' ');
-        debugPrint('Image Signature: $signature');
+        gemmaLog('Image Signature: $signature');
       }
     } catch (e) {
-      debugPrint('Error logging image info: $e');
+      gemmaLog('Error logging image info: $e');
     }
   }
 

--- a/lib/core/image_processor.dart
+++ b/lib/core/image_processor.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
+import 'utils/gemma_log.dart';
 
 /// Comprehensive image processing utilities to prevent AI image corruption
 /// and ensure proper vision encoder compatibility.
@@ -17,36 +18,36 @@ class ImageProcessor {
   static Future<ProcessedImage> processImage(Uint8List imageBytes,
       {String? originalFormat}) async {
     try {
-      debugPrint('ImageProcessor: Starting image processing...');
+      gemmaLog('ImageProcessor: Starting image processing...');
 
       // Step 1: Validate input
       _validateImageBytes(imageBytes);
 
       // Step 2: Decode image to check format and get dimensions
       final decodedImage = await _decodeImage(imageBytes);
-      debugPrint(
+      gemmaLog(
           'ImageProcessor: Original image - Format: ${originalFormat ?? 'unknown'}, '
           'Width: ${decodedImage.width}, Height: ${decodedImage.height}');
 
       // Step 3: Resize to target dimensions (896x896 for Gemma 3)
       final resizedImage =
           await _resizeImage(decodedImage, _targetWidth, _targetHeight);
-      debugPrint(
+      gemmaLog(
           'ImageProcessor: Image resized to ${_targetWidth}x$_targetHeight');
 
       // Step 4: Convert to optimal format (PNG for lossless quality)
       final processedBytes = await _encodeToPng(resizedImage);
-      debugPrint('ImageProcessor: Image converted to PNG format');
+      gemmaLog('ImageProcessor: Image converted to PNG format');
 
       // Step 5: Create Base64 encoded version for transmission
       final base64String = _encodeBase64Safe(processedBytes);
-      debugPrint(
+      gemmaLog(
           'ImageProcessor: Base64 encoding completed (${base64String.length} chars)');
 
       // Step 6: Validate final output
       _validateProcessedImage(processedBytes, base64String);
 
-      debugPrint('ImageProcessor: Image processing completed successfully');
+      gemmaLog('ImageProcessor: Image processing completed successfully');
 
       return ProcessedImage(
         originalBytes: imageBytes,
@@ -58,7 +59,7 @@ class ImageProcessor {
         originalFormat: originalFormat ?? detectFormat(imageBytes),
       );
     } catch (e) {
-      debugPrint('ImageProcessor: Error processing image - $e');
+      gemmaLog('ImageProcessor: Error processing image - $e');
       throw ImageProcessingException('Failed to process image: $e');
     }
   }
@@ -76,7 +77,7 @@ class ImageProcessor {
 
     // Check for minimum viable image size (roughly 100x100 pixels in most formats)
     if (imageBytes.length < 1024) {
-      debugPrint(
+      gemmaLog(
           'ImageProcessor: Warning - Image appears very small (${imageBytes.length} bytes)');
     }
   }

--- a/lib/core/image_tokenizer.dart
+++ b/lib/core/image_tokenizer.dart
@@ -216,7 +216,8 @@ class ImageTokenizer {
           if (entry.value > words.length * 0.3) {
             // More than 30% of words
             gemmaLog(
-                'ImageTokenizer: Detected excessive repetition of "${entry.key}" (${entry.value} times)');
+                'ImageTokenizer: Detected excessive repetition of "${entry.key}" (${entry.value} times)',
+                level: GemmaLogLevel.verbose);
             return true;
           }
         }

--- a/lib/core/image_tokenizer.dart
+++ b/lib/core/image_tokenizer.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/foundation.dart';
 import 'image_processor.dart';
+import 'utils/gemma_log.dart';
 
 /// Handles proper image tokenization for multimodal AI models to prevent
 /// "Prompt contained 0 image tokens but received 1 images" errors and
@@ -13,7 +13,7 @@ class ImageTokenizer {
     required String role,
   }) {
     try {
-      debugPrint('ImageTokenizer: Creating structured image message...');
+      gemmaLog('ImageTokenizer: Creating structured image message...');
 
       // Validate inputs
       if (text.isEmpty) {
@@ -43,12 +43,12 @@ class ImageTokenizer {
         ],
       };
 
-      debugPrint('ImageTokenizer: Structured message created with '
+      gemmaLog('ImageTokenizer: Structured message created with '
           '${(message['content'] as List).length} content items');
 
       return message;
     } catch (e) {
-      debugPrint('ImageTokenizer: Error creating image message - $e');
+      gemmaLog('ImageTokenizer: Error creating image message - $e');
       throw ImageTokenizationException('Failed to create image message: $e');
     }
   }
@@ -61,7 +61,7 @@ class ImageTokenizer {
     required ModelType modelType,
   }) {
     try {
-      debugPrint('ImageTokenizer: Creating image prompt for $modelType...');
+      gemmaLog('ImageTokenizer: Creating image prompt for $modelType...');
 
       switch (modelType) {
         case ModelType.gemmaIt:
@@ -72,7 +72,7 @@ class ImageTokenizer {
           return _createGeneralImagePrompt(text, processedImage);
       }
     } catch (e) {
-      debugPrint('ImageTokenizer: Error creating image prompt - $e');
+      gemmaLog('ImageTokenizer: Error creating image prompt - $e');
       throw ImageTokenizationException('Failed to create image prompt: $e');
     }
   }
@@ -96,7 +96,7 @@ class ImageTokenizer {
     prompt.write('\n<start_of_turn>model\n');
 
     final result = prompt.toString();
-    debugPrint('ImageTokenizer: Created Gemma prompt (${result.length} chars)');
+    gemmaLog('ImageTokenizer: Created Gemma prompt (${result.length} chars)');
     return result;
   }
 
@@ -113,7 +113,7 @@ class ImageTokenizer {
     prompt.write('<｜/image｜><｜Assistant｜>');
 
     final result = prompt.toString();
-    debugPrint(
+    gemmaLog(
         'ImageTokenizer: Created DeepSeek prompt (${result.length} chars)');
     return result;
   }
@@ -132,15 +132,14 @@ class ImageTokenizer {
     prompt.write('<start_of_turn>model\n');
 
     final result = prompt.toString();
-    debugPrint(
-        'ImageTokenizer: Created general prompt (${result.length} chars)');
+    gemmaLog('ImageTokenizer: Created general prompt (${result.length} chars)');
     return result;
   }
 
   /// Validates that a message contains proper image tokens
   static bool validateImageTokens(String prompt, int expectedImageCount) {
     try {
-      debugPrint(
+      gemmaLog(
           'ImageTokenizer: Validating image tokens - expected: $expectedImageCount');
 
       // Count image tokens using various patterns
@@ -167,12 +166,11 @@ class ImageTokenizer {
         imageTokenCount += base64Matches.length;
       }
 
-      debugPrint(
-          'ImageTokenizer: Found $imageTokenCount image tokens in prompt');
+      gemmaLog('ImageTokenizer: Found $imageTokenCount image tokens in prompt');
 
       return imageTokenCount >= expectedImageCount;
     } catch (e) {
-      debugPrint('ImageTokenizer: Error validating image tokens - $e');
+      gemmaLog('ImageTokenizer: Error validating image tokens - $e');
       return false;
     }
   }
@@ -196,7 +194,7 @@ class ImageTokenizer {
 
       for (final pattern in corruptionPatterns) {
         if (pattern.hasMatch(response)) {
-          debugPrint(
+          gemmaLog(
               'ImageTokenizer: Detected corruption pattern - ${pattern.pattern}');
           return true;
         }
@@ -217,7 +215,7 @@ class ImageTokenizer {
         for (final entry in wordCounts.entries) {
           if (entry.value > words.length * 0.3) {
             // More than 30% of words
-            debugPrint(
+            gemmaLog(
                 'ImageTokenizer: Detected excessive repetition of "${entry.key}" (${entry.value} times)');
             return true;
           }
@@ -226,15 +224,14 @@ class ImageTokenizer {
 
       return false;
     } catch (e) {
-      debugPrint('ImageTokenizer: Error detecting corruption patterns - $e');
+      gemmaLog('ImageTokenizer: Error detecting corruption patterns - $e');
       return false;
     }
   }
 
   /// Creates a safe fallback prompt when image processing fails
   static String createFallbackPrompt(String text, {String? errorMessage}) {
-    debugPrint(
-        'ImageTokenizer: Creating fallback prompt due to: $errorMessage');
+    gemmaLog('ImageTokenizer: Creating fallback prompt due to: $errorMessage');
 
     final prompt = StringBuffer();
     prompt.write(

--- a/lib/core/image_tokenizer.dart
+++ b/lib/core/image_tokenizer.dart
@@ -229,22 +229,6 @@ class ImageTokenizer {
       return false;
     }
   }
-
-  /// Creates a safe fallback prompt when image processing fails
-  static String createFallbackPrompt(String text, {String? errorMessage}) {
-    gemmaLog('ImageTokenizer: Creating fallback prompt due to: $errorMessage');
-
-    final prompt = StringBuffer();
-    prompt.write(
-        'User provided an image but it could not be processed properly. ');
-    if (errorMessage != null) {
-      prompt.write('Error: $errorMessage. ');
-    }
-    prompt.write('Please respond to the following text only: ');
-    prompt.write(text);
-
-    return prompt.toString();
-  }
 }
 
 /// Model types that require different tokenization approaches

--- a/lib/core/infrastructure/dart_vector_store_repository.dart
+++ b/lib/core/infrastructure/dart_vector_store_repository.dart
@@ -7,6 +7,7 @@ import 'package:flutter_gemma/core/infrastructure/hnsw_vector_index.dart';
 import 'package:flutter_gemma/core/services/vector_store_filter.dart';
 import 'package:flutter_gemma/core/services/vector_store_repository.dart';
 import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Unified VectorStore using sqlite3 dart:ffi + HNSW.
 ///
@@ -270,11 +271,11 @@ class DartVectorStoreRepository implements VectorStoreRepository {
           .toList();
 
       _hnswIndex.rebuild(docs);
-      debugPrint(
+      gemmaLog(
         '[DartVectorStore] HNSW index rebuilt with ${docs.length} documents',
       );
     } catch (e) {
-      debugPrint(
+      gemmaLog(
         '[DartVectorStore] Warning: Failed to rebuild HNSW index: $e',
       );
       _hnswIndex.clear();

--- a/lib/core/infrastructure/in_memory_model_repository.dart
+++ b/lib/core/infrastructure/in_memory_model_repository.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/services/model_repository.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// In-memory implementation of ModelRepository
 ///
@@ -28,7 +28,7 @@ class InMemoryModelRepository implements ModelRepository {
     if (info.id.isEmpty) {
       throw ArgumentError('Model ID cannot be empty');
     }
-    debugPrint('[InMemoryModelRepository] 💾 Saving model: ${info.id}');
+    gemmaLog('[InMemoryModelRepository] 💾 Saving model: ${info.id}');
     _models[info.id] = info;
   }
 
@@ -38,7 +38,7 @@ class InMemoryModelRepository implements ModelRepository {
       throw ArgumentError('Model ID cannot be empty');
     }
     final model = _models[id];
-    debugPrint(
+    gemmaLog(
         '[InMemoryModelRepository] ${model != null ? "✅ Loaded" : "❌ Not found"}: $id');
     return model;
   }
@@ -49,14 +49,14 @@ class InMemoryModelRepository implements ModelRepository {
       throw ArgumentError('Model ID cannot be empty');
     }
     final existed = _models.remove(id) != null;
-    debugPrint(
+    gemmaLog(
         '[InMemoryModelRepository] ${existed ? "🗑️  Deleted" : "⚠️  Not found"}: $id');
   }
 
   @override
   Future<List<ModelInfo>> listInstalled() async {
     final models = _models.values.toList();
-    debugPrint(
+    gemmaLog(
         '[InMemoryModelRepository] 📋 Listing ${models.length} installed models');
     return models;
   }
@@ -67,7 +67,7 @@ class InMemoryModelRepository implements ModelRepository {
       throw ArgumentError('Model ID cannot be empty');
     }
     final installed = _models.containsKey(id);
-    debugPrint(
+    gemmaLog(
         '[InMemoryModelRepository] ${installed ? "✅" : "❌"} isInstalled($id): $installed');
     return installed;
   }
@@ -79,8 +79,7 @@ class InMemoryModelRepository implements ModelRepository {
   void clear() {
     final count = _models.length;
     _models.clear();
-    debugPrint(
-        '[InMemoryModelRepository] 🧹 Cleared $count models from memory');
+    gemmaLog('[InMemoryModelRepository] 🧹 Cleared $count models from memory');
   }
 
   /// Gets the current number of installed models

--- a/lib/core/infrastructure/platform_file_system_service.dart
+++ b/lib/core/infrastructure/platform_file_system_service.dart
@@ -1,9 +1,10 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
 import 'package:flutter_gemma/core/services/file_system_service.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Platform-specific file system implementation using dart:io
 ///
@@ -92,8 +93,7 @@ class PlatformFileSystemService implements FileSystemService {
       final legacyPath = path.join(legacy.path, filename);
       if (await File(legacyPath).exists()) {
         if (_legacyFallbackLogged.add(legacyPath)) {
-          debugPrint(
-              '[flutter_gemma] Reading model from legacy Documents path; '
+          gemmaLog('[flutter_gemma] Reading model from legacy Documents path; '
               'consider re-installing to migrate: $legacyPath');
         }
         return legacyPath;
@@ -222,7 +222,7 @@ class PlatformFileSystemService implements FileSystemService {
         base = Directory(local);
       } else {
         if (local != null && local.isNotEmpty) {
-          debugPrint('[flutter_gemma] LOCALAPPDATA is not absolute '
+          gemmaLog('[flutter_gemma] LOCALAPPDATA is not absolute '
               '("$local") — falling back to USERPROFILE / Application '
               'Support. Models would otherwise land in a \$PWD-relative '
               'directory.');

--- a/lib/core/infrastructure/qdrant_vector_store_repository.dart
+++ b/lib/core/infrastructure/qdrant_vector_store_repository.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_gemma/core/qdrant/filter_codec.dart';
 import 'package:flutter_gemma/core/qdrant/point_id_hasher.dart';
 import 'package:flutter_gemma/core/qdrant/qdrant_edge_client.dart';
 import 'package:flutter_gemma/core/services/vector_store_filter.dart';
 import 'package:flutter_gemma/core/services/vector_store_repository.dart';
 import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// [VectorStoreRepository] backed by qdrant-edge (FFI shim →
 /// [QdrantEdgeClient] → native cdylib). The default native implementation
@@ -75,7 +75,7 @@ class QdrantVectorStoreRepository implements VectorStoreRepository {
       try {
         await existing.close();
       } on QdrantException catch (e) {
-        debugPrint('[QdrantVectorStore] close() failed (best-effort): $e');
+        gemmaLog('[QdrantVectorStore] close() failed (best-effort): $e');
       }
     }
     _client = null;
@@ -152,7 +152,7 @@ class QdrantVectorStoreRepository implements VectorStoreRepository {
   Future<void> removeDocument({required String id}) async {
     final c = _client;
     if (c == null) {
-      debugPrint(
+      gemmaLog(
           '[QdrantVectorStore] removeDocument($id) called before initialize() — ignored');
       return;
     }
@@ -240,7 +240,7 @@ class QdrantVectorStoreRepository implements VectorStoreRepository {
       try {
         await c.close();
       } on QdrantException catch (e) {
-        debugPrint('[QdrantVectorStore] close() failed (best-effort): $e');
+        gemmaLog('[QdrantVectorStore] close() failed (best-effort): $e');
       }
     }
   }

--- a/lib/core/infrastructure/url_utils.dart
+++ b/lib/core/infrastructure/url_utils.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import '../utils/gemma_log.dart';
 
 /// Utilities for URL manipulation
 class UrlUtils {
@@ -31,7 +31,7 @@ class UrlUtils {
 
       return normalized;
     } catch (e) {
-      debugPrint('[UrlUtils] ⚠️  URL normalization failed: $e');
+      gemmaLog('[UrlUtils] ⚠️  URL normalization failed: $e');
       return url;
     }
   }

--- a/lib/core/infrastructure/web_cache_interop.dart
+++ b/lib/core/infrastructure/web_cache_interop.dart
@@ -6,6 +6,7 @@ library;
 
 import 'dart:js_interop';
 import 'package:flutter/foundation.dart';
+import '../utils/gemma_log.dart';
 
 /// External JS functions for Cache API
 @JS('cacheHas')
@@ -66,7 +67,7 @@ class WebCacheInterop {
       final result = await _cacheHasJS(cacheName.toJS, url.toJS).toDart;
       return result.toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ has failed for $url: $e');
+      gemmaLog('[WebCacheInterop] ❌ has failed for $url: $e');
       return false;
     }
   }
@@ -77,7 +78,7 @@ class WebCacheInterop {
       final result = await _cacheGetBlobUrlJS(cacheName.toJS, url.toJS).toDart;
       return result?.toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ getBlobUrl failed for $url: $e');
+      gemmaLog('[WebCacheInterop] ❌ getBlobUrl failed for $url: $e');
       return null;
     }
   }
@@ -87,7 +88,7 @@ class WebCacheInterop {
     try {
       await _cachePutJS(cacheName.toJS, url.toJS, data.toJS).toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ put failed for $url: $e');
+      gemmaLog('[WebCacheInterop] ❌ put failed for $url: $e');
       rethrow;
     }
   }
@@ -98,7 +99,7 @@ class WebCacheInterop {
       final result = await _cacheDeleteJS(cacheName.toJS, url.toJS).toDart;
       return result.toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ delete failed for $url: $e');
+      gemmaLog('[WebCacheInterop] ❌ delete failed for $url: $e');
       return false;
     }
   }
@@ -109,7 +110,7 @@ class WebCacheInterop {
       final result = await _cacheDeleteCacheJS(cacheName.toJS).toDart;
       return result.toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ deleteCache failed: $e');
+      gemmaLog('[WebCacheInterop] ❌ deleteCache failed: $e');
       return false;
     }
   }
@@ -120,7 +121,7 @@ class WebCacheInterop {
       final result = await _cacheGetAllKeysJS(cacheName.toJS).toDart;
       return result.toDart.map((js) => js.toDart).toList();
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ getAllKeys failed: $e');
+      gemmaLog('[WebCacheInterop] ❌ getAllKeys failed: $e');
       return [];
     }
   }
@@ -131,7 +132,7 @@ class WebCacheInterop {
       final result = await _storageRequestPersistentJS().toDart;
       return result.toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ requestPersistentStorage failed: $e');
+      gemmaLog('[WebCacheInterop] ❌ requestPersistentStorage failed: $e');
       return false;
     }
   }
@@ -145,7 +146,7 @@ class WebCacheInterop {
         result.quota.toDartInt,
       );
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ getStorageQuota failed: $e');
+      gemmaLog('[WebCacheInterop] ❌ getStorageQuota failed: $e');
       return StorageQuota(0, 0);
     }
   }
@@ -155,7 +156,7 @@ class WebCacheInterop {
     try {
       _blobUrlRevokeJS(blobUrl.toJS);
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ revokeBlobUrl failed: $e');
+      gemmaLog('[WebCacheInterop] ❌ revokeBlobUrl failed: $e');
     }
   }
 
@@ -165,7 +166,7 @@ class WebCacheInterop {
       final blob = _createBlobJs(data.toJS);
       return _createObjectUrlJs(blob).toDart;
     } catch (e) {
-      debugPrint('[WebCacheInterop] ❌ createBlobUrl failed: $e');
+      gemmaLog('[WebCacheInterop] ❌ createBlobUrl failed: $e');
       rethrow;
     }
   }

--- a/lib/core/infrastructure/web_cache_service.dart
+++ b/lib/core/infrastructure/web_cache_service.dart
@@ -22,6 +22,7 @@ import 'package:flutter_gemma/core/infrastructure/web_cache_interop_stub.dart'
 import 'package:flutter_gemma/core/model_management/constants/preferences_keys.dart';
 import 'package:flutter_gemma/core/infrastructure/url_utils.dart';
 import 'package:flutter_gemma/core/infrastructure/web_file_system_service.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Web cache service
 ///
@@ -58,13 +59,13 @@ class WebCacheService {
       final cached = await _cacheInterop.has(cacheName, normalizedUrl);
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '[WebCacheService] 🔍 isCached($url) -> $cached (normalized: $normalizedUrl)');
       }
 
       return cached;
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ isCached failed for $url: $e');
+      gemmaLog('[WebCacheService] ❌ isCached failed for $url: $e');
       return false;
     }
   }
@@ -78,7 +79,7 @@ class WebCacheService {
       final normalizedUrl = UrlUtils.normalizeUrl(url);
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             'WebCacheService: getCachedBlobUrl($url) normalized: $normalizedUrl');
       }
 
@@ -86,7 +87,7 @@ class WebCacheService {
       final cached = await _cacheInterop.has(cacheName, normalizedUrl);
       if (!cached) {
         if (kDebugMode) {
-          debugPrint('[WebCacheService] ⚠️  Not cached: $normalizedUrl');
+          gemmaLog('[WebCacheService] ⚠️  Not cached: $normalizedUrl');
         }
         return null;
       }
@@ -95,7 +96,7 @@ class WebCacheService {
       final blobUrl = await _cacheInterop.getBlobUrl(cacheName, normalizedUrl);
 
       if (blobUrl == null) {
-        debugPrint(
+        gemmaLog(
             '[WebCacheService] ❌ Failed to create blob URL for $normalizedUrl');
         // Cache corrupted? Delete metadata
         await _deleteMetadata(url);
@@ -103,12 +104,12 @@ class WebCacheService {
       }
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] ✅ Created blob URL: $blobUrl');
+        gemmaLog('[WebCacheService] ✅ Created blob URL: $blobUrl');
       }
 
       return blobUrl;
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ getCachedBlobUrl failed for $url: $e');
+      gemmaLog('[WebCacheService] ❌ getCachedBlobUrl failed for $url: $e');
       return null;
     }
   }
@@ -124,7 +125,7 @@ class WebCacheService {
       final normalizedUrl = UrlUtils.normalizeUrl(url);
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             'WebCacheService: cacheModel($url) size: ${data.length} bytes, normalized: $normalizedUrl');
       }
 
@@ -140,14 +141,14 @@ class WebCacheService {
       ));
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] ✅ Successfully cached $url');
+        gemmaLog('[WebCacheService] ✅ Successfully cached $url');
       }
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ cacheModel failed for $url: $e');
+      gemmaLog('[WebCacheService] ❌ cacheModel failed for $url: $e');
 
       // Handle QuotaExceededError
       if (e.toString().contains('quota')) {
-        debugPrint(
+        gemmaLog(
             '[WebCacheService] ⚠️  Storage quota exceeded, attempting cleanup');
         await _cleanupOldEntries();
         // Retry once after cleanup
@@ -160,10 +161,10 @@ class WebCacheService {
             timestamp: DateTime.now(),
             cacheKey: normalizedUrl,
           ));
-          debugPrint('[WebCacheService] ✅ Cached after cleanup: $url');
+          gemmaLog('[WebCacheService] ✅ Cached after cleanup: $url');
           return;
         } catch (retryError) {
-          debugPrint('[WebCacheService] ❌ Retry failed: $retryError');
+          gemmaLog('[WebCacheService] ❌ Retry failed: $retryError');
         }
       }
 
@@ -177,7 +178,7 @@ class WebCacheService {
   Future<void> clearCache() async {
     try {
       if (kDebugMode) {
-        debugPrint('[WebCacheService] 🗑️ Clearing cache');
+        gemmaLog('[WebCacheService] 🗑️ Clearing cache');
       }
 
       // Delete Cache API
@@ -193,10 +194,10 @@ class WebCacheService {
       }
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] ✅ Cache cleared');
+        gemmaLog('[WebCacheService] ✅ Cache cleared');
       }
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ clearCache failed: $e');
+      gemmaLog('[WebCacheService] ❌ clearCache failed: $e');
       rethrow;
     }
   }
@@ -210,7 +211,7 @@ class WebCacheService {
       final granted = await _cacheInterop.requestPersistentStorage();
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '[WebCacheService] ${granted ? "✅" : "⚠️ "} Persistent storage ${granted ? "granted" : "denied"}');
       }
 
@@ -220,7 +221,7 @@ class WebCacheService {
 
       return granted;
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ requestPersistentStorage failed: $e');
+      gemmaLog('[WebCacheService] ❌ requestPersistentStorage failed: $e');
       return false;
     }
   }
@@ -233,12 +234,12 @@ class WebCacheService {
       final quota = await _cacheInterop.getStorageQuota();
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] 📊 Storage quota: $quota');
+        gemmaLog('[WebCacheService] 📊 Storage quota: $quota');
       }
 
       return quota;
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ getStorageQuota failed: $e');
+      gemmaLog('[WebCacheService] ❌ getStorageQuota failed: $e');
       return StorageQuota(0, 0);
     }
   }
@@ -249,12 +250,12 @@ class WebCacheService {
       final urls = await _cacheInterop.getAllKeys(cacheName);
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] 🔍 Found ${urls.length} cached URLs');
+        gemmaLog('[WebCacheService] 🔍 Found ${urls.length} cached URLs');
       }
 
       return urls;
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ getCachedUrls failed: $e');
+      gemmaLog('[WebCacheService] ❌ getCachedUrls failed: $e');
       return [];
     }
   }
@@ -276,10 +277,10 @@ class WebCacheService {
       await prefs.setString(key, json);
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] 💾 Saved metadata for ${metadata.url}');
+        gemmaLog('[WebCacheService] 💾 Saved metadata for ${metadata.url}');
       }
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ _saveMetadata failed: $e');
+      gemmaLog('[WebCacheService] ❌ _saveMetadata failed: $e');
     }
   }
 
@@ -291,10 +292,10 @@ class WebCacheService {
       await prefs.remove(key);
 
       if (kDebugMode) {
-        debugPrint('[WebCacheService] 🗑️ Deleted metadata for $url');
+        gemmaLog('[WebCacheService] 🗑️ Deleted metadata for $url');
       }
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ _deleteMetadata failed: $e');
+      gemmaLog('[WebCacheService] ❌ _deleteMetadata failed: $e');
     }
   }
 
@@ -314,7 +315,7 @@ class WebCacheService {
               final metadata = CacheMetadata.fromJson(json);
               metadataList.add(metadata);
             } catch (e) {
-              debugPrint('[WebCacheService] ❌ Failed to parse metadata: $e');
+              gemmaLog('[WebCacheService] ❌ Failed to parse metadata: $e');
               // Invalid metadata - delete it
               await prefs.remove(key);
             }
@@ -324,7 +325,7 @@ class WebCacheService {
 
       return metadataList;
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ _getAllMetadata failed: $e');
+      gemmaLog('[WebCacheService] ❌ _getAllMetadata failed: $e');
       return [];
     }
   }
@@ -335,7 +336,7 @@ class WebCacheService {
   Future<void> _cleanupOldEntries() async {
     try {
       if (kDebugMode) {
-        debugPrint('[WebCacheService] 🗑️ Running cleanup');
+        gemmaLog('[WebCacheService] 🗑️ Running cleanup');
       }
 
       final now = DateTime.now();
@@ -359,14 +360,14 @@ class WebCacheService {
           deletedCount++;
 
           if (kDebugMode) {
-            debugPrint(
+            gemmaLog(
                 '[WebCacheService] 🗑️ Deleted old entry: ${meta.url} (age: ${age.inDays} days)');
           }
         }
       }
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '[WebCacheService] ✅ Cleanup complete, deleted $deletedCount entries');
       }
 
@@ -375,7 +376,7 @@ class WebCacheService {
       await prefs.setInt(
           PreferencesKeys.webCacheLastCleanup, now.millisecondsSinceEpoch);
     } catch (e) {
-      debugPrint('[WebCacheService] ❌ _cleanupOldEntries failed: $e');
+      gemmaLog('[WebCacheService] ❌ _cleanupOldEntries failed: $e');
     }
   }
 
@@ -401,7 +402,7 @@ class WebCacheService {
       if (enableCache) {
         final cachedBlobUrl = await getCachedBlobUrl(cacheKey);
         if (cachedBlobUrl != null) {
-          debugPrint('[WebCacheService] ✅ Found in cache: $cacheKey');
+          gemmaLog('[WebCacheService] ✅ Found in cache: $cacheKey');
           _fileSystem.registerUrl(targetPath, cachedBlobUrl);
           yield 100; // Instant completion
           return;
@@ -409,7 +410,7 @@ class WebCacheService {
       }
 
       // 2. Load data with progress tracking
-      debugPrint(
+      gemmaLog(
           '[WebCacheService] 📥 Loading: $cacheKey (cache: ${enableCache ? "enabled" : "disabled"})');
 
       final controller = StreamController<int>();
@@ -455,18 +456,18 @@ class WebCacheService {
         // 5. Register in file system
         _fileSystem.registerUrl(targetPath, blobUrl);
 
-        debugPrint('[WebCacheService] ✅ Cached and registered: $cacheKey');
+        gemmaLog('[WebCacheService] ✅ Cached and registered: $cacheKey');
       } else {
         // Create temporary blob URL without caching
         final blobUrl = _cacheInterop.createBlobUrl(loadedData!);
         _fileSystem.registerUrl(targetPath, blobUrl);
 
-        debugPrint('[WebCacheService] ✅ Registered (no cache): $cacheKey');
+        gemmaLog('[WebCacheService] ✅ Registered (no cache): $cacheKey');
       }
 
       yield 100; // Final completion
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           '[WebCacheService] ❌ getOrCacheAndRegisterWithProgress failed: $e');
       rethrow;
     }

--- a/lib/core/infrastructure/web_download_service.dart
+++ b/lib/core/infrastructure/web_download_service.dart
@@ -13,6 +13,7 @@ import 'package:flutter_gemma/core/infrastructure/web_cache_service.dart';
 import 'package:flutter_gemma/core/infrastructure/web_opfs_interop_stub.dart'
     if (dart.library.js_interop) 'package:flutter_gemma/core/infrastructure/web_opfs_service.dart';
 import 'package:flutter_gemma/core/infrastructure/url_utils.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// JavaScript AbortController for cancelling fetch requests
 @JS('AbortController')
@@ -91,11 +92,10 @@ class WebDownloadService implements DownloadService {
     // STREAMING MODE: Use OPFS for large models
     if (webStorageMode == WebStorageMode.streaming) {
       if (opfsService == null) {
-        debugPrint(
-            '[WARNING] OPFS not available, falling back to cacheApi mode');
-        debugPrint(
+        gemmaLog('[WARNING] OPFS not available, falling back to cacheApi mode');
+        gemmaLog(
             '[WARNING] Large models (>2GB) may fail with ArrayBuffer limit');
-        debugPrint(
+        gemmaLog(
             '[WARNING] Use a browser that supports OPFS (Chrome 86+, Edge 86+, Safari 15.2+)');
         // Fall back to cache API mode
         yield* _downloadToCache(url, targetPath,
@@ -125,7 +125,7 @@ class WebDownloadService implements DownloadService {
     // Check cache first (works for both public and private models)
     final cachedBlobUrl = await cacheService.getCachedBlobUrl(normalizedUrl);
     if (cachedBlobUrl != null) {
-      debugPrint('✅ Model found in cache (skipping download): $url');
+      gemmaLog('✅ Model found in cache (skipping download): $url');
 
       // Register cached blob URL
       _fileSystem.registerUrl(targetPath, cachedBlobUrl);
@@ -137,14 +137,14 @@ class WebDownloadService implements DownloadService {
     }
 
     // Not in cache - proceed with download
-    debugPrint('📥 Model not in cache, downloading: $url');
+    gemmaLog('📥 Model not in cache, downloading: $url');
 
     if (token == null) {
       // PUBLIC PATH: Download and cache
       yield* _downloadPublic(url, normalizedUrl, targetPath, cancelToken);
     } else {
       // PRIVATE PATH: Fetch with auth
-      debugPrint(
+      gemmaLog(
           'WebDownloadService: Starting authenticated download for $targetPath');
 
       yield* _downloadWithAuth(
@@ -167,14 +167,13 @@ class WebDownloadService implements DownloadService {
     try {
       cancelToken?.throwIfCancelled();
 
-      debugPrint(
-          '[WebDownloadService] 🚀 OPFS streaming download: $targetPath');
+      gemmaLog('[WebDownloadService] 🚀 OPFS streaming download: $targetPath');
 
       // Check if already in OPFS
       final isAlreadyCached = await opfsService!.isModelCached(targetPath);
       // ignore: dead_code
       if (isAlreadyCached) {
-        debugPrint('[WebDownloadService] ✅ Model already in OPFS: $targetPath');
+        gemmaLog('[WebDownloadService] ✅ Model already in OPFS: $targetPath');
 
         // Register as OPFS file (special marker for getStreamReader)
         _fileSystem.registerUrl(targetPath, 'opfs://$targetPath');
@@ -202,8 +201,7 @@ class WebDownloadService implements DownloadService {
         },
         abortSignal: abortController.signal,
       ).then((_) {
-        debugPrint(
-            '[WebDownloadService] ✅ OPFS download complete: $targetPath');
+        gemmaLog('[WebDownloadService] ✅ OPFS download complete: $targetPath');
 
         // Register as OPFS file
         _fileSystem.registerUrl(targetPath, 'opfs://$targetPath');
@@ -212,7 +210,7 @@ class WebDownloadService implements DownloadService {
           streamController.close();
         }
       }).catchError((error) {
-        debugPrint('[WebDownloadService] ❌ OPFS download failed: $error');
+        gemmaLog('[WebDownloadService] ❌ OPFS download failed: $error');
         if (streamController != null && !streamController.isClosed) {
           streamController.addError(error);
           streamController.close();
@@ -227,11 +225,10 @@ class WebDownloadService implements DownloadService {
     } on DownloadCancelledException {
       // Abort the JS fetch request
       abortController?.abort();
-      debugPrint(
-          '[WebDownloadService] 🛑 OPFS download cancelled: $targetPath');
+      gemmaLog('[WebDownloadService] 🛑 OPFS download cancelled: $targetPath');
       rethrow;
     } catch (e) {
-      debugPrint('[WebDownloadService] ❌ OPFS download error: $e');
+      gemmaLog('[WebDownloadService] ❌ OPFS download error: $e');
       throw DownloadException(
         DownloadError.unknown('Failed to download to OPFS: $e'),
       );
@@ -259,12 +256,12 @@ class WebDownloadService implements DownloadService {
         loader: (onProgress) async {
           cancelToken?.throwIfCancelled();
 
-          debugPrint('[WebDownloadService] 📥 Downloading public model: $url');
+          gemmaLog('[WebDownloadService] 📥 Downloading public model: $url');
 
           // Note: fetchFile doesn't support progress callbacks yet
           final response = await _jsInterop.fetchFile(url);
 
-          debugPrint(
+          gemmaLog(
               '[WebDownloadService] ✅ Downloaded: ${response.data.length} bytes');
           onProgress(1.0);
 
@@ -279,11 +276,11 @@ class WebDownloadService implements DownloadService {
         _blobUrlManager.track(targetPath, blobUrl);
       }
 
-      debugPrint('[WebDownloadService] ✅ Public model downloaded and cached');
+      gemmaLog('[WebDownloadService] ✅ Public model downloaded and cached');
     } on DownloadCancelledException {
       rethrow;
     } catch (e) {
-      debugPrint('[WebDownloadService] ❌ Public download failed: $e');
+      gemmaLog('[WebDownloadService] ❌ Public download failed: $e');
       throw DownloadException(
         DownloadError.unknown('Failed to download public model: $e'),
       );
@@ -300,7 +297,7 @@ class WebDownloadService implements DownloadService {
     try {
       cancelToken?.throwIfCancelled();
 
-      debugPrint(
+      gemmaLog(
           'WebDownloadService: Starting authenticated download for $targetPath');
 
       // Use unified caching helper with auth download
@@ -309,7 +306,7 @@ class WebDownloadService implements DownloadService {
         loader: (onProgress) async {
           cancelToken?.throwIfCancelled();
 
-          debugPrint(
+          gemmaLog(
               '[WebDownloadService] 📥 Downloading authenticated model: $url');
 
           // Create completer for async result
@@ -323,7 +320,7 @@ class WebDownloadService implements DownloadService {
             onProgress: onProgress, // Pass progress callback directly
           )
               .then((response) {
-            debugPrint(
+            gemmaLog(
                 '[WebDownloadService] ✅ Downloaded: ${response.data.length} bytes');
             completer.complete(response.data);
           }).catchError((error) {
@@ -341,13 +338,13 @@ class WebDownloadService implements DownloadService {
         _blobUrlManager.track(targetPath, blobUrl);
       }
 
-      debugPrint(
+      gemmaLog(
           '[WebDownloadService] ✅ Authenticated model downloaded and cached');
     } on DownloadCancelledException {
-      debugPrint('WebDownloadService: Download cancelled for $targetPath');
+      gemmaLog('WebDownloadService: Download cancelled for $targetPath');
       rethrow;
     } catch (e) {
-      debugPrint('[WebDownloadService] ❌ Authenticated download failed: $e');
+      gemmaLog('[WebDownloadService] ❌ Authenticated download failed: $e');
       throw DownloadException(
         DownloadError.unknown('Failed to download authenticated model: $e'),
       );

--- a/lib/core/infrastructure/web_file_system_service.dart
+++ b/lib/core/infrastructure/web_file_system_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/services/file_system_service.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Web implementation of FileSystemService using URL-based storage
 ///
@@ -25,7 +26,7 @@ class WebFileSystemService implements FileSystemService {
     // On web, we can't write files to local file system
     // Instead, we create a blob URL via WebJsInterop (handled by WebDownloadService)
     // For now, this is primarily used for registration
-    debugPrint(
+    gemmaLog(
         'WebFileSystemService: writeFile called for $path (${data.length} bytes)');
 
     // Store a marker that this file exists
@@ -55,12 +56,12 @@ class WebFileSystemService implements FileSystemService {
     // Blob URL revocation is handled by BlobUrlManager (integrated via WebDownloadService)
     // The cleanup callback (_onBlobUrlRemoved) will be invoked if this is a blob URL
     if (url != null && wasBlob == true) {
-      debugPrint('WebFileSystemService: Triggering blob URL cleanup for $path');
+      gemmaLog('WebFileSystemService: Triggering blob URL cleanup for $path');
       _onBlobUrlRemoved?.call(url);
     }
 
     if (url != null) {
-      debugPrint('WebFileSystemService: Removed URL mapping for $path');
+      gemmaLog('WebFileSystemService: Removed URL mapping for $path');
     }
   }
 
@@ -110,7 +111,7 @@ class WebFileSystemService implements FileSystemService {
     // Use absolute path starting with / to ensure proper resolution
     final assetPath = '/$resourceName';
 
-    debugPrint(
+    gemmaLog(
         'WebFileSystemService: Bundled resource path for $resourceName: $assetPath');
 
     return assetPath;
@@ -123,7 +124,7 @@ class WebFileSystemService implements FileSystemService {
     // On web, external paths are URLs
     _urlMappings[filename] = externalPath;
 
-    debugPrint(
+    gemmaLog(
         'WebFileSystemService: Registered external file $filename -> $externalPath');
   }
 
@@ -169,7 +170,7 @@ class WebFileSystemService implements FileSystemService {
     // Trigger cleanup callback for all blob URLs
     for (final entry in _urlMappings.entries) {
       if (_isBlobUrl[entry.key] == true) {
-        debugPrint(
+        gemmaLog(
             'WebFileSystemService: Triggering blob URL cleanup for ${entry.key}');
         _onBlobUrlRemoved?.call(entry.value);
       }
@@ -177,7 +178,7 @@ class WebFileSystemService implements FileSystemService {
 
     _urlMappings.clear();
     _isBlobUrl.clear();
-    debugPrint('WebFileSystemService: Cleared all URL mappings');
+    gemmaLog('WebFileSystemService: Cleared all URL mappings');
   }
 
   /// Callback for blob URL removal (set by BlobUrlManager)

--- a/lib/core/infrastructure/web_js_interop.dart
+++ b/lib/core/infrastructure/web_js_interop.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 import 'package:flutter/foundation.dart';
+import '../utils/gemma_log.dart';
 
 /// Response from fetch operations
 class FetchResponse {
@@ -220,7 +221,7 @@ class WebJsInterop {
       _revokeBlobUrlJs(blobUrl.toJS);
     } catch (e) {
       // Ignore errors during cleanup
-      debugPrint('Warning: Failed to revoke blob URL: $e');
+      gemmaLog('Warning: Failed to revoke blob URL: $e');
     }
   }
 
@@ -260,12 +261,11 @@ class WebJsInterop {
     final chunks = <Uint8List>[];
     int bytesReceived = 0;
 
-    debugPrint(
-        '🌊 Starting stream: contentLength=${contentLength ?? "unknown"}');
+    gemmaLog('🌊 Starting stream: contentLength=${contentLength ?? "unknown"}');
 
     // Warn about large files
     if (contentLength != null && contentLength > 2 * 1024 * 1024 * 1024) {
-      debugPrint(
+      gemmaLog(
           'Warning: Large file detected (${contentLength ~/ 1024 / 1024}MB). '
           'May encounter memory limits on some browsers.');
     }

--- a/lib/core/infrastructure/web_opfs_service.dart
+++ b/lib/core/infrastructure/web_opfs_service.dart
@@ -8,8 +8,8 @@ library;
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/infrastructure/web_opfs_interop.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Service for OPFS file management
 ///
@@ -36,7 +36,7 @@ class WebOPFSService {
       final result = await _opfs.isModelCached(filename.toJS).toDart;
       return result.toDart;
     } catch (e) {
-      debugPrint('[WebOPFSService] Error checking cache for $filename: $e');
+      gemmaLog('[WebOPFSService] Error checking cache for $filename: $e');
       return false;
     }
   }
@@ -50,7 +50,7 @@ class WebOPFSService {
       if (result == null) return null;
       return result.toDartInt;
     } catch (e) {
-      debugPrint('[WebOPFSService] Error getting size for $filename: $e');
+      gemmaLog('[WebOPFSService] Error getting size for $filename: $e');
       return null;
     }
   }
@@ -76,7 +76,7 @@ class WebOPFSService {
     JSAny? abortSignal,
   }) async {
     try {
-      debugPrint('[WebOPFSService] Starting download: $filename');
+      gemmaLog('[WebOPFSService] Starting download: $filename');
 
       // Create JS callback for progress
       final jsProgressCallback = (JSNumber percentJs) {
@@ -99,10 +99,10 @@ class WebOPFSService {
         throw Exception('OPFS download returned false');
       }
 
-      debugPrint('[WebOPFSService] Download complete: $filename');
+      gemmaLog('[WebOPFSService] Download complete: $filename');
     } catch (e, stackTrace) {
-      debugPrint('[WebOPFSService] Download failed: $e');
-      debugPrint('[WebOPFSService] Stack trace: $stackTrace');
+      gemmaLog('[WebOPFSService] Download failed: $e');
+      gemmaLog('[WebOPFSService] Stack trace: $stackTrace');
       throw Exception('Failed to download to OPFS: $e');
     }
   }
@@ -121,13 +121,13 @@ class WebOPFSService {
   /// - [Exception] if file not found in OPFS
   Future<JSAny> getStreamReader(String filename) async {
     try {
-      debugPrint('[WebOPFSService] Getting stream reader for: $filename');
+      gemmaLog('[WebOPFSService] Getting stream reader for: $filename');
       final reader = await _opfs.getStreamReader(filename.toJS).toDart;
-      debugPrint('[WebOPFSService] Stream reader created');
+      gemmaLog('[WebOPFSService] Stream reader created');
       return reader;
     } catch (e, stackTrace) {
-      debugPrint('[WebOPFSService] Failed to get stream reader: $e');
-      debugPrint('[WebOPFSService] Stack trace: $stackTrace');
+      gemmaLog('[WebOPFSService] Failed to get stream reader: $e');
+      gemmaLog('[WebOPFSService] Stack trace: $stackTrace');
       throw Exception('Model not found in OPFS: $filename');
     }
   }
@@ -142,13 +142,13 @@ class WebOPFSService {
   /// [getStreamReader] instead.
   Future<JSAny> getStream(String filename) async {
     try {
-      debugPrint('[WebOPFSService] Getting readable stream for: $filename');
+      gemmaLog('[WebOPFSService] Getting readable stream for: $filename');
       final stream = await _opfs.getReadableStream(filename.toJS).toDart;
-      debugPrint('[WebOPFSService] Readable stream created');
+      gemmaLog('[WebOPFSService] Readable stream created');
       return stream;
     } catch (e, stackTrace) {
-      debugPrint('[WebOPFSService] Failed to get readable stream: $e');
-      debugPrint('[WebOPFSService] Stack trace: $stackTrace');
+      gemmaLog('[WebOPFSService] Failed to get readable stream: $e');
+      gemmaLog('[WebOPFSService] Stack trace: $stackTrace');
       throw Exception('Model not found in OPFS: $filename');
     }
   }
@@ -163,9 +163,9 @@ class WebOPFSService {
   Future<void> deleteModel(String filename) async {
     try {
       await _opfs.deleteModel(filename.toJS).toDart;
-      debugPrint('[WebOPFSService] Deleted: $filename');
+      gemmaLog('[WebOPFSService] Deleted: $filename');
     } catch (e) {
-      debugPrint('[WebOPFSService] Failed to delete $filename: $e');
+      gemmaLog('[WebOPFSService] Failed to delete $filename: $e');
       throw Exception('Failed to delete from OPFS: $e');
     }
   }
@@ -182,7 +182,7 @@ class WebOPFSService {
         'quota': stats.quota.toDartInt,
       };
     } catch (e) {
-      debugPrint('[WebOPFSService] Failed to get storage stats: $e');
+      gemmaLog('[WebOPFSService] Failed to get storage stats: $e');
       return {'usage': 0, 'quota': 0};
     }
   }
@@ -194,10 +194,10 @@ class WebOPFSService {
     try {
       final count = await _opfs.clearAll().toDart;
       final deletedCount = count.toDartInt;
-      debugPrint('[WebOPFSService] Cleared $deletedCount files from OPFS');
+      gemmaLog('[WebOPFSService] Cleared $deletedCount files from OPFS');
       return deletedCount;
     } catch (e) {
-      debugPrint('[WebOPFSService] Failed to clear OPFS: $e');
+      gemmaLog('[WebOPFSService] Failed to clear OPFS: $e');
       throw Exception('Failed to clear OPFS: $e');
     }
   }

--- a/lib/core/infrastructure/web_vector_store_repository.dart
+++ b/lib/core/infrastructure/web_vector_store_repository.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/infrastructure/hnsw_vector_index.dart';
 import 'package:flutter_gemma/core/services/vector_store_filter.dart';
 import 'package:flutter_gemma/core/services/vector_store_repository.dart';
 import 'package:flutter_gemma/pigeon.g.dart';
 import 'package:flutter_gemma/web/vector_store_web.dart';
 import 'dart:js_interop';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Web implementation of VectorStoreRepository using SQLite WASM + HNSW
 ///
@@ -97,11 +97,11 @@ class WebVectorStoreRepository implements VectorStoreRepository {
 
       _hnswIndex.rebuild(hnswDocs);
 
-      debugPrint(
+      gemmaLog(
           '[WebVectorStore] HNSW index rebuilt with ${documents.length} documents');
     } catch (e) {
       // Log but don't fail - fallback to brute-force search
-      debugPrint('[WebVectorStore] Warning: Failed to rebuild HNSW index: $e');
+      gemmaLog('[WebVectorStore] Warning: Failed to rebuild HNSW index: $e');
       _hnswIndex.clear();
     }
   }
@@ -150,7 +150,7 @@ class WebVectorStoreRepository implements VectorStoreRepository {
         _hnswIndex.add(id, embedding);
       } catch (e) {
         // Log but don't fail - HNSW is optional optimization
-        debugPrint('[WebVectorStore] Warning: Failed to add to HNSW: $e');
+        gemmaLog('[WebVectorStore] Warning: Failed to add to HNSW: $e');
       }
     } catch (e) {
       // Dimension mismatch errors from JS are rethrown as-is
@@ -187,7 +187,7 @@ class WebVectorStoreRepository implements VectorStoreRepository {
     }
 
     if (filter != null && !filter.isEmpty) {
-      debugPrint(
+      gemmaLog(
           '[WebVectorStore] Filter argument ignored on web (wa-sqlite has no payload filtering); '
           'pass null filter to silence this log.');
     }
@@ -195,13 +195,13 @@ class WebVectorStoreRepository implements VectorStoreRepository {
     try {
       // Use HNSW if enabled and index has enough documents
       if (enableHnsw && _hnswIndex.count >= _hnswThreshold) {
-        debugPrint(
+        gemmaLog(
             '[WebVectorStore] Using HNSW search (${_hnswIndex.count} docs)');
         return await _searchWithHnsw(queryEmbedding, topK, threshold);
       }
 
       // Fallback to brute-force for small datasets or when HNSW disabled
-      debugPrint(
+      gemmaLog(
           '[WebVectorStore] Using brute-force search (HNSW enabled: $enableHnsw, count: ${_hnswIndex.count})');
       return await _store!.searchSimilarDart(queryEmbedding, topK, threshold);
     } catch (e) {

--- a/lib/core/litert/litert_embedding_core.dart
+++ b/lib/core/litert/litert_embedding_core.dart
@@ -25,10 +25,10 @@ import 'dart:ffi';
 
 import 'package:dart_sentencepiece_tokenizer/dart_sentencepiece_tokenizer.dart';
 import 'package:ffi/ffi.dart';
-import 'package:flutter/foundation.dart' show debugPrint;
 
 import 'litert_bindings.dart';
 import 'litert_embedding_worker.dart' show EmbeddingBackend;
+import '../utils/gemma_log.dart';
 
 /// Gemma special-token IDs. `dart_sentencepiece_tokenizer` defaults to the
 /// swapped pair (bosId=1, eosId=2), so we add them manually.
@@ -186,7 +186,7 @@ class EmbeddingCore {
         dim = outputDimension;
       }
 
-      debugPrint(
+      gemmaLog(
           '[EmbeddingCore] loaded: seqLen=$seqLen, dim=$dim, backend=$backend');
 
       return EmbeddingCore._(

--- a/lib/core/litert/litert_embedding_worker.dart
+++ b/lib/core/litert/litert_embedding_worker.dart
@@ -20,7 +20,6 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 import 'litert_embedding_core.dart';
@@ -256,7 +255,7 @@ Future<void> _workerEntry(_WorkerInit init) async {
       outputDimension: init.outputDimension,
     );
   } catch (e, st) {
-    debugPrint('[EmbeddingWorker] load failed: $e\n$st');
+    gemmaLog('[EmbeddingWorker] load failed: $e\n$st');
     init.replyTo.send('Embedding worker failed to load: $e');
     return;
   }

--- a/lib/core/litert/litert_embedding_worker.dart
+++ b/lib/core/litert/litert_embedding_worker.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 import 'litert_embedding_core.dart';
 
@@ -74,6 +75,7 @@ class _WorkerInit {
     required this.backend,
     required this.inputSequenceLength,
     required this.outputDimension,
+    required this.logLevel,
   });
   final SendPort replyTo;
   final String modelPath;
@@ -81,6 +83,7 @@ class _WorkerInit {
   final EmbeddingBackend backend;
   final int? inputSequenceLength;
   final int? outputDimension;
+  final GemmaLogLevel logLevel;
 }
 
 /// Main-isolate handle to the embedding worker. Spawns the isolate, performs
@@ -149,6 +152,7 @@ class EmbeddingWorker {
         backend: backend,
         inputSequenceLength: inputSequenceLength,
         outputDimension: outputDimension,
+        logLevel: gemmaLogLevel,
       ),
       // onExit posts `null` to fromWorker so we never wait on a dead isolate.
       onExit: fromWorker.sendPort,
@@ -240,6 +244,8 @@ class EmbeddingWorker {
 
 /// Isolate entry point. Loads the model, then serves requests until _Close.
 Future<void> _workerEntry(_WorkerInit init) async {
+  // snapshot main-isolate level into this isolate
+  gemmaLogLevel = init.logLevel;
   final EmbeddingCore core;
   try {
     core = await EmbeddingCore.load(

--- a/lib/core/migration/legacy_preferences_migrator.dart
+++ b/lib/core/migration/legacy_preferences_migrator.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/services/model_repository.dart' as repo;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Migrates old Legacy preference keys to Modern ModelRepository
 ///
@@ -50,11 +50,11 @@ class LegacyPreferencesMigrator {
       final registry = ServiceRegistry.instance;
       final repository = registry.modelRepository;
 
-      debugPrint('🔄 Starting Legacy preferences migration...');
+      gemmaLog('🔄 Starting Legacy preferences migration...');
 
       // Check if migration already done
       if (!forceRemigration && await isMigrationCompleted()) {
-        debugPrint('✅ Migration already completed, skipping');
+        gemmaLog('✅ Migration already completed, skipping');
         return MigrationResult(
           migratedCount: 0,
           skippedCount: 0,
@@ -79,11 +79,11 @@ class LegacyPreferencesMigrator {
             hasLoraWeights: false,
           );
           migratedCount++;
-          debugPrint('✅ Migrated inference model: $filename');
+          gemmaLog('✅ Migrated inference model: $filename');
         } catch (e) {
           errors.add('Failed to migrate inference model $filename: $e');
           skippedCount++;
-          debugPrint('⚠️  Failed to migrate $filename: $e');
+          gemmaLog('⚠️  Failed to migrate $filename: $e');
         }
       }
 
@@ -99,11 +99,11 @@ class LegacyPreferencesMigrator {
             hasLoraWeights: true,
           );
           migratedCount++;
-          debugPrint('✅ Migrated LoRA weights: $filename');
+          gemmaLog('✅ Migrated LoRA weights: $filename');
         } catch (e) {
           errors.add('Failed to migrate LoRA $filename: $e');
           skippedCount++;
-          debugPrint('⚠️  Failed to migrate $filename: $e');
+          gemmaLog('⚠️  Failed to migrate $filename: $e');
         }
       }
 
@@ -120,11 +120,11 @@ class LegacyPreferencesMigrator {
             hasLoraWeights: false,
           );
           migratedCount++;
-          debugPrint('✅ Migrated embedding model: $filename');
+          gemmaLog('✅ Migrated embedding model: $filename');
         } catch (e) {
           errors.add('Failed to migrate embedding model $filename: $e');
           skippedCount++;
-          debugPrint('⚠️  Failed to migrate $filename: $e');
+          gemmaLog('⚠️  Failed to migrate $filename: $e');
         }
       }
 
@@ -141,24 +141,24 @@ class LegacyPreferencesMigrator {
             hasLoraWeights: false,
           );
           migratedCount++;
-          debugPrint('✅ Migrated tokenizer: $filename');
+          gemmaLog('✅ Migrated tokenizer: $filename');
         } catch (e) {
           errors.add('Failed to migrate tokenizer $filename: $e');
           skippedCount++;
-          debugPrint('⚠️  Failed to migrate $filename: $e');
+          gemmaLog('⚠️  Failed to migrate $filename: $e');
         }
       }
 
       // 5. Clean up old Legacy keys
       if (migratedCount > 0) {
         await _cleanupLegacyKeys(prefs);
-        debugPrint('🧹 Cleaned up old Legacy preference keys');
+        gemmaLog('🧹 Cleaned up old Legacy preference keys');
       }
 
       // Mark migration as completed
       await prefs.setBool('_migration_completed_v1', true);
 
-      debugPrint(
+      gemmaLog(
           '✅ Migration completed! Migrated: $migratedCount, Skipped: $skippedCount');
 
       return MigrationResult(
@@ -168,8 +168,8 @@ class LegacyPreferencesMigrator {
         alreadyCompleted: false,
       );
     } catch (e, stackTrace) {
-      debugPrint('❌ Migration failed critically: $e');
-      debugPrint('Stack trace: $stackTrace');
+      gemmaLog('❌ Migration failed critically: $e');
+      gemmaLog('Stack trace: $stackTrace');
       throw MigrationException('Migration failed: $e', e, stackTrace);
     }
   }
@@ -219,7 +219,7 @@ class LegacyPreferencesMigrator {
         }
       }
     } catch (e) {
-      debugPrint('⚠️  Could not get size for $filename: $e');
+      gemmaLog('⚠️  Could not get size for $filename: $e');
       // Continue without size
     }
 
@@ -237,7 +237,7 @@ class LegacyPreferencesMigrator {
 
   /// Cleans up old Legacy preference keys
   Future<void> _cleanupLegacyKeys(SharedPreferences prefs) async {
-    debugPrint('🧹 Cleaning up old Legacy preference keys...');
+    gemmaLog('🧹 Cleaning up old Legacy preference keys...');
 
     // Remove main lists
     await prefs.remove('installed_models');
@@ -253,7 +253,7 @@ class LegacyPreferencesMigrator {
           key == 'installed_model_file_name' ||
           key == 'embedding_model_file') {
         await prefs.remove(key);
-        debugPrint('🧹 Removed old key: $key');
+        gemmaLog('🧹 Removed old key: $key');
       }
     }
   }

--- a/lib/core/model_management/cancel_token.dart
+++ b/lib/core/model_management/cancel_token.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart';
+import '../utils/gemma_log.dart';
 
 /// Token for cancelling model downloads
 ///
@@ -48,7 +48,7 @@ class CancelToken {
   /// [reason] - Optional message explaining why the operation was cancelled
   void cancel([String reason = 'Operation cancelled']) {
     if (isCancelled) {
-      debugPrint('⚠️ CancelToken already cancelled. '
+      gemmaLog('⚠️ CancelToken already cancelled. '
           'Previous reason: $_cancelReason, new reason: $reason');
       return;
     }
@@ -57,7 +57,7 @@ class CancelToken {
     _stackTrace = StackTrace.current;
     _completer?.complete();
 
-    debugPrint('🚫 CancelToken cancelled: $reason');
+    gemmaLog('🚫 CancelToken cancelled: $reason');
   }
 
   /// Throws if this token has been cancelled

--- a/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/lib/core/model_management/managers/mobile_model_manager.dart
@@ -2,14 +2,20 @@ part of '../../../mobile/flutter_gemma_mobile.dart';
 
 /// Main unified model manager that orchestrates all model operations
 class MobileModelManager extends ModelFileManager {
-  bool _isInitialized = false;
+  /// Single-flight init guard. Cached so concurrent callers share one
+  /// initialization; the cached future is NOT cleared on failure (init reads
+  /// SharedPreferences — a failure there is not transiently retryable, and a
+  /// sticky failure avoids an infinite re-init loop). See #314.
+  Future<void>? _initFuture;
 
-  /// Initializes the unified model manager
-  Future<void> initialize() async {
-    if (_isInitialized) return;
+  /// Initializes the unified model manager. Idempotent and concurrency-safe.
+  Future<void> initialize() => _initFuture ??= _doInit();
 
+  @override
+  Future<void> ensureInitialized() => initialize();
+
+  Future<void> _doInit() async {
     try {
-      _isInitialized = true;
       await _restoreActiveInferenceModel();
       await _restoreActiveEmbeddingModel();
       gemmaLog('UnifiedModelManager initialized successfully');
@@ -708,12 +714,8 @@ class MobileModelManager extends ModelFileManager {
     );
   }
 
-  /// Ensures the manager is initialized
-  Future<void> _ensureInitialized() async {
-    if (!_isInitialized) {
-      await initialize();
-    }
-  }
+  /// Internal readiness guard for manager operations.
+  Future<void> _ensureInitialized() => initialize();
 
   // === Legacy Asset Loading Methods Implementation ===
 

--- a/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/lib/core/model_management/managers/mobile_model_manager.dart
@@ -3,9 +3,10 @@ part of '../../../mobile/flutter_gemma_mobile.dart';
 /// Main unified model manager that orchestrates all model operations
 class MobileModelManager extends ModelFileManager {
   /// Single-flight init guard. Cached so concurrent callers share one
-  /// initialization; the cached future is NOT cleared on failure (init reads
-  /// SharedPreferences — a failure there is not transiently retryable, and a
-  /// sticky failure avoids an infinite re-init loop). See #314.
+  /// initialization. Init only restores the previously-active model identity
+  /// (#227); a restore failure degrades to "no active model" rather than
+  /// throwing, so a corrupt/unreadable prefs state never blocks app startup
+  /// (#314 follow-up). The cached future therefore always completes normally.
   Future<void>? _initFuture;
 
   /// Initializes the unified model manager. Idempotent and concurrency-safe.
@@ -20,12 +21,11 @@ class MobileModelManager extends ModelFileManager {
       await _restoreActiveEmbeddingModel();
       gemmaLog('UnifiedModelManager initialized successfully');
     } catch (e) {
-      gemmaLog('Failed to initialize UnifiedModelManager: $e');
-      throw ModelStorageException(
-        'Failed to initialize model manager',
-        e,
-        'initialize',
-      );
+      // Restoring the previously-active model is best-effort. A failure here
+      // (e.g. unreadable SharedPreferences) must not abort app startup — start
+      // with no active model; the user can re-install/select. (#314 follow-up)
+      gemmaLog(
+          'UnifiedModelManager: active-model restore failed, starting with no active model: $e');
     }
   }
 

--- a/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/lib/core/model_management/managers/mobile_model_manager.dart
@@ -20,12 +20,13 @@ class MobileModelManager extends ModelFileManager {
       await _restoreActiveInferenceModel();
       await _restoreActiveEmbeddingModel();
       gemmaLog('UnifiedModelManager initialized successfully');
-    } catch (e) {
+    } catch (e, st) {
       // Restoring the previously-active model is best-effort. A failure here
       // (e.g. unreadable SharedPreferences) must not abort app startup — start
       // with no active model; the user can re-install/select. (#314 follow-up)
+      // Include the stack trace so an unexpected restore bug stays diagnosable.
       gemmaLog(
-          'UnifiedModelManager: active-model restore failed, starting with no active model: $e');
+          'UnifiedModelManager: active-model restore failed, starting with no active model: $e\n$st');
     }
   }
 

--- a/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/lib/core/model_management/managers/mobile_model_manager.dart
@@ -12,9 +12,9 @@ class MobileModelManager extends ModelFileManager {
       _isInitialized = true;
       await _restoreActiveInferenceModel();
       await _restoreActiveEmbeddingModel();
-      debugPrint('UnifiedModelManager initialized successfully');
+      gemmaLog('UnifiedModelManager initialized successfully');
     } catch (e) {
-      debugPrint('Failed to initialize UnifiedModelManager: $e');
+      gemmaLog('Failed to initialize UnifiedModelManager: $e');
       throw ModelStorageException(
         'Failed to initialize model manager',
         e,
@@ -31,8 +31,10 @@ class MobileModelManager extends ModelFileManager {
   /// callers had to re-invoke `installModel()` every launch.
   Future<void> _restoreActiveInferenceModel() async {
     final prefs = await SharedPreferences.getInstance();
-    final modelTypeName = prefs.getString(PreferencesKeys.activeInferenceModelType);
-    final fileTypeName = prefs.getString(PreferencesKeys.activeInferenceFileType);
+    final modelTypeName =
+        prefs.getString(PreferencesKeys.activeInferenceModelType);
+    final fileTypeName =
+        prefs.getString(PreferencesKeys.activeInferenceFileType);
     final filename = prefs.getString(PreferencesKeys.activeInferenceFilename);
 
     if (modelTypeName == null || fileTypeName == null || filename == null) {
@@ -45,7 +47,7 @@ class MobileModelManager extends ModelFileManager {
       modelType = ModelType.values.byName(modelTypeName);
       fileType = ModelFileType.values.byName(fileTypeName);
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           '[ModelManager] active model restore: unknown enum value ($modelTypeName / $fileTypeName) — skipping');
       return;
     }
@@ -53,7 +55,7 @@ class MobileModelManager extends ModelFileManager {
     final filePath = await ServiceRegistry.instance.fileSystemService
         .getTargetPath(filename);
     if (!File(filePath).existsSync()) {
-      debugPrint(
+      gemmaLog(
           '[ModelManager] active model restore: file $filePath missing — skipping');
       return;
     }
@@ -64,7 +66,7 @@ class MobileModelManager extends ModelFileManager {
       modelType: modelType,
       fileType: fileType,
     );
-    debugPrint('[ModelManager] restored active inference model: $filename');
+    gemmaLog('[ModelManager] restored active inference model: $filename');
   }
 
   /// Mirror of [_restoreActiveInferenceModel] for the embedding pair
@@ -84,7 +86,7 @@ class MobileModelManager extends ModelFileManager {
     final modelPath = await fs.getTargetPath(modelFilename);
     final tokenizerPath = await fs.getTargetPath(tokenizerFilename);
     if (!File(modelPath).existsSync() || !File(tokenizerPath).existsSync()) {
-      debugPrint(
+      gemmaLog(
           '[ModelManager] active embedding restore: file missing — skipping');
       return;
     }
@@ -94,20 +96,20 @@ class MobileModelManager extends ModelFileManager {
       modelSource: FileSource(modelPath),
       tokenizerSource: FileSource(tokenizerPath),
     );
-    debugPrint('[ModelManager] restored active embedding model: $modelFilename');
+    gemmaLog('[ModelManager] restored active embedding model: $modelFilename');
   }
 
   /// Internal method for ModelSpec-based operations
   Future<void> _ensureModelReadySpec(ModelSpec spec) async {
     await _ensureInitialized();
 
-    debugPrint('UnifiedModelManager: Ensuring model ready - ${spec.name}');
+    gemmaLog('UnifiedModelManager: Ensuring model ready - ${spec.name}');
 
     try {
       await _ensureModelReady(spec);
-      debugPrint('UnifiedModelManager: Model ${spec.name} is ready');
+      gemmaLog('UnifiedModelManager: Model ${spec.name} is ready');
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to ensure model ready - ${spec.name}: $e');
       rethrow;
     }
@@ -116,19 +118,19 @@ class MobileModelManager extends ModelFileManager {
   /// Ensures a model is ready, applying replace policy
   /// Delegates to Modern API handlers via ServiceRegistry
   Future<void> _ensureModelReady(ModelSpec spec) async {
-    debugPrint('🔍 Ensuring model ready: ${spec.name}');
-    debugPrint('🔍 Model source type: ${spec.files.first.source.runtimeType}');
+    gemmaLog('🔍 Ensuring model ready: ${spec.name}');
+    gemmaLog('🔍 Model source type: ${spec.files.first.source.runtimeType}');
 
     // Check if already installed
     final installed = await _isModelInstalled(spec);
-    debugPrint('🔍 isModelInstalled returned: $installed');
+    gemmaLog('🔍 isModelInstalled returned: $installed');
 
     if (installed) {
-      debugPrint('✅ Model ${spec.name} already ready (skipping installation)');
+      gemmaLog('✅ Model ${spec.name} already ready (skipping installation)');
       return;
     }
 
-    debugPrint('📥 Model not installed, proceeding with installation...');
+    gemmaLog('📥 Model not installed, proceeding with installation...');
 
     // Handle model switching with replace policy
     await _handleModelSwitching(spec);
@@ -144,7 +146,7 @@ class MobileModelManager extends ModelFileManager {
     final handlerRegistry = registry.sourceHandlerRegistry;
 
     for (final file in spec.files) {
-      debugPrint(
+      gemmaLog(
           '🔀 Routing file: ${file.filename}, source type: ${file.source.runtimeType}');
 
       try {
@@ -159,7 +161,7 @@ class MobileModelManager extends ModelFileManager {
         }
 
         await handler.install(file.source);
-        debugPrint(
+        gemmaLog(
             '✅ File installed: ${file.filename} via Modern handler: ${file.source.runtimeType}');
       } catch (e) {
         throw ModelStorageException(
@@ -175,7 +177,7 @@ class MobileModelManager extends ModelFileManager {
   Future<void> _handleModelSwitching(ModelSpec spec) async {
     // If replace policy, clean up ALL models of this type before installing new one
     if (spec.replacePolicy == ModelReplacePolicy.replace) {
-      debugPrint(
+      gemmaLog(
           'Policy-based replacement: cleaning up ALL ${spec.type.name} models');
 
       // Delete all installed models of this type from ModelRepository
@@ -188,7 +190,7 @@ class MobileModelManager extends ModelFileManager {
           await ModelFileSystemManager.deleteModelFile(filename);
           await repository.deleteModel(filename);
         } catch (e) {
-          debugPrint('Failed to delete model file $filename: $e');
+          gemmaLog('Failed to delete model file $filename: $e');
         }
       }
 
@@ -200,7 +202,7 @@ class MobileModelManager extends ModelFileManager {
   /// Clean up all tasks and files of a specific type
   Future<void> _cleanupAllTasksOfType(ModelManagementType type) async {
     try {
-      debugPrint('Cleaning up all tasks of type: ${type.name}');
+      gemmaLog('Cleaning up all tasks of type: ${type.name}');
 
       final downloader = FileDownloader();
       final records = await downloader.database.allRecords();
@@ -215,23 +217,23 @@ class MobileModelManager extends ModelFileManager {
           try {
             await ModelFileSystemManager.deleteModelFile(filename);
           } catch (e) {
-            debugPrint('Could not delete partial file $filename: $e');
+            gemmaLog('Could not delete partial file $filename: $e');
           }
         }
       }
 
       if (cleanedCount > 0) {
-        debugPrint('Cleaned up $cleanedCount tasks of type ${type.name}');
+        gemmaLog('Cleaned up $cleanedCount tasks of type ${type.name}');
       }
 
       // Reset background_downloader tasks
       try {
         await downloader.reset(group: 'flutter_gemma_downloads');
       } catch (e) {
-        debugPrint('Failed to reset background_downloader tasks: $e');
+        gemmaLog('Failed to reset background_downloader tasks: $e');
       }
     } catch (e) {
-      debugPrint('Failed to cleanup tasks of type ${type.name}: $e');
+      gemmaLog('Failed to cleanup tasks of type ${type.name}: $e');
     }
   }
 
@@ -281,17 +283,17 @@ class MobileModelManager extends ModelFileManager {
       {String? token}) async* {
     await _ensureInitialized();
 
-    debugPrint(
+    gemmaLog(
         'UnifiedModelManager: Starting download with progress - ${spec.name}');
 
     try {
       yield* _downloadModelWithProgress(spec, token: token);
-      debugPrint('UnifiedModelManager: Download completed - ${spec.name}');
+      gemmaLog('UnifiedModelManager: Download completed - ${spec.name}');
 
       // Set as active model after successful download (same as Modern API)
       setActiveModel(spec);
     } catch (e) {
-      debugPrint('UnifiedModelManager: Download failed - ${spec.name}: $e');
+      gemmaLog('UnifiedModelManager: Download failed - ${spec.name}: $e');
       rethrow;
     }
   }
@@ -397,18 +399,18 @@ class MobileModelManager extends ModelFileManager {
   Future<void> downloadModel(ModelSpec spec, {String? token}) async {
     await _ensureInitialized();
 
-    debugPrint('UnifiedModelManager: Starting download - ${spec.name}');
+    gemmaLog('UnifiedModelManager: Starting download - ${spec.name}');
 
     try {
       await for (final _ in _downloadModelWithProgress(spec, token: token)) {
         // Just consume the stream without emitting progress
       }
-      debugPrint('UnifiedModelManager: Download completed - ${spec.name}');
+      gemmaLog('UnifiedModelManager: Download completed - ${spec.name}');
 
       // Set as active model after successful download (same as Modern API)
       setActiveModel(spec);
     } catch (e) {
-      debugPrint('UnifiedModelManager: Download failed - ${spec.name}: $e');
+      gemmaLog('UnifiedModelManager: Download failed - ${spec.name}: $e');
       rethrow;
     }
   }
@@ -420,10 +422,10 @@ class MobileModelManager extends ModelFileManager {
 
     try {
       final result = await _isModelInstalled(spec);
-      debugPrint('UnifiedModelManager: Model ${spec.name} installed: $result');
+      gemmaLog('UnifiedModelManager: Model ${spec.name} installed: $result');
       return result;
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to check if model installed - ${spec.name}: $e');
       return false;
     }
@@ -450,7 +452,7 @@ class MobileModelManager extends ModelFileManager {
   Future<void> deleteModel(ModelSpec spec) async {
     await _ensureInitialized();
 
-    debugPrint('UnifiedModelManager: Deleting model - ${spec.name}');
+    gemmaLog('UnifiedModelManager: Deleting model - ${spec.name}');
 
     try {
       final registry = ServiceRegistry.instance;
@@ -462,9 +464,9 @@ class MobileModelManager extends ModelFileManager {
         await repository.deleteModel(file.filename);
       }
 
-      debugPrint('UnifiedModelManager: Model deleted - ${spec.name}');
+      gemmaLog('UnifiedModelManager: Model deleted - ${spec.name}');
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to delete model - ${spec.name}: $e');
       throw ModelStorageException(
         'Failed to delete model: ${spec.name}',
@@ -495,11 +497,11 @@ class MobileModelManager extends ModelFileManager {
           .map((info) => info.id)
           .toList();
 
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Found ${files.length} installed files for type $type');
       return files;
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to get installed models for type $type: $e');
       return [];
     }
@@ -514,7 +516,7 @@ class MobileModelManager extends ModelFileManager {
       final files = await getInstalledModels(type);
       return files.isNotEmpty;
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to check if any model is installed for type $type: $e');
       return false;
     }
@@ -525,7 +527,7 @@ class MobileModelManager extends ModelFileManager {
   Future<void> performCleanup() async {
     await _ensureInitialized();
 
-    debugPrint('UnifiedModelManager: Performing cleanup');
+    gemmaLog('UnifiedModelManager: Performing cleanup');
 
     try {
       // 1. Get protected files from ModelRepository
@@ -541,9 +543,9 @@ class MobileModelManager extends ModelFileManager {
       final downloader = FileDownloader();
       await downloader.reset(group: 'flutter_gemma_downloads');
 
-      debugPrint('UnifiedModelManager: Cleanup completed');
+      gemmaLog('UnifiedModelManager: Cleanup completed');
     } catch (e) {
-      debugPrint('UnifiedModelManager: Cleanup failed: $e');
+      gemmaLog('UnifiedModelManager: Cleanup failed: $e');
       // Don't rethrow - cleanup failures should not break the app
     }
   }
@@ -564,10 +566,10 @@ class MobileModelManager extends ModelFileManager {
 
     try {
       final result = await ModelFileSystemManager.validateModelFiles(spec);
-      debugPrint('UnifiedModelManager: Model ${spec.name} validation: $result');
+      gemmaLog('UnifiedModelManager: Model ${spec.name} validation: $result');
       return result;
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to validate model - ${spec.name}: $e');
       return false;
     }
@@ -608,7 +610,7 @@ class MobileModelManager extends ModelFileManager {
 
       return filePaths;
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Failed to get file paths for ${spec.name}: $e');
       return null;
     }
@@ -781,7 +783,7 @@ class MobileModelManager extends ModelFileManager {
     await _ensureInitialized();
     _activeInferenceModel = null;
     _activeEmbeddingModel = null;
-    debugPrint('Model cache cleared');
+    gemmaLog('Model cache cleared');
   }
 
   // === Active Model Management ===
@@ -811,13 +813,13 @@ class MobileModelManager extends ModelFileManager {
   void setActiveModel(ModelSpec spec) {
     if (spec is InferenceModelSpec) {
       _activeInferenceModel = spec;
-      debugPrint('✅ Set active inference model: ${spec.name}');
+      gemmaLog('✅ Set active inference model: ${spec.name}');
       // Fire-and-forget — SharedPreferences write is cheap and the
       // success of the operation is already reflected in memory.
       unawaited(_persistActiveInferenceIdentity(spec));
     } else if (spec is EmbeddingModelSpec) {
       _activeEmbeddingModel = spec;
-      debugPrint('✅ Set active embedding model: ${spec.name}');
+      gemmaLog('✅ Set active embedding model: ${spec.name}');
       unawaited(_persistActiveEmbeddingIdentity(spec));
     } else {
       throw ArgumentError('Unknown ModelSpec type: ${spec.runtimeType}');
@@ -827,26 +829,26 @@ class MobileModelManager extends ModelFileManager {
   Future<void> _persistActiveInferenceIdentity(InferenceModelSpec spec) async {
     try {
       final filename = spec.files
-          .firstWhere((f) => f.prefsKey == PreferencesKeys.installedModelFileName)
+          .firstWhere(
+              (f) => f.prefsKey == PreferencesKeys.installedModelFileName)
           .filename;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
           PreferencesKeys.activeInferenceModelType, spec.modelType.name);
       await prefs.setString(
           PreferencesKeys.activeInferenceFileType, spec.fileType.name);
-      await prefs.setString(
-          PreferencesKeys.activeInferenceFilename, filename);
+      await prefs.setString(PreferencesKeys.activeInferenceFilename, filename);
       await prefs.setString(
           PreferencesKeys.activeInferenceSource, spec.modelSource.encode());
     } catch (e) {
-      debugPrint('[ModelManager] persistActiveInferenceIdentity failed: $e');
+      gemmaLog('[ModelManager] persistActiveInferenceIdentity failed: $e');
     }
   }
 
   Future<void> _persistActiveEmbeddingIdentity(EmbeddingModelSpec spec) async {
     try {
-      final modelFile = spec.files.firstWhere(
-          (f) => f.prefsKey == PreferencesKeys.embeddingModelFile);
+      final modelFile = spec.files
+          .firstWhere((f) => f.prefsKey == PreferencesKeys.embeddingModelFile);
       final tokenizerFile = spec.files.firstWhere(
           (f) => f.prefsKey == PreferencesKeys.embeddingTokenizerFile);
       final prefs = await SharedPreferences.getInstance();
@@ -859,7 +861,7 @@ class MobileModelManager extends ModelFileManager {
       await prefs.setString(PreferencesKeys.activeEmbeddingTokenizerSource,
           spec.tokenizerSource.encode());
     } catch (e) {
-      debugPrint('[ModelManager] persistActiveEmbeddingIdentity failed: $e');
+      gemmaLog('[ModelManager] persistActiveEmbeddingIdentity failed: $e');
     }
   }
 
@@ -958,7 +960,7 @@ class MobileModelManager extends ModelFileManager {
 
       return stats;
     } catch (e) {
-      debugPrint('UnifiedModelManager: Failed to get storage stats: $e');
+      gemmaLog('UnifiedModelManager: Failed to get storage stats: $e');
       return {
         'protectedFiles': 0,
         'totalSizeBytes': 0,
@@ -983,7 +985,7 @@ class MobileModelManager extends ModelFileManager {
         protectedFiles: protectedFiles,
       );
     } catch (e) {
-      debugPrint('UnifiedModelManager: Failed to get orphaned files: $e');
+      gemmaLog('UnifiedModelManager: Failed to get orphaned files: $e');
       return [];
     }
   }
@@ -999,7 +1001,7 @@ class MobileModelManager extends ModelFileManager {
         protectedFiles: protectedFiles,
       );
     } catch (e) {
-      debugPrint('UnifiedModelManager: Failed to get storage info: $e');
+      gemmaLog('UnifiedModelManager: Failed to get storage info: $e');
       return const StorageStats(
         totalFiles: 0,
         totalSizeBytes: 0,
@@ -1017,7 +1019,7 @@ class MobileModelManager extends ModelFileManager {
   Future<int> cleanupStorage() async {
     await _ensureInitialized();
 
-    debugPrint('UnifiedModelManager: Cleaning up storage (explicit user call)');
+    gemmaLog('UnifiedModelManager: Cleaning up storage (explicit user call)');
 
     try {
       final protectedFiles = await _getProtectedFiles();
@@ -1026,11 +1028,10 @@ class MobileModelManager extends ModelFileManager {
         enableResumeDetection: true,
       );
 
-      debugPrint(
-          'UnifiedModelManager: Cleaned up $deletedCount orphaned files');
+      gemmaLog('UnifiedModelManager: Cleaned up $deletedCount orphaned files');
       return deletedCount;
     } catch (e) {
-      debugPrint('UnifiedModelManager: Failed to cleanup storage: $e');
+      gemmaLog('UnifiedModelManager: Failed to cleanup storage: $e');
       return 0;
     }
   }
@@ -1064,10 +1065,10 @@ class MobileModelManager extends ModelFileManager {
           await getInstalledModels(ModelManagementType.embedding);
       protected.addAll(installedEmbedding);
 
-      debugPrint(
+      gemmaLog(
           'UnifiedModelManager: Protected files count: ${protected.length}');
     } catch (e) {
-      debugPrint('UnifiedModelManager: Failed to get protected files: $e');
+      gemmaLog('UnifiedModelManager: Failed to get protected files: $e');
     }
 
     return protected;

--- a/lib/core/model_management/managers/web_model_manager.dart
+++ b/lib/core/model_management/managers/web_model_manager.dart
@@ -17,7 +17,10 @@ part of '../../../web/flutter_gemma_web.dart';
 /// - Easier to maintain and test
 class WebModelManager extends ModelFileManager {
   /// Single-flight init guard — see MobileModelManager / #314. Cached so
-  /// concurrent callers share one init; not cleared on failure.
+  /// concurrent callers share one init. Init only restores the previously-
+  /// active model identity (#227); a restore failure degrades to "no active
+  /// model" rather than throwing, so it never blocks app startup. The cached
+  /// future therefore always completes normally.
   Future<void>? _initFuture;
 
   /// Initializes the web model manager. Idempotent and concurrency-safe.
@@ -27,9 +30,16 @@ class WebModelManager extends ModelFileManager {
   Future<void> ensureInitialized() => initialize();
 
   Future<void> _doInit() async {
-    await _restoreActiveInferenceModel();
-    await _restoreActiveEmbeddingModel();
-    gemmaLog('WebModelManager initialized');
+    try {
+      await _restoreActiveInferenceModel();
+      await _restoreActiveEmbeddingModel();
+      gemmaLog('WebModelManager initialized');
+    } catch (e) {
+      // Best-effort restore: a failure must not abort app startup — start with
+      // no active model. (#314 follow-up; mirrors MobileModelManager.)
+      gemmaLog(
+          'WebModelManager: active-model restore failed, starting with no active model: $e');
+    }
   }
 
   /// Rehydrate `_activeInferenceModel` from the identity persisted by a
@@ -372,8 +382,14 @@ class WebModelManager extends ModelFileManager {
             fileSystem.registerUrl(file.filename, cachedBlobUrl);
             url = cachedBlobUrl;
           } else {
+            // Cached blob is gone and the auth token is not persisted across
+            // restarts (ModelSource.encode drops it). Falling back to the
+            // original URL works for PUBLIC models but a GATED model will fail
+            // the fetch later with an opaque network error. Surface it now at a
+            // visible level so the cause (re-auth / re-install needed) is clear.
             gemmaLog(
-                '[WebModelManager] ⚠️  Not found in cache, will use original URL (may require auth)');
+                '[WebModelManager] ⚠️  "${file.filename}" not in cache; falling back to original URL ${networkSource.url}. '
+                'If this model is gated/private, the load will fail (auth token is not restored) — re-install the model to re-authenticate.');
           }
         }
         path = url ?? (file.source as NetworkSource).url;

--- a/lib/core/model_management/managers/web_model_manager.dart
+++ b/lib/core/model_management/managers/web_model_manager.dart
@@ -16,12 +16,17 @@ part of '../../../web/flutter_gemma_web.dart';
 /// - Platform-agnostic (same pattern as MobileModelManager)
 /// - Easier to maintain and test
 class WebModelManager extends ModelFileManager {
-  bool _isInitialized = false;
+  /// Single-flight init guard — see MobileModelManager / #314. Cached so
+  /// concurrent callers share one init; not cleared on failure.
+  Future<void>? _initFuture;
 
-  /// Initializes the web model manager
-  Future<void> initialize() async {
-    if (_isInitialized) return;
-    _isInitialized = true;
+  /// Initializes the web model manager. Idempotent and concurrency-safe.
+  Future<void> initialize() => _initFuture ??= _doInit();
+
+  @override
+  Future<void> ensureInitialized() => initialize();
+
+  Future<void> _doInit() async {
     await _restoreActiveInferenceModel();
     await _restoreActiveEmbeddingModel();
     gemmaLog('WebModelManager initialized');
@@ -497,11 +502,7 @@ class WebModelManager extends ModelFileManager {
     await ensureModelReadyFromSpec(spec);
   }
 
-  Future<void> _ensureInitialized() async {
-    if (!_isInitialized) {
-      await initialize();
-    }
-  }
+  Future<void> _ensureInitialized() => initialize();
 
   /// Creates an inference model specification from parameters
   static InferenceModelSpec createInferenceSpec({

--- a/lib/core/model_management/managers/web_model_manager.dart
+++ b/lib/core/model_management/managers/web_model_manager.dart
@@ -34,11 +34,12 @@ class WebModelManager extends ModelFileManager {
       await _restoreActiveInferenceModel();
       await _restoreActiveEmbeddingModel();
       gemmaLog('WebModelManager initialized');
-    } catch (e) {
+    } catch (e, st) {
       // Best-effort restore: a failure must not abort app startup — start with
       // no active model. (#314 follow-up; mirrors MobileModelManager.)
+      // Include the stack trace so an unexpected restore bug stays diagnosable.
       gemmaLog(
-          'WebModelManager: active-model restore failed, starting with no active model: $e');
+          'WebModelManager: active-model restore failed, starting with no active model: $e\n$st');
     }
   }
 

--- a/lib/core/model_management/managers/web_model_manager.dart
+++ b/lib/core/model_management/managers/web_model_manager.dart
@@ -24,7 +24,7 @@ class WebModelManager extends ModelFileManager {
     _isInitialized = true;
     await _restoreActiveInferenceModel();
     await _restoreActiveEmbeddingModel();
-    debugPrint('WebModelManager initialized');
+    gemmaLog('WebModelManager initialized');
   }
 
   /// Rehydrate `_activeInferenceModel` from the identity persisted by a
@@ -54,14 +54,14 @@ class WebModelManager extends ModelFileManager {
       modelType = ModelType.values.byName(modelTypeName);
       fileType = ModelFileType.values.byName(fileTypeName);
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           '[WebModelManager] active model restore: unknown enum value — skipping');
       return;
     }
 
     final source = ModelSource.tryDecode(sourceEncoded);
     if (source == null) {
-      debugPrint(
+      gemmaLog(
           '[WebModelManager] active model restore: malformed source — skipping');
       return;
     }
@@ -71,7 +71,7 @@ class WebModelManager extends ModelFileManager {
     // later on the first getActiveModel() call.
     final repo = ServiceRegistry.instance.modelRepository;
     if (!await repo.isInstalled(filename)) {
-      debugPrint(
+      gemmaLog(
           '[WebModelManager] active model restore: $filename not in repository — skipping');
       return;
     }
@@ -82,8 +82,7 @@ class WebModelManager extends ModelFileManager {
       modelType: modelType,
       fileType: fileType,
     );
-    debugPrint(
-        '[WebModelManager] restored active inference model: $filename');
+    gemmaLog('[WebModelManager] restored active inference model: $filename');
   }
 
   Future<void> _restoreActiveEmbeddingModel() async {
@@ -107,7 +106,7 @@ class WebModelManager extends ModelFileManager {
     final modelSource = ModelSource.tryDecode(modelSourceEncoded);
     final tokenizerSource = ModelSource.tryDecode(tokenizerSourceEncoded);
     if (modelSource == null || tokenizerSource == null) {
-      debugPrint(
+      gemmaLog(
           '[WebModelManager] active embedding restore: malformed source — skipping');
       return;
     }
@@ -115,7 +114,7 @@ class WebModelManager extends ModelFileManager {
     final repo = ServiceRegistry.instance.modelRepository;
     if (!await repo.isInstalled(modelFilename) ||
         !await repo.isInstalled(tokenizerFilename)) {
-      debugPrint(
+      gemmaLog(
           '[WebModelManager] active embedding restore: file missing — skipping');
       return;
     }
@@ -125,7 +124,7 @@ class WebModelManager extends ModelFileManager {
       modelSource: modelSource,
       tokenizerSource: tokenizerSource,
     );
-    debugPrint(
+    gemmaLog(
         '[WebModelManager] restored active embedding model: $modelFilename');
   }
 
@@ -156,7 +155,7 @@ class WebModelManager extends ModelFileManager {
       {String? token}) async* {
     await _ensureInitialized();
 
-    debugPrint('WebModelManager: Starting download for ${spec.name}');
+    gemmaLog('WebModelManager: Starting download for ${spec.name}');
 
     // Phase 5: Delegate to Modern API
     final registry = ServiceRegistry.instance;
@@ -215,7 +214,7 @@ class WebModelManager extends ModelFileManager {
       currentFileName: 'Complete',
     );
 
-    debugPrint('WebModelManager: Download completed for ${spec.name}');
+    gemmaLog('WebModelManager: Download completed for ${spec.name}');
   }
 
   @override
@@ -244,7 +243,7 @@ class WebModelManager extends ModelFileManager {
       await repository.deleteModel(file.filename);
     }
 
-    debugPrint('WebModelManager: Model ${spec.name} deleted');
+    gemmaLog('WebModelManager: Model ${spec.name} deleted');
   }
 
   /// Gets list of installed model filenames
@@ -300,7 +299,7 @@ class WebModelManager extends ModelFileManager {
   @override
   Future<void> performCleanup() async {
     await _ensureInitialized();
-    debugPrint('WebModelManager: Cleanup not needed on web');
+    gemmaLog('WebModelManager: Cleanup not needed on web');
   }
 
   /// Validates if a model is properly installed
@@ -349,7 +348,7 @@ class WebModelManager extends ModelFileManager {
         // If URL lost (page reload), restore from Cache API
         var url = fileSystem.getUrl(file.filename);
         if (url == null) {
-          debugPrint(
+          gemmaLog(
               '[WebModelManager] Blob URL lost for ${file.filename}, restoring from cache...');
 
           // Try to restore from Cache API
@@ -362,13 +361,13 @@ class WebModelManager extends ModelFileManager {
           final cachedBlobUrl =
               await cacheService.getCachedBlobUrl(networkSource.url);
           if (cachedBlobUrl != null) {
-            debugPrint(
+            gemmaLog(
                 '[WebModelManager] ✅ Restored blob URL from cache: $cachedBlobUrl');
             // Re-register the blob URL
             fileSystem.registerUrl(file.filename, cachedBlobUrl);
             url = cachedBlobUrl;
           } else {
-            debugPrint(
+            gemmaLog(
                 '[WebModelManager] ⚠️  Not found in cache, will use original URL (may require auth)');
           }
         }
@@ -382,7 +381,7 @@ class WebModelManager extends ModelFileManager {
         // If URL lost (page reload), recreate it
         var url = fileSystem.getUrl(file.filename);
         if (url == null) {
-          debugPrint(
+          gemmaLog(
               '[WebModelManager] Blob URL lost for ${file.filename}, recreating from asset...');
           // Recreate Blob URL by reinstalling
           final handler =
@@ -660,14 +659,14 @@ class WebModelManager extends ModelFileManager {
   /// ```dart
   /// // OLD:
   /// await for (final progress in manager.installModelFromAssetWithProgress('assets/models/gemma.task')) {
-  ///   debugPrint('Progress: $progress%');
+  ///   gemmaLog('Progress: $progress%');
   /// }
   ///
   /// // NEW:
   /// await for (final progress in FlutterGemma.installModel()
   ///     .fromAsset('assets/models/gemma.task')
   ///     .installWithProgress()) {
-  ///   debugPrint('Progress: ${progress.currentFileProgress}%');
+  ///   gemmaLog('Progress: ${progress.currentFileProgress}%');
   /// }
   /// ```
   @Deprecated(
@@ -759,7 +758,7 @@ class WebModelManager extends ModelFileManager {
     _activeInferenceModel = null;
     _activeEmbeddingModel = null;
 
-    debugPrint('WebModelManager: Model cache cleared (active models reset)');
+    gemmaLog('WebModelManager: Model cache cleared (active models reset)');
   }
 
   // === Legacy LoRA Management Methods Implementation ===
@@ -839,11 +838,11 @@ class WebModelManager extends ModelFileManager {
   void setActiveModel(ModelSpec spec) {
     if (spec is InferenceModelSpec) {
       _activeInferenceModel = spec;
-      debugPrint('✅ Set active inference model: ${spec.name}');
+      gemmaLog('✅ Set active inference model: ${spec.name}');
       unawaited(_persistActiveInferenceIdentity(spec));
     } else if (spec is EmbeddingModelSpec) {
       _activeEmbeddingModel = spec;
-      debugPrint('✅ Set active embedding model: ${spec.name}');
+      gemmaLog('✅ Set active embedding model: ${spec.name}');
       unawaited(_persistActiveEmbeddingIdentity(spec));
     } else {
       throw ArgumentError('Unknown ModelSpec type: ${spec.runtimeType}');
@@ -861,19 +860,18 @@ class WebModelManager extends ModelFileManager {
           PreferencesKeys.activeInferenceModelType, spec.modelType.name);
       await prefs.setString(
           PreferencesKeys.activeInferenceFileType, spec.fileType.name);
-      await prefs.setString(
-          PreferencesKeys.activeInferenceFilename, filename);
+      await prefs.setString(PreferencesKeys.activeInferenceFilename, filename);
       await prefs.setString(
           PreferencesKeys.activeInferenceSource, spec.modelSource.encode());
     } catch (e) {
-      debugPrint('[WebModelManager] persistActiveInferenceIdentity failed: $e');
+      gemmaLog('[WebModelManager] persistActiveInferenceIdentity failed: $e');
     }
   }
 
   Future<void> _persistActiveEmbeddingIdentity(EmbeddingModelSpec spec) async {
     try {
-      final modelFile = spec.files.firstWhere(
-          (f) => f.prefsKey == PreferencesKeys.embeddingModelFile);
+      final modelFile = spec.files
+          .firstWhere((f) => f.prefsKey == PreferencesKeys.embeddingModelFile);
       final tokenizerFile = spec.files.firstWhere(
           (f) => f.prefsKey == PreferencesKeys.embeddingTokenizerFile);
       final prefs = await SharedPreferences.getInstance();
@@ -886,7 +884,7 @@ class WebModelManager extends ModelFileManager {
       await prefs.setString(PreferencesKeys.activeEmbeddingTokenizerSource,
           spec.tokenizerSource.encode());
     } catch (e) {
-      debugPrint('[WebModelManager] persistActiveEmbeddingIdentity failed: $e');
+      gemmaLog('[WebModelManager] persistActiveEmbeddingIdentity failed: $e');
     }
   }
 
@@ -914,7 +912,7 @@ class WebModelManager extends ModelFileManager {
   Future<int> cleanupStorage() async {
     await _ensureInitialized();
     // Web platform doesn't have file system access, nothing to cleanup
-    debugPrint('WebModelManager: cleanupStorage() is a no-op on web');
+    gemmaLog('WebModelManager: cleanupStorage() is a no-op on web');
     return 0;
   }
 
@@ -932,9 +930,9 @@ class WebModelManager extends ModelFileManager {
       final registry = ServiceRegistry.instance;
       final downloadService = registry.downloadService as WebDownloadService;
       await downloadService.cacheService.clearCache();
-      debugPrint('WebModelManager: Browser cache cleared');
+      gemmaLog('WebModelManager: Browser cache cleared');
     } catch (e) {
-      debugPrint('WebModelManager: clearCache failed: $e');
+      gemmaLog('WebModelManager: clearCache failed: $e');
       rethrow;
     }
   }
@@ -961,7 +959,7 @@ class WebModelManager extends ModelFileManager {
         'availableBytes': quota.available,
       };
     } catch (e) {
-      debugPrint('[WebModelManager] ❌ getCacheStats failed: $e');
+      gemmaLog('[WebModelManager] ❌ getCacheStats failed: $e');
       return {
         'cachedUrls': 0,
         'storageUsage': 0,

--- a/lib/core/model_management/utils/file_system_manager.dart
+++ b/lib/core/model_management/utils/file_system_manager.dart
@@ -71,14 +71,14 @@ class ModelFileSystemManager {
       // Basic size check - model files should be at least the minimum size
       final sizeInBytes = await file.length();
       if (sizeInBytes < minSizeBytes) {
-        debugPrint(
+        gemmaLog(
             'File $filePath too small: $sizeInBytes bytes (minimum: $minSizeBytes)');
         return false;
       }
 
       return true;
     } catch (e) {
-      debugPrint('Error validating file $filePath: $e');
+      gemmaLog('Error validating file $filePath: $e');
       return false;
     }
   }
@@ -197,7 +197,7 @@ class ModelFileSystemManager {
 
       return false;
     } catch (e) {
-      debugPrint('Failed to check active task for $filename: $e');
+      gemmaLog('Failed to check active task for $filename: $e');
       return true; // Assume has task to be safe
     }
   }
@@ -215,7 +215,7 @@ class ModelFileSystemManager {
     List<String>? supportedExtensions,
     bool enableResumeDetection = true,
   }) async {
-    debugPrint('⚠️  cleanupOrphanedFiles() called explicitly by user');
+    gemmaLog('⚠️  cleanupOrphanedFiles() called explicitly by user');
 
     final orphaned = await getOrphanedFiles(
       protectedFiles: protectedFiles,
@@ -227,13 +227,13 @@ class ModelFileSystemManager {
       try {
         await File(info.path).delete();
         deletedCount++;
-        debugPrint('Deleted orphaned file: ${info.filename}');
+        gemmaLog('Deleted orphaned file: ${info.filename}');
       } catch (e) {
-        debugPrint('Failed to delete ${info.filename}: $e');
+        gemmaLog('Failed to delete ${info.filename}: $e');
       }
     }
 
-    debugPrint('Cleaned up $deletedCount orphaned files');
+    gemmaLog('Cleaned up $deletedCount orphaned files');
     return deletedCount;
   }
 
@@ -245,10 +245,10 @@ class ModelFileSystemManager {
 
       if (await file.exists()) {
         await file.delete();
-        debugPrint('Deleted model file: $filename');
+        gemmaLog('Deleted model file: $filename');
       }
     } catch (e) {
-      debugPrint('Failed to delete model file $filename: $e');
+      gemmaLog('Failed to delete model file $filename: $e');
       throw ModelStorageException(
         'Failed to delete model file: $filename',
         e,
@@ -265,7 +265,7 @@ class ModelFileSystemManager {
         await directory.create(recursive: true);
       }
     } catch (e) {
-      debugPrint('Failed to create directory $dirPath: $e');
+      gemmaLog('Failed to create directory $dirPath: $e');
       throw ModelStorageException(
         'Failed to create directory: $dirPath',
         e,
@@ -283,7 +283,7 @@ class ModelFileSystemManager {
       }
       return 0;
     } catch (e) {
-      debugPrint('Failed to get file size for $filePath: $e');
+      gemmaLog('Failed to get file size for $filePath: $e');
       return 0;
     }
   }
@@ -309,7 +309,7 @@ class ModelFileSystemManager {
       // Platform-specific validation for bundled files
       if (file.source is BundledSource) {
         if (!await _validateBundledResource(filePath)) {
-          debugPrint('Bundled resource validation failed: ${file.filename}');
+          gemmaLog('Bundled resource validation failed: ${file.filename}');
           return false;
         }
       } else {
@@ -317,7 +317,7 @@ class ModelFileSystemManager {
         final minSize = getMinimumSize(file.extension);
 
         if (!await isFileValid(filePath, minSizeBytes: minSize)) {
-          debugPrint('Model file validation failed: ${file.filename}');
+          gemmaLog('Model file validation failed: ${file.filename}');
           return false;
         }
       }
@@ -381,7 +381,7 @@ class ModelFileSystemManager {
 
   /// Cleans up failed download files for a model specification
   static Future<void> cleanupFailedDownload(ModelSpec spec) async {
-    debugPrint('Cleaning up failed download for model: ${spec.name}');
+    gemmaLog('Cleaning up failed download for model: ${spec.name}');
 
     for (final file in spec.files) {
       try {
@@ -389,10 +389,10 @@ class ModelFileSystemManager {
         final fileObj = File(filePath);
         if (await fileObj.exists()) {
           await fileObj.delete();
-          debugPrint('Cleaned up partial file: ${file.filename}');
+          gemmaLog('Cleaned up partial file: ${file.filename}');
         }
       } catch (e) {
-        debugPrint('Failed to cleanup file ${file.filename}: $e');
+        gemmaLog('Failed to cleanup file ${file.filename}: $e');
       }
     }
   }

--- a/lib/core/model_management/utils/resume_checker.dart
+++ b/lib/core/model_management/utils/resume_checker.dart
@@ -37,42 +37,41 @@ class ResumeChecker {
   /// Returns [ResumeStatus] indicating what action should be taken
   static Future<ResumeStatus> checkResumeStatus(String filename) async {
     try {
-      debugPrint('ResumeChecker: Checking resume status for $filename');
+      gemmaLog('ResumeChecker: Checking resume status for $filename');
 
       // 1. Check if file exists and get its state
       final filePath = await ModelFileSystemManager.getModelFilePath(filename);
       final file = File(filePath);
 
-      debugPrint('ResumeChecker: Checking file path: $filePath');
+      gemmaLog('ResumeChecker: Checking file path: $filePath');
 
       // List directory contents for debugging
       try {
         final directory = file.parent;
         final directoryExists = await directory.exists();
-        debugPrint(
+        gemmaLog(
             'ResumeChecker: Directory exists: $directoryExists - ${directory.path}');
 
         if (directoryExists) {
           final files = await directory.list().toList();
-          debugPrint(
+          gemmaLog(
               'ResumeChecker: Directory contents (${files.length} items):');
           for (final item in files) {
             final name = item.path.split('/').last;
             final isFile = item is File;
             final size = isFile ? await item.length() : 0;
-            debugPrint('  - $name ${isFile ? "($size bytes)" : "(directory)"}');
+            gemmaLog('  - $name ${isFile ? "($size bytes)" : "(directory)"}');
           }
         }
       } catch (e) {
-        debugPrint('ResumeChecker: Failed to list directory: $e');
+        gemmaLog('ResumeChecker: Failed to list directory: $e');
       }
 
       final fileExists = await file.exists();
-      debugPrint('ResumeChecker: File exists: $fileExists for $filename');
+      gemmaLog('ResumeChecker: File exists: $fileExists for $filename');
 
       if (!fileExists) {
-        debugPrint(
-            'ResumeChecker: File not found: $filename at path: $filePath');
+        gemmaLog('ResumeChecker: File not found: $filename at path: $filePath');
         return ResumeStatus.fileNotFound;
       }
 
@@ -80,11 +79,11 @@ class ResumeChecker {
       final fileSize = await file.length();
       final isValid = await ModelFileSystemManager.isFileValid(filePath);
 
-      debugPrint(
+      gemmaLog(
           'ResumeChecker: File size: $fileSize, isValid: $isValid for $filename');
 
       if (isValid && fileSize > 0) {
-        debugPrint('ResumeChecker: File is already complete: $filename');
+        gemmaLog('ResumeChecker: File is already complete: $filename');
         return ResumeStatus.fileComplete;
       }
 
@@ -111,25 +110,24 @@ class ResumeChecker {
       }
 
       if (task == null) {
-        debugPrint(
+        gemmaLog(
             'ResumeChecker: No tracked task for $filename - returning noTask status');
         return ResumeStatus.noTask;
       }
 
-      debugPrint('ResumeChecker: Found task for $filename: ${task.taskId}');
+      gemmaLog('ResumeChecker: Found task for $filename: ${task.taskId}');
 
       // 4. Check if background_downloader thinks this task can be resumed
       final canResume = await _downloader.taskCanResume(task);
       if (canResume) {
-        debugPrint('ResumeChecker: File can be resumed: $filename');
+        gemmaLog('ResumeChecker: File can be resumed: $filename');
         return ResumeStatus.canResume;
       } else {
-        debugPrint('ResumeChecker: File cannot be resumed: $filename');
+        gemmaLog('ResumeChecker: File cannot be resumed: $filename');
         return ResumeStatus.cannotResume;
       }
     } catch (e) {
-      debugPrint(
-          'ResumeChecker: Error checking resume status for $filename: $e');
+      gemmaLog('ResumeChecker: Error checking resume status for $filename: $e');
       return ResumeStatus.error;
     }
   }
@@ -140,7 +138,7 @@ class ResumeChecker {
   /// Returns map of filename -> ResumeStatus for each file
   static Future<Map<String, ResumeStatus>> checkModelResume(
       ModelSpec spec) async {
-    debugPrint('ResumeChecker: Checking resume status for model: ${spec.name}');
+    gemmaLog('ResumeChecker: Checking resume status for model: ${spec.name}');
 
     final results = <String, ResumeStatus>{};
 
@@ -150,7 +148,7 @@ class ResumeChecker {
     }
 
     final summary = _summarizeResumeResults(results);
-    debugPrint('ResumeChecker: Model ${spec.name} resume summary: $summary');
+    gemmaLog('ResumeChecker: Model ${spec.name} resume summary: $summary');
 
     return results;
   }
@@ -204,7 +202,7 @@ class ResumeChecker {
   /// [spec] - The model specification to clean
   /// Returns the number of cleaned up files
   static Future<int> cleanupInvalidResumeStates(ModelSpec spec) async {
-    debugPrint(
+    gemmaLog(
         'ResumeChecker: Cleaning up invalid resume states for ${spec.name}');
 
     final statuses = await checkModelResume(spec);
@@ -221,10 +219,10 @@ class ResumeChecker {
           try {
             await ModelFileSystemManager.deleteModelFile(filename);
             cleanedCount++;
-            debugPrint(
+            gemmaLog(
                 'ResumeChecker: Cleaned up invalid resume state for $filename');
           } catch (e) {
-            debugPrint('ResumeChecker: Failed to cleanup $filename: $e');
+            gemmaLog('ResumeChecker: Failed to cleanup $filename: $e');
           }
           break;
 
@@ -239,11 +237,11 @@ class ResumeChecker {
               // Partial file without task - delete it
               await ModelFileSystemManager.deleteModelFile(filename);
               cleanedCount++;
-              debugPrint(
+              gemmaLog(
                   'ResumeChecker: Removed orphaned partial file: $filename');
             }
           } catch (e) {
-            debugPrint(
+            gemmaLog(
                 'ResumeChecker: Error checking orphaned file $filename: $e');
           }
           break;
@@ -254,7 +252,7 @@ class ResumeChecker {
       }
     }
 
-    debugPrint(
+    gemmaLog(
         'ResumeChecker: Cleaned up $cleanedCount files for model ${spec.name}');
     return cleanedCount;
   }

--- a/lib/core/multimodal_image_handler.dart
+++ b/lib/core/multimodal_image_handler.dart
@@ -5,6 +5,7 @@ import 'vision_encoder_validator.dart';
 import 'image_error_handler.dart';
 import 'message.dart';
 import 'model.dart';
+import 'utils/gemma_log.dart';
 
 /// Main integration class for handling multimodal image processing in Flutter Gemma
 /// to prevent AI image corruption and repeating text pattern issues.
@@ -18,7 +19,7 @@ class MultimodalImageHandler {
     bool enableProcessing = true,
   }) async {
     try {
-      debugPrint(
+      gemmaLog(
           'MultimodalImageHandler: Starting image processing for $modelType...');
 
       // Step 1: Validate image for vision encoder compatibility
@@ -55,7 +56,7 @@ class MultimodalImageHandler {
         }
       }
 
-      debugPrint(
+      gemmaLog(
           'MultimodalImageHandler: Image processing completed successfully');
 
       return MultimodalImageResult(
@@ -65,7 +66,7 @@ class MultimodalImageHandler {
         validationPassed: enableValidation,
       );
     } catch (e) {
-      debugPrint('MultimodalImageHandler: Image processing failed - $e');
+      gemmaLog('MultimodalImageHandler: Image processing failed - $e');
 
       // Handle the error and provide recovery suggestions
       final errorResult = ImageErrorHandler.handleImageProcessingError(
@@ -96,7 +97,7 @@ class MultimodalImageHandler {
       originalFormat: originalFormat,
     );
 
-    debugPrint(
+    gemmaLog(
         'MultimodalImageHandler: Image processed - ${processedImage.width}x${processedImage.height}, '
         'Format: ${processedImage.format}, Base64 Length: ${processedImage.base64Length}');
 
@@ -111,7 +112,7 @@ class MultimodalImageHandler {
     bool isUser = true,
   }) {
     try {
-      debugPrint(
+      gemmaLog(
           'MultimodalImageHandler: Creating multimodal message for $modelType...');
 
       // Validate inputs
@@ -130,7 +131,7 @@ class MultimodalImageHandler {
         isUser: isUser,
       );
     } catch (e) {
-      debugPrint(
+      gemmaLog(
           'MultimodalImageHandler: Failed to create multimodal message - $e');
 
       // Try to create a fallback text-only message
@@ -147,7 +148,7 @@ class MultimodalImageHandler {
     required ModelType modelType,
   }) {
     try {
-      debugPrint(
+      gemmaLog(
           'MultimodalImageHandler: Creating tokenized prompt for $modelType...');
 
       // Use ImageTokenizer to create properly formatted prompt
@@ -161,16 +162,16 @@ class MultimodalImageHandler {
       final hasValidTokens =
           tokenizer.ImageTokenizer.validateImageTokens(prompt, 1);
       if (!hasValidTokens) {
-        debugPrint(
+        gemmaLog(
             'MultimodalImageHandler: Warning - Prompt may have tokenization issues');
       }
 
-      debugPrint(
+      gemmaLog(
           'MultimodalImageHandler: Tokenized prompt created (${prompt.length} chars)');
 
       return prompt;
     } catch (e) {
-      debugPrint('MultimodalImageHandler: Tokenization failed - $e');
+      gemmaLog('MultimodalImageHandler: Tokenization failed - $e');
 
       // Handle tokenization error
       final errorResult = ImageErrorHandler.handleTokenizationError(
@@ -194,19 +195,19 @@ class MultimodalImageHandler {
     required ProcessedImage? processedImage,
   }) {
     try {
-      debugPrint('MultimodalImageHandler: Validating model response...');
+      gemmaLog('MultimodalImageHandler: Validating model response...');
 
       // Detect corruption patterns
       final corruptionResult =
           ImageErrorHandler.detectResponseCorruption(response);
 
       if (corruptionResult.isCorrupted) {
-        debugPrint(
+        gemmaLog(
             'MultimodalImageHandler: Corruption detected with ${corruptionResult.confidence.toStringAsFixed(2)} confidence');
 
         // Log detailed analysis
-        debugPrint('Corruption Analysis: ${corruptionResult.analysis}');
-        debugPrint('Suggested Action: ${corruptionResult.suggestedAction}');
+        gemmaLog('Corruption Analysis: ${corruptionResult.analysis}');
+        gemmaLog('Suggested Action: ${corruptionResult.suggestedAction}');
 
         return ResponseValidationResult(
           isValid: false,
@@ -219,7 +220,7 @@ class MultimodalImageHandler {
         );
       }
 
-      debugPrint('MultimodalImageHandler: Response validation passed');
+      gemmaLog('MultimodalImageHandler: Response validation passed');
 
       // Return success result when no corruption detected
       return ResponseValidationResult(
@@ -232,7 +233,7 @@ class MultimodalImageHandler {
         originalResponse: response,
       );
     } catch (e) {
-      debugPrint('MultimodalImageHandler: Response validation failed - $e');
+      gemmaLog('MultimodalImageHandler: Response validation failed - $e');
 
       return ResponseValidationResult(
         isValid: false,
@@ -320,7 +321,7 @@ class MultimodalImageHandler {
 
       return null;
     } catch (e) {
-      debugPrint('Error extracting Base64 from prompt: $e');
+      gemmaLog('Error extracting Base64 from prompt: $e');
       return null;
     }
   }
@@ -334,7 +335,7 @@ class MultimodalImageHandler {
     String? response,
   }) {
     try {
-      debugPrint('MultimodalImageHandler: Creating diagnostic report...');
+      gemmaLog('MultimodalImageHandler: Creating diagnostic report...');
 
       final format = ImageProcessor.detectFormat(imageBytes);
       final sizeInKB = imageBytes.length / 1024;
@@ -359,10 +360,10 @@ class MultimodalImageHandler {
         hasResponse: response != null,
       );
 
-      debugPrint('MultimodalImageHandler: Diagnostic report created');
+      gemmaLog('MultimodalImageHandler: Diagnostic report created');
       return report;
     } catch (e) {
-      debugPrint('MultimodalImageHandler: Diagnostic report failed - $e');
+      gemmaLog('MultimodalImageHandler: Diagnostic report failed - $e');
       rethrow;
     }
   }

--- a/lib/core/multimodal_image_handler.dart
+++ b/lib/core/multimodal_image_handler.dart
@@ -134,10 +134,10 @@ class MultimodalImageHandler {
       gemmaLog(
           'MultimodalImageHandler: Failed to create multimodal message - $e');
 
-      // Try to create a fallback text-only message
-      final fallbackText =
-          '$text\n[Note: Image could not be processed properly]';
-      return Message.text(text: fallbackText, isUser: isUser);
+      // Do NOT silently drop the image into a text-only message — that makes
+      // the model answer as if no image was sent. Surface the failure so the
+      // caller can react (no-silent-fallbacks).
+      rethrow;
     }
   }
 
@@ -173,7 +173,9 @@ class MultimodalImageHandler {
     } catch (e) {
       gemmaLog('MultimodalImageHandler: Tokenization failed - $e');
 
-      // Handle tokenization error
+      // Run the error handler for its diagnostics, then throw — returning a
+      // text-only fallback prompt silently drops the image and makes the model
+      // answer as if none was sent (no-silent-fallbacks).
       final errorResult = ImageErrorHandler.handleTokenizationError(
         e,
         StackTrace.current,
@@ -182,9 +184,7 @@ class MultimodalImageHandler {
         expectedImageCount: 1,
       );
 
-      // Return fallback prompt
-      return tokenizer.ImageTokenizer.createFallbackPrompt(text,
-          errorMessage: errorResult.message);
+      throw Exception('Image tokenization failed: ${errorResult.message}');
     }
   }
 

--- a/lib/core/parsing/deepseek_function_call_format.dart
+++ b/lib/core/parsing/deepseek_function_call_format.dart
@@ -104,7 +104,8 @@ class DeepSeekFunctionCallFormat extends FunctionCallFormat {
       try {
         final args = jsonDecode(argsStr);
         if (args is Map<String, dynamic>) {
-          gemmaLog('DeepSeekFormat: Parsed function: $functionName($args)');
+          gemmaLog('DeepSeekFormat: Parsed function: $functionName($args)',
+              level: GemmaLogLevel.verbose);
           results.add(FunctionCallResponse(name: functionName, args: args));
         }
       } catch (e) {

--- a/lib/core/parsing/deepseek_function_call_format.dart
+++ b/lib/core/parsing/deepseek_function_call_format.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 
 import 'function_call_format.dart';
 import 'json_function_call_format.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 // DeepSeek special tokens (full-width Unicode characters)
 const _toolCallsBegin = '<｜tool▁calls▁begin｜>';
@@ -104,12 +104,11 @@ class DeepSeekFunctionCallFormat extends FunctionCallFormat {
       try {
         final args = jsonDecode(argsStr);
         if (args is Map<String, dynamic>) {
-          debugPrint('DeepSeekFormat: Parsed function: $functionName($args)');
+          gemmaLog('DeepSeekFormat: Parsed function: $functionName($args)');
           results.add(FunctionCallResponse(name: functionName, args: args));
         }
       } catch (e) {
-        debugPrint(
-            'DeepSeekFormat: Failed to parse args for $functionName: $e');
+        gemmaLog('DeepSeekFormat: Failed to parse args for $functionName: $e');
       }
     }
 

--- a/lib/core/parsing/json_function_call_format.dart
+++ b/lib/core/parsing/json_function_call_format.dart
@@ -103,7 +103,8 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      gemmaLog('JsonFormat: Found tool_code XML block: $jsonStr');
+      gemmaLog('JsonFormat: Found tool_code XML block: $jsonStr',
+          level: GemmaLogLevel.verbose);
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
     return null;
@@ -116,7 +117,8 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      gemmaLog('JsonFormat: Found tool_code markdown block: $jsonStr');
+      gemmaLog('JsonFormat: Found tool_code markdown block: $jsonStr',
+          level: GemmaLogLevel.verbose);
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
     return null;
@@ -129,7 +131,8 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      gemmaLog('JsonFormat: Found markdown json block: $jsonStr');
+      gemmaLog('JsonFormat: Found markdown json block: $jsonStr',
+          level: GemmaLogLevel.verbose);
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
 
@@ -139,7 +142,8 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
       if (jsonStr.startsWith('{') && jsonStr.contains('"name"')) {
-        gemmaLog('JsonFormat: Found markdown code block: $jsonStr');
+        gemmaLog('JsonFormat: Found markdown code block: $jsonStr',
+            level: GemmaLogLevel.verbose);
         return JsonParsingUtils.parseJsonString(jsonStr);
       }
     }
@@ -150,7 +154,8 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
   FunctionCallResponse? _parseDirectJson(String content) {
     final trimmed = content.trim();
     if (trimmed.startsWith('{') && trimmed.contains('"name"')) {
-      gemmaLog('JsonFormat: Found direct JSON: $trimmed');
+      gemmaLog('JsonFormat: Found direct JSON: $trimmed',
+          level: GemmaLogLevel.verbose);
       return JsonParsingUtils.parseJsonString(trimmed);
     }
     return null;

--- a/lib/core/parsing/json_function_call_format.dart
+++ b/lib/core/parsing/json_function_call_format.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 
 import 'function_call_format.dart';
 import 'json_parsing_utils.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// JSON-based function call format (default).
 ///
@@ -103,7 +103,7 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      debugPrint('JsonFormat: Found tool_code XML block: $jsonStr');
+      gemmaLog('JsonFormat: Found tool_code XML block: $jsonStr');
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
     return null;
@@ -116,7 +116,7 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      debugPrint('JsonFormat: Found tool_code markdown block: $jsonStr');
+      gemmaLog('JsonFormat: Found tool_code markdown block: $jsonStr');
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
     return null;
@@ -129,7 +129,7 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      debugPrint('JsonFormat: Found markdown json block: $jsonStr');
+      gemmaLog('JsonFormat: Found markdown json block: $jsonStr');
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
 
@@ -139,7 +139,7 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
       if (jsonStr.startsWith('{') && jsonStr.contains('"name"')) {
-        debugPrint('JsonFormat: Found markdown code block: $jsonStr');
+        gemmaLog('JsonFormat: Found markdown code block: $jsonStr');
         return JsonParsingUtils.parseJsonString(jsonStr);
       }
     }
@@ -150,7 +150,7 @@ class JsonFunctionCallFormat extends FunctionCallFormat {
   FunctionCallResponse? _parseDirectJson(String content) {
     final trimmed = content.trim();
     if (trimmed.startsWith('{') && trimmed.contains('"name"')) {
-      debugPrint('JsonFormat: Found direct JSON: $trimmed');
+      gemmaLog('JsonFormat: Found direct JSON: $trimmed');
       return JsonParsingUtils.parseJsonString(trimmed);
     }
     return null;

--- a/lib/core/parsing/json_parsing_utils.dart
+++ b/lib/core/parsing/json_parsing_utils.dart
@@ -34,7 +34,8 @@ class JsonParsingUtils {
 
         // Use empty map for zero-argument functions (get_time, refresh, etc.)
         final resolvedArgs = args ?? <String, dynamic>{};
-        gemmaLog('JsonParsingUtils: Parsed function: $name($resolvedArgs)');
+        gemmaLog('JsonParsingUtils: Parsed function: $name($resolvedArgs)',
+            level: GemmaLogLevel.verbose);
         return FunctionCallResponse(name: name, args: resolvedArgs);
       }
 

--- a/lib/core/parsing/json_parsing_utils.dart
+++ b/lib/core/parsing/json_parsing_utils.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model_response.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Shared JSON parsing utilities used by multiple format implementations.
 class JsonParsingUtils {
@@ -23,7 +23,7 @@ class JsonParsingUtils {
       if (decoded is Map<String, dynamic>) {
         final name = decoded['name'] as String?;
         if (name == null) {
-          debugPrint('JsonParsingUtils: JSON missing "name" field');
+          gemmaLog('JsonParsingUtils: JSON missing "name" field');
           return null;
         }
 
@@ -34,14 +34,14 @@ class JsonParsingUtils {
 
         // Use empty map for zero-argument functions (get_time, refresh, etc.)
         final resolvedArgs = args ?? <String, dynamic>{};
-        debugPrint('JsonParsingUtils: Parsed function: $name($resolvedArgs)');
+        gemmaLog('JsonParsingUtils: Parsed function: $name($resolvedArgs)');
         return FunctionCallResponse(name: name, args: resolvedArgs);
       }
 
-      debugPrint('JsonParsingUtils: JSON missing "name" field or not a Map');
+      gemmaLog('JsonParsingUtils: JSON missing "name" field or not a Map');
       return null;
     } catch (e) {
-      debugPrint('JsonParsingUtils: Failed to decode JSON: $e');
+      gemmaLog('JsonParsingUtils: Failed to decode JSON: $e');
       return null;
     }
   }
@@ -62,7 +62,7 @@ class JsonParsingUtils {
         return results;
       }
     } catch (e) {
-      debugPrint('JsonParsingUtils: Failed to decode JSON array: $e');
+      gemmaLog('JsonParsingUtils: Failed to decode JSON array: $e');
     }
     return [];
   }

--- a/lib/core/parsing/llama_function_call_format.dart
+++ b/lib/core/parsing/llama_function_call_format.dart
@@ -101,7 +101,8 @@ class LlamaFunctionCallFormat extends FunctionCallFormat {
       final argsStr = match.group(2)!;
 
       final args = _parsePythonArgs(argsStr);
-      gemmaLog('LlamaFormat: Parsed function: $name($args)');
+      gemmaLog('LlamaFormat: Parsed function: $name($args)',
+          level: GemmaLogLevel.verbose);
       results.add(FunctionCallResponse(name: name, args: args));
     }
 

--- a/lib/core/parsing/llama_function_call_format.dart
+++ b/lib/core/parsing/llama_function_call_format.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 
 import 'function_call_format.dart';
 import 'json_function_call_format.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Llama 3.2 tool call format.
 ///
@@ -101,7 +101,7 @@ class LlamaFunctionCallFormat extends FunctionCallFormat {
       final argsStr = match.group(2)!;
 
       final args = _parsePythonArgs(argsStr);
-      debugPrint('LlamaFormat: Parsed function: $name($args)');
+      gemmaLog('LlamaFormat: Parsed function: $name($args)');
       results.add(FunctionCallResponse(name: name, args: args));
     }
 

--- a/lib/core/parsing/phi_function_call_format.dart
+++ b/lib/core/parsing/phi_function_call_format.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 
 import 'function_call_format.dart';
 import 'json_function_call_format.dart';
 import 'json_parsing_utils.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Phi-4 tool call format.
 ///
@@ -86,7 +86,7 @@ class PhiFunctionCallFormat extends FunctionCallFormat {
     if (match == null) return [];
 
     final jsonStr = match.group(1)!.trim();
-    debugPrint('PhiFormat: Found tool_calls block: $jsonStr');
+    gemmaLog('PhiFormat: Found tool_calls block: $jsonStr');
 
     // Phi-4 always outputs a JSON array
     final results = JsonParsingUtils.parseJsonArray(jsonStr);

--- a/lib/core/parsing/phi_function_call_format.dart
+++ b/lib/core/parsing/phi_function_call_format.dart
@@ -86,7 +86,8 @@ class PhiFunctionCallFormat extends FunctionCallFormat {
     if (match == null) return [];
 
     final jsonStr = match.group(1)!.trim();
-    gemmaLog('PhiFormat: Found tool_calls block: $jsonStr');
+    gemmaLog('PhiFormat: Found tool_calls block: $jsonStr',
+        level: GemmaLogLevel.verbose);
 
     // Phi-4 always outputs a JSON array
     final results = JsonParsingUtils.parseJsonArray(jsonStr);

--- a/lib/core/parsing/qwen_function_call_format.dart
+++ b/lib/core/parsing/qwen_function_call_format.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/core/model_response.dart';
 
 import 'function_call_format.dart';
 import 'json_function_call_format.dart';
 import 'json_parsing_utils.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Qwen/Mistral tool call format.
 ///
@@ -79,7 +79,7 @@ class QwenFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      debugPrint('QwenFormat: Found tool_call block: $jsonStr');
+      gemmaLog('QwenFormat: Found tool_call block: $jsonStr');
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
     return null;

--- a/lib/core/parsing/qwen_function_call_format.dart
+++ b/lib/core/parsing/qwen_function_call_format.dart
@@ -79,7 +79,8 @@ class QwenFunctionCallFormat extends FunctionCallFormat {
 
     if (match != null) {
       final jsonStr = match.group(1)!.trim();
-      gemmaLog('QwenFormat: Found tool_call block: $jsonStr');
+      gemmaLog('QwenFormat: Found tool_call block: $jsonStr',
+          level: GemmaLogLevel.verbose);
       return JsonParsingUtils.parseJsonString(jsonStr);
     }
     return null;

--- a/lib/core/parsing/sdk_response_parser.dart
+++ b/lib/core/parsing/sdk_response_parser.dart
@@ -88,7 +88,8 @@ class SdkResponseParser {
     void addFromCallObject(Object? raw) {
       if (raw is! Map<String, dynamic>) return;
       Map<String, dynamic>? fn;
-      if (raw['type'] == 'function' && raw['function'] is Map<String, dynamic>) {
+      if (raw['type'] == 'function' &&
+          raw['function'] is Map<String, dynamic>) {
         fn = raw['function'] as Map<String, dynamic>;
       } else if (raw['name'] is String) {
         fn = raw;
@@ -129,8 +130,7 @@ class SdkResponseParser {
   static dynamic _stripEscapeTokens(dynamic value) {
     if (value is String) return value.replaceAll('<|"|>', '');
     if (value is Map) {
-      return value
-          .map((k, v) => MapEntry(k as String, _stripEscapeTokens(v)));
+      return value.map((k, v) => MapEntry(k as String, _stripEscapeTokens(v)));
     }
     if (value is List) return value.map(_stripEscapeTokens).toList();
     return value;

--- a/lib/core/utils/gemma_log.dart
+++ b/lib/core/utils/gemma_log.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+
+/// Verbosity for flutter_gemma's internal logs.
+///
+/// - [none] — silence the plugin entirely.
+/// - [info] — lifecycle, errors, non-PII diagnostics (default in debug).
+/// - [verbose] — adds model output / prompts / conversation history.
+enum GemmaLogLevel { none, info, verbose }
+
+/// Active log level. Top-level (Dart-canonical for process-global logger
+/// state) so [gemmaLog] reads it without importing the public facade.
+///
+/// NOTE: top-level mutables are per-isolate in Dart — a spawned isolate gets
+/// its own copy initialized to [GemmaLogLevel.info]. Isolate entry points must
+/// set this from data passed at spawn (see the embedding worker).
+GemmaLogLevel gemmaLogLevel = GemmaLogLevel.info;
+
+/// Internal log entry point. Every plugin log routes through here.
+///
+/// - Release builds: silent regardless of level. `kDebugMode` is a compile-time
+///   `false`, so the body is dead-code-eliminated. (Callers that interpolate a
+///   large/hot variable must still guard the CALL SITE with `if (kDebugMode)`
+///   to avoid building the string in release.)
+/// - Debug builds: prints when [level] <= [gemmaLogLevel], after sanitizing
+///   U+FFFD so it can't crash `flutter run` (issue #306).
+void gemmaLog(String message, {GemmaLogLevel level = GemmaLogLevel.info}) {
+  if (!kDebugMode) return;
+  if (gemmaLogLevel == GemmaLogLevel.none) return;
+  if (level.index > gemmaLogLevel.index) return;
+  debugPrint(sanitizeForLog(message));
+}
+
+/// Rewrites U+FFFD (the replacement character) and unpaired UTF-16 surrogates
+/// to the literal text `U+FFFD`.
+///
+/// Both encode to the bytes `0xEF 0xBF 0xBD` on stdout, which `flutter run`'s
+/// reader treats as malformed output and aborts on (issue #306). A lone
+/// surrogate appears when a `substring`/chunk boundary splits an emoji or other
+/// astral character mid-pair.
+String sanitizeForLog(String text) {
+  var needsWork = false;
+  for (var i = 0; i < text.length; i++) {
+    final u = text.codeUnitAt(i);
+    if (u == 0xFFFD || (u >= 0xD800 && u <= 0xDFFF)) {
+      needsWork = true;
+      break;
+    }
+  }
+  if (!needsWork) return text;
+
+  final out = StringBuffer();
+  for (var i = 0; i < text.length; i++) {
+    final u = text.codeUnitAt(i);
+    if (u == 0xFFFD) {
+      out.write('U+FFFD');
+    } else if (u >= 0xD800 && u <= 0xDBFF) {
+      final hasLow = i + 1 < text.length &&
+          text.codeUnitAt(i + 1) >= 0xDC00 &&
+          text.codeUnitAt(i + 1) <= 0xDFFF;
+      if (hasLow) {
+        out.writeCharCode(u);
+        out.writeCharCode(text.codeUnitAt(i + 1));
+        i++;
+      } else {
+        out.write('U+FFFD');
+      }
+    } else if (u >= 0xDC00 && u <= 0xDFFF) {
+      out.write('U+FFFD');
+    } else {
+      out.writeCharCode(u);
+    }
+  }
+  return out.toString();
+}

--- a/lib/core/vision_encoder_validator.dart
+++ b/lib/core/vision_encoder_validator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'image_processor.dart';
+import 'utils/gemma_log.dart';
 
 /// Validates images for compatibility with AI vision encoders to prevent
 /// corruption that causes models to interpret images as repeating text patterns.
@@ -17,8 +18,7 @@ class VisionEncoderValidator {
     String? originalFormat,
   }) {
     try {
-      debugPrint(
-          'VisionEncoderValidator: Validating image for $encoderType...');
+      gemmaLog('VisionEncoderValidator: Validating image for $encoderType...');
 
       // Get appropriate specifications
       final specs = _getSpecsForEncoder(encoderType);
@@ -46,7 +46,7 @@ class VisionEncoderValidator {
         return compatibilityValidation;
       }
 
-      debugPrint(
+      gemmaLog(
           'VisionEncoderValidator: Image validation passed for $encoderType');
 
       return ValidationResult(
@@ -56,7 +56,7 @@ class VisionEncoderValidator {
         suggestions: [],
       );
     } catch (e) {
-      debugPrint('VisionEncoderValidator: Validation failed - $e');
+      gemmaLog('VisionEncoderValidator: Validation failed - $e');
       return ValidationResult(
         isValid: false,
         encoderType: encoderType,

--- a/lib/desktop/flutter_gemma_desktop.dart
+++ b/lib/desktop/flutter_gemma_desktop.dart
@@ -21,6 +21,7 @@ import '../mobile/flutter_gemma_mobile.dart'
     show InferenceModelSpec, MobileModelManager;
 
 import '../core/model_management/constants/preferences_keys.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 part 'desktop_inference_model.dart';
 
@@ -43,7 +44,7 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
   /// No parameters needed for desktop platforms.
   static void registerWith() {
     FlutterGemmaPlugin.instance = instance;
-    debugPrint('[FlutterGemmaDesktop] Plugin registered for desktop platform');
+    gemmaLog('[FlutterGemmaDesktop] Plugin registered for desktop platform');
   }
 
   // Reuse MobileModelManager for desktop (same filesystem behavior)
@@ -104,14 +105,14 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
               currentModel.maxTokens != maxTokens);
 
       if (modelChanged || paramsChanged) {
-        debugPrint(
+        gemmaLog(
             'Model recreation: modelChanged=$modelChanged, paramsChanged=$paramsChanged');
         await _initializedModel?.close();
         _initCompleter = null;
         _initializedModel = null;
         _lastActiveInferenceSpec = null;
       } else {
-        debugPrint('Reusing existing model instance for ${requestedSpec.name}');
+        gemmaLog('Reusing existing model instance for ${requestedSpec.name}');
         return _initCompleter!.future;
       }
     }
@@ -137,7 +138,7 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
       }
 
       final modelPath = modelFilePaths.values.first;
-      debugPrint('[FlutterGemmaDesktop] Using model: $modelPath');
+      gemmaLog('[FlutterGemmaDesktop] Using model: $modelPath');
 
       // Get cache dir for faster reloads
       final cacheDir = (await getApplicationSupportDirectory()).path;
@@ -241,7 +242,7 @@ class FlutterGemmaDesktop extends FlutterGemmaPlugin {
         throw StateError('Embedding model path is required');
       }
 
-      debugPrint('[FlutterGemmaDesktop] Loading embedding model: $modelPath');
+      gemmaLog('[FlutterGemmaDesktop] Loading embedding model: $modelPath');
 
       if (tokenizerPath == null) {
         throw StateError('Tokenizer path is required for desktop embeddings');

--- a/lib/flutter_gemma.dart
+++ b/lib/flutter_gemma.dart
@@ -11,6 +11,7 @@ export 'core/model.dart'; // Export ModelType and other model-related classes
 export 'core/model_response.dart';
 export 'core/function_call_parser.dart';
 export 'core/tool.dart';
+export 'core/utils/gemma_log.dart' show GemmaLogLevel;
 export 'core/chat.dart';
 export 'core/model_management/cancel_token.dart';
 export 'core/ffi/backend_preference.dart'

--- a/lib/mobile/flutter_gemma_mobile.dart
+++ b/lib/mobile/flutter_gemma_mobile.dart
@@ -28,6 +28,7 @@ import '../core/domain/model_source.dart';
 import '../core/services/model_repository.dart' as repo;
 import '../core/model_management/constants/preferences_keys.dart';
 import '../core/utils/file_name_utils.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 part 'flutter_gemma_mobile_inference_model.dart';
 
@@ -102,11 +103,11 @@ class MobileInferenceModelSession extends InferenceModelSession {
         text: '[System: ${systemInstruction!}]\n\n${message.text}',
       );
     }
-    debugPrint(
+    gemmaLog(
         '[MobileSession.addQueryChunk] modelType=$modelType, fileType=$fileType, msgType=${message.type}');
     final finalPrompt = messageToSend.transformToChatPrompt(
         type: modelType, fileType: fileType);
-    debugPrint(
+    gemmaLog(
         '[MobileSession.addQueryChunk] finalPrompt length=${finalPrompt.length}');
     if (message.hasImage && supportImage) {
       final images = message.images.isNotEmpty
@@ -260,13 +261,13 @@ class MobileInferenceModelSession extends InferenceModelSession {
       // Ignore "not supported" errors, but rethrow others
       if (e.code != 'stop_not_supported') {
         if (kDebugMode) {
-          debugPrint('Warning: Failed to stop generation: ${e.message}');
+          gemmaLog('Warning: Failed to stop generation: ${e.message}');
         }
       }
     } catch (e) {
       // Ignore other errors during cleanup
       if (kDebugMode) {
-        debugPrint('Warning: Unexpected error during stop generation: $e');
+        gemmaLog('Warning: Unexpected error during stop generation: $e');
       }
     }
 
@@ -526,15 +527,15 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
 
       if (currentSpec.name != requestedSpec.name) {
         // Active model changed - close old model and create new one
-        debugPrint(
+        gemmaLog(
             '⚠️  Active model changed: ${currentSpec.name} → ${requestedSpec.name}');
-        debugPrint('🔄 Closing old model and creating new one...');
+        gemmaLog('🔄 Closing old model and creating new one...');
         await _initializedModel?.close();
         // onClose callback will reset _initializedModel and _initCompleter
         _lastActiveInferenceSpec = null;
       } else {
         // Same model - return existing singleton
-        debugPrint(
+        gemmaLog(
             'ℹ️  Reusing existing model instance for ${requestedSpec.name}');
         return _initCompleter!.future;
       }
@@ -577,7 +578,7 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
       return completer.future;
     }
 
-    debugPrint('Using unified model file: $modelPath');
+    gemmaLog('Using unified model file: $modelPath');
 
     try {
       final InferenceModel model;
@@ -586,11 +587,11 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
       // .task/.bin files → use MediaPipe via Pigeon (existing path)
       if (fileType == ModelFileType.litertlm &&
           (Platform.isIOS || Platform.isAndroid)) {
-        debugPrint(
+        gemmaLog(
             '[FlutterGemmaMobile] Using FFI path for .litertlm on ${Platform.operatingSystem}');
         final ffiPathSw = Stopwatch()..start();
         final cacheDir = (await getApplicationSupportDirectory()).path;
-        debugPrint(
+        gemmaLog(
             '[FlutterGemmaMobile/perf] getApplicationSupportDirectory: ${ffiPathSw.elapsedMilliseconds}ms');
         // NPU on Android `.litertlm` restored to 0.13.x parity. The Kotlin
         // LiteRtLmEngine path was dropped in 0.14.0 (commit 81025da); this
@@ -611,9 +612,9 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
           enableAudio: supportAudio,
           enableSpeculativeDecoding: enableSpeculativeDecoding,
         );
-        debugPrint(
+        gemmaLog(
             '[FlutterGemmaMobile/perf] ffiClient.initialize total: ${ffiPathSw.elapsedMilliseconds - beforeInit}ms');
-        debugPrint(
+        gemmaLog(
             '[FlutterGemmaMobile/perf] FFI model creation total: ${ffiPathSw.elapsedMilliseconds}ms');
 
         model = _initializedModel = FfiInferenceModel(
@@ -720,15 +721,15 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
 
         if (currentSpec.name != requestedSpec.name) {
           // Active model changed - close old model and create new one
-          debugPrint(
+          gemmaLog(
               '⚠️  Active embedding model changed: ${currentSpec.name} → ${requestedSpec.name}');
-          debugPrint('🔄 Closing old embedding model and creating new one...');
+          gemmaLog('🔄 Closing old embedding model and creating new one...');
           await _initializedEmbeddingModel?.close();
           // onClose callback will reset _initializedEmbeddingModel and _initEmbeddingCompleter
           _lastActiveEmbeddingSpec = null;
         } else {
           // Same model - return existing singleton
-          debugPrint(
+          gemmaLog(
               'ℹ️  Reusing existing embedding model instance for ${requestedSpec.name}');
           return _initEmbeddingCompleter!.future;
         }
@@ -737,13 +738,12 @@ class FlutterGemmaMobile extends FlutterGemmaPlugin {
       modelPath = activeModelPath;
       tokenizerPath = activeTokenizerPath;
 
-      debugPrint(
+      gemmaLog(
           'Using active embedding model: $modelPath, tokenizer: $tokenizerPath');
     } else {
       // Legacy API with explicit paths - check if singleton exists
       if (_initEmbeddingCompleter case Completer<EmbeddingModel> completer) {
-        debugPrint(
-            'ℹ️  Reusing existing embedding model instance (Legacy API)');
+        gemmaLog('ℹ️  Reusing existing embedding model instance (Legacy API)');
         return completer.future;
       }
     }

--- a/lib/mobile/smart_downloader.dart
+++ b/lib/mobile/smart_downloader.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter_gemma/core/domain/download_error.dart';
 import 'package:flutter_gemma/core/domain/download_exception.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 /// Smart downloader with HTTP-aware retry logic
 ///
@@ -42,13 +42,13 @@ class SmartDownloader {
       await downloader.configure(
         androidConfig: [(Config.runInForeground, Config.always)],
       );
-      debugPrint('📲 SmartDownloader: Configured for ALWAYS foreground');
+      gemmaLog('📲 SmartDownloader: Configured for ALWAYS foreground');
     } else if (foreground == false) {
       // Never foreground
       await downloader.configure(
         androidConfig: [(Config.runInForeground, Config.never)],
       );
-      debugPrint('📲 SmartDownloader: Configured for NEVER foreground');
+      gemmaLog('📲 SmartDownloader: Configured for NEVER foreground');
     } else {
       // Auto-detect based on file size (default)
       await downloader.configure(
@@ -56,7 +56,7 @@ class SmartDownloader {
           (Config.runInForegroundIfFileLargerThan, _foregroundThresholdMB),
         ],
       );
-      debugPrint(
+      gemmaLog(
           '📲 SmartDownloader: Configured for AUTO foreground (>${_foregroundThresholdMB}MB)');
     }
 
@@ -157,16 +157,16 @@ class SmartDownloader {
     if (cancelToken != null) {
       cancellationListener =
           cancelToken.whenCancelled.asStream().listen((_) async {
-        debugPrint('🚫 Cancellation requested');
+        gemmaLog('🚫 Cancellation requested');
 
         // Cancel the actual download task
         if (currentTaskId != null) {
-          debugPrint('🚫 Cancelling task: $currentTaskId');
+          gemmaLog('🚫 Cancelling task: $currentTaskId');
           try {
             await FileDownloader().cancelTaskWithId(
                 currentTaskId!); // ← ADD: Actually cancel the task
           } catch (e) {
-            debugPrint('⚠️ Failed to cancel task: $e');
+            gemmaLog('⚠️ Failed to cancel task: $e');
           }
         }
 
@@ -238,11 +238,11 @@ class SmartDownloader {
     final taskId =
         '${url.hashCode.toUnsigned(32).toRadixString(16)}_${targetPath.hashCode.toUnsigned(32).toRadixString(16)}';
 
-    debugPrint(
+    gemmaLog(
         '🔵 _downloadWithSmartRetry called - attempt $currentAttempt/$maxRetries');
-    debugPrint('🔵 URL: $url');
-    debugPrint('🔵 Target: $targetPath');
-    debugPrint('🔵 TaskId: $taskId');
+    gemmaLog('🔵 URL: $url');
+    gemmaLog('🔵 Target: $targetPath');
+    gemmaLog('🔵 TaskId: $taskId');
 
     // Declare listener outside try block so it's accessible in catch
     StreamSubscription? listener;
@@ -253,7 +253,7 @@ class SmartDownloader {
       // Check if task already exists (e.g., after app restart or sleep/wake)
       final existingTask = await downloader.taskForId(taskId);
       if (existingTask != null) {
-        debugPrint(
+        gemmaLog(
             '🔵 Task $taskId already in progress, attaching to existing...');
 
         // Create completer to wait for existing task completion
@@ -265,12 +265,12 @@ class SmartDownloader {
 
           if (update is TaskProgressUpdate) {
             final percents = (update.progress * 100).round();
-            debugPrint('📊 Progress (existing): $percents%');
+            gemmaLog('📊 Progress (existing): $percents%');
             if (!progress.isClosed) {
               progress.add(percents.clamp(0, 100));
             }
           } else if (update is TaskStatusUpdate) {
-            debugPrint('📡 TaskStatusUpdate (existing): ${update.status}');
+            gemmaLog('📡 TaskStatusUpdate (existing): ${update.status}');
             if (update.status == TaskStatus.complete) {
               if (!progress.isClosed) {
                 progress.add(100);
@@ -310,7 +310,7 @@ class SmartDownloader {
       // HuggingFace uses weak ETags - resume not reliable
       // Other servers (GCS, Kaggle, custom) - resume usually works
       final allowPause = !_isHuggingFaceUrl(url);
-      debugPrint(
+      gemmaLog(
           '🔵 allowPause: $allowPause (HuggingFace: ${_isHuggingFaceUrl(url)})');
 
       final task = DownloadTask(
@@ -349,17 +349,17 @@ class SmartDownloader {
       listener = _getUpdatesStream().listen((update) async {
         if (update.task.taskId != task.taskId) return;
 
-        debugPrint(
+        gemmaLog(
             '📡 Received update for task ${task.taskId}: ${update.runtimeType}');
 
         if (update is TaskProgressUpdate) {
           final percents = (update.progress * 100).round();
-          debugPrint('📊 Progress: $percents%');
+          gemmaLog('📊 Progress: $percents%');
           if (!progress.isClosed) {
             progress.add(percents.clamp(0, 100));
           }
         } else if (update is TaskStatusUpdate) {
-          debugPrint(
+          gemmaLog(
               '📡 TaskStatusUpdate: ${update.status}, HTTP: ${update.responseStatusCode}');
 
           switch (update.status) {
@@ -373,12 +373,12 @@ class SmartDownloader {
               break;
 
             case TaskStatus.failed:
-              debugPrint('🔴 SmartDownloader: TaskStatus.failed detected');
-              debugPrint(
+              gemmaLog('🔴 SmartDownloader: TaskStatus.failed detected');
+              gemmaLog(
                   '🔴 HTTP Status Code from update: ${update.responseStatusCode}');
-              debugPrint('🔴 Exception: ${update.exception}');
-              debugPrint('🔴 Progress closed: ${progress.isClosed}');
-              debugPrint('🔴 Current attempt: $currentAttempt');
+              gemmaLog('🔴 Exception: ${update.exception}');
+              gemmaLog('🔴 Progress closed: ${progress.isClosed}');
+              gemmaLog('🔴 Current attempt: $currentAttempt');
 
               // Try to get HTTP code from multiple sources
               int? httpCode = update.responseStatusCode;
@@ -388,7 +388,7 @@ class SmartDownloader {
                 if (update.exception is TaskHttpException) {
                   httpCode =
                       (update.exception as TaskHttpException).httpResponseCode;
-                  debugPrint(
+                  gemmaLog(
                       '🔴 HTTP Status Code from TaskHttpException: $httpCode');
                 }
               }
@@ -415,7 +415,7 @@ class SmartDownloader {
                 await listener?.cancel();
                 completer.complete();
               } else {
-                debugPrint('🔄 Resume pending - keeping listener active');
+                gemmaLog('🔄 Resume pending - keeping listener active');
               }
               break;
 
@@ -432,7 +432,7 @@ class SmartDownloader {
               break;
 
             case TaskStatus.notFound:
-              debugPrint(
+              gemmaLog(
                   '🔴 SmartDownloader: TaskStatus.notFound detected (404)');
 
               // 404 is a non-retryable error - handle immediately
@@ -468,29 +468,29 @@ class SmartDownloader {
       // Notify about new listener
       onListenerCreated?.call(listener);
 
-      debugPrint('🔵 Enqueueing task ${task.taskId}...');
+      gemmaLog('🔵 Enqueueing task ${task.taskId}...');
       final result = await downloader.enqueue(task);
-      debugPrint('🔵 Enqueue result: $result');
+      gemmaLog('🔵 Enqueue result: $result');
 
       // Notify about task ID for cancellation
       onTaskCreated?.call(task.taskId); // ← ADD: Notify task created
 
       // ✅ Wait for download to complete
-      debugPrint('🔵 Waiting for download completion...');
+      gemmaLog('🔵 Waiting for download completion...');
       await completer.future;
-      debugPrint('🔵 Download completed!');
+      gemmaLog('🔵 Download completed!');
 
       // Ensure listener is canceled after completion
       await listener.cancel();
     } catch (e) {
-      debugPrint('❌ Exception in _downloadWithSmartRetry: $e');
-      debugPrint('❌ Stack trace: ${StackTrace.current}');
+      gemmaLog('❌ Exception in _downloadWithSmartRetry: $e');
+      gemmaLog('❌ Stack trace: ${StackTrace.current}');
 
       // Cancel listener before retry
       await listener?.cancel();
 
       if (currentAttempt < maxRetries) {
-        debugPrint(
+        gemmaLog(
             '⚠️ Retrying after exception... attempt ${currentAttempt + 1}/$maxRetries');
         await Future.delayed(
             Duration(seconds: currentAttempt * 2)); // Exponential backoff
@@ -553,27 +553,27 @@ class SmartDownloader {
     void Function(StreamSubscription)? onListenerCreated,
     void Function(String taskId)? onTaskCreated,
   }) async {
-    debugPrint('🟡 _handleFailedDownload called');
-    debugPrint('🟡 httpStatusCode: $httpStatusCode');
-    debugPrint('🟡 progress.isClosed: ${progress.isClosed}');
+    gemmaLog('🟡 _handleFailedDownload called');
+    gemmaLog('🟡 httpStatusCode: $httpStatusCode');
+    gemmaLog('🟡 progress.isClosed: ${progress.isClosed}');
 
     // Check if error is retryable based on HTTP status code
     if (httpStatusCode != null) {
-      debugPrint('🟢 httpStatusCode is not null: $httpStatusCode');
+      gemmaLog('🟢 httpStatusCode is not null: $httpStatusCode');
 
       // Auth errors (401, 403) and not-found (404) should NOT be retried
       if (httpStatusCode == 401) {
-        debugPrint('🟢 Detected 401 - stopping immediately');
+        gemmaLog('🟢 Detected 401 - stopping immediately');
         if (!progress.isClosed) {
-          debugPrint('🟢 Adding error to progress stream');
+          gemmaLog('🟢 Adding error to progress stream');
           progress.addError(
             const DownloadException(DownloadError.unauthorized()),
             StackTrace.current,
           );
           progress.close();
-          debugPrint('🟢 Progress stream closed');
+          gemmaLog('🟢 Progress stream closed');
         } else {
-          debugPrint('⚠️ Progress already closed - cannot add error!');
+          gemmaLog('⚠️ Progress already closed - cannot add error!');
         }
         return false; // Stop immediately, no resume pending
       }
@@ -605,16 +605,16 @@ class SmartDownloader {
     try {
       final canResume = await downloader.taskCanResume(task);
       if (canResume) {
-        debugPrint('🔄 Attempting to resume task ${task.taskId}...');
+        gemmaLog('🔄 Attempting to resume task ${task.taskId}...');
         await downloader.resume(task);
-        debugPrint('🔄 Resume triggered, waiting for status update...');
+        gemmaLog('🔄 Resume triggered, waiting for status update...');
         // Resume triggered - let event loop handle the result
         // If resume succeeds → TaskStatus.complete will fire
         // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and retry logic runs
         return true; // ✅ Resume pending - caller should keep listener active!
       }
     } catch (e) {
-      debugPrint('⚠️ Resume failed with exception: $e');
+      gemmaLog('⚠️ Resume failed with exception: $e');
       // Fall through to retry logic below
     }
 

--- a/lib/model_file_manager_interface.dart
+++ b/lib/model_file_manager_interface.dart
@@ -90,6 +90,12 @@ abstract class ModelFileManager {
   /// Sets the active model for subsequent inference operations
   void setActiveModel(ModelSpec spec);
 
+  /// Ensures the manager is fully initialized — active model/embedder state
+  /// restored from storage (#227). Idempotent and safe to call concurrently;
+  /// all callers share a single initialization. Await this before reading
+  /// [activeInferenceModel] / [activeEmbeddingModel] (#314).
+  Future<void> ensureInitialized();
+
   /// Gets the currently active inference model specification
   ModelSpec? get activeInferenceModel;
 

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -662,7 +662,8 @@ class WebModelSession extends InferenceModelSession {
     _promptParts.add(TextPromptPart(finalPrompt));
     if (kDebugMode) {
       gemmaLog(
-          '🟢 Added text part: ${finalPrompt.substring(0, math.min(100, finalPrompt.length))}...');
+          '🟢 Added text part: ${finalPrompt.substring(0, math.min(100, finalPrompt.length))}...',
+          level: GemmaLogLevel.verbose);
     }
 
     if (kDebugMode) {

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -29,6 +29,7 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'litert_lm_web.dart';
 import 'llm_inference_web.dart';
 import 'flutter_gemma_web_embedding_model.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 part '../core/model_management/managers/web_model_manager.dart';
 part 'web_model_source.dart';
@@ -142,7 +143,7 @@ class FlutterGemmaWeb extends FlutterGemmaPlugin {
     // TODO: Implement multimodal support for web
     if (supportImage || maxNumImages != null) {
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             'Warning: Image support is not yet implemented for web platform');
       }
     }
@@ -170,7 +171,7 @@ class FlutterGemmaWeb extends FlutterGemmaPlugin {
       }
       if (parametersChanged) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '[FlutterGemmaWeb] Model parameters changed, closing existing model');
         }
         await existing.close();
@@ -259,7 +260,7 @@ class FlutterGemmaWeb extends FlutterGemmaPlugin {
       tokenizerPath = activeTokenizerPath;
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             'Using active embedding model: $modelPath, tokenizer: $tokenizerPath');
       }
     }
@@ -274,7 +275,7 @@ class FlutterGemmaWeb extends FlutterGemmaPlugin {
 
       if (modelChanged) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '[FlutterGemmaWeb] Embedding model paths changed, closing existing model');
         }
         await existing.close();
@@ -299,9 +300,9 @@ class FlutterGemmaWeb extends FlutterGemmaPlugin {
     try {
       _vectorStoreRepository = WebVectorStoreRepository();
       await _vectorStoreRepository!.initialize(databasePath);
-      debugPrint('[FlutterGemmaWeb] VectorStore initialized with SQLite WASM');
+      gemmaLog('[FlutterGemmaWeb] VectorStore initialized with SQLite WASM');
     } catch (e) {
-      debugPrint('[FlutterGemmaWeb] Failed to initialize VectorStore: $e');
+      gemmaLog('[FlutterGemmaWeb] Failed to initialize VectorStore: $e');
       rethrow;
     }
   }
@@ -469,8 +470,7 @@ class WebInferenceModel extends InferenceModel {
     // Thinking mode not supported on Web (MediaPipe has no extraContext/channels API)
     if (enableThinking) {
       if (kDebugMode) {
-        debugPrint(
-            'Warning: enableThinking is not supported on Web (MediaPipe). '
+        gemmaLog('Warning: enableThinking is not supported on Web (MediaPipe). '
             'Use Android or Desktop with .litertlm models for Gemma 4 thinking mode.');
       }
     }
@@ -478,7 +478,7 @@ class WebInferenceModel extends InferenceModel {
     // TODO: Implement vision modality for web
     if (enableVisionModality == true) {
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             'Warning: Vision modality is not yet implemented for web platform');
       }
     }
@@ -486,8 +486,7 @@ class WebInferenceModel extends InferenceModel {
     // Audio modality is handled via supportAudio flag in the model
     if (enableAudioModality == true && !supportAudio) {
       if (kDebugMode) {
-        debugPrint(
-            'Warning: Audio modality requested but supportAudio is false');
+        gemmaLog('Warning: Audio modality requested but supportAudio is false');
       }
     }
 
@@ -594,7 +593,7 @@ class WebModelSession extends InferenceModelSession {
   @override
   Future<void> addQueryChunk(Message message) async {
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '🟢 WebModelSession.addQueryChunk() called - hasImage: ${message.hasImage}, hasAudio: ${message.hasAudio}, supportImage: $supportImage, supportAudio: $supportAudio');
     }
 
@@ -616,7 +615,7 @@ class WebModelSession extends InferenceModelSession {
     if (message.hasImage) {
       if (!supportImage) {
         if (kDebugMode) {
-          debugPrint('🔴 Model does not support images - throwing exception');
+          gemmaLog('🔴 Model does not support images - throwing exception');
         }
         throw ArgumentError('This model does not support images');
       }
@@ -628,12 +627,12 @@ class WebModelSession extends InferenceModelSession {
               : const <Uint8List>[]);
       for (final imageBytes in images) {
         if (kDebugMode) {
-          debugPrint('🟢 Processing image: ${imageBytes.length} bytes');
+          gemmaLog('🟢 Processing image: ${imageBytes.length} bytes');
         }
         final imagePart = ImagePromptPart.fromBytes(imageBytes);
         _promptParts.add(imagePart);
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '🟢 Added image part with dataUrl length: ${imagePart.dataUrl.length}');
         }
       }
@@ -642,11 +641,11 @@ class WebModelSession extends InferenceModelSession {
     // Handle audio processing for web (Gemma 3n E4B)
     if (message.hasAudio && message.audioBytes != null) {
       if (kDebugMode) {
-        debugPrint('🎵 Processing audio: ${message.audioBytes!.length} bytes');
+        gemmaLog('🎵 Processing audio: ${message.audioBytes!.length} bytes');
       }
       if (!supportAudio) {
         if (kDebugMode) {
-          debugPrint('🔴 Model does not support audio - throwing exception');
+          gemmaLog('🔴 Model does not support audio - throwing exception');
         }
         throw ArgumentError('This model does not support audio');
       }
@@ -654,7 +653,7 @@ class WebModelSession extends InferenceModelSession {
       final audioPart = AudioPromptPart(message.audioBytes!);
       _promptParts.add(audioPart);
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '🎵 Added audio part with ${message.audioBytes!.length} bytes');
       }
     }
@@ -662,25 +661,25 @@ class WebModelSession extends InferenceModelSession {
     // Add text part last so multimodal turns keep image/audio context first.
     _promptParts.add(TextPromptPart(finalPrompt));
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '🟢 Added text part: ${finalPrompt.substring(0, math.min(100, finalPrompt.length))}...');
     }
 
     if (kDebugMode) {
-      debugPrint('🟢 Total prompt parts: ${_promptParts.length}');
+      gemmaLog('🟢 Total prompt parts: ${_promptParts.length}');
     }
   }
 
   /// Convert PromptParts to JavaScript array for MediaPipe
   JSAny _createPromptArray() {
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '🔧 _createPromptArray: Starting with ${_promptParts.length} prompt parts');
     }
 
     if (_promptParts.isEmpty) {
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '📝 _createPromptArray: Empty prompt parts, returning empty string');
       }
       return ''.toJS; // Empty string fallback
@@ -691,9 +690,9 @@ class WebModelSession extends InferenceModelSession {
       final fullText =
           _promptParts.cast<TextPromptPart>().map((part) => part.text).join('');
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '📝 _createPromptArray: All text parts, returning string of length ${fullText.length}');
-        debugPrint(
+        gemmaLog(
             '📝 _createPromptArray: Text preview: ${fullText.substring(0, math.min(100, fullText.length))}...');
       }
       return fullText.toJS;
@@ -701,7 +700,7 @@ class WebModelSession extends InferenceModelSession {
 
     // Multimodal: create array of parts following MediaPipe documentation format
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '🎯 _createPromptArray: Multimodal mode - creating array with proper format');
     }
 
@@ -715,28 +714,27 @@ class WebModelSession extends InferenceModelSession {
 
       if (part is TextPromptPart) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '📝 _createPromptArray: Adding text part: "${part.text.substring(0, math.min(50, part.text.length))}..."');
         }
         jsArray.add(part.text.toJS);
       } else if (part is ImagePromptPart) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '🖼️ _createPromptArray: Adding image part with data URL length: ${part.dataUrl.length}');
-          debugPrint(
+          gemmaLog(
               '🖼️ _createPromptArray: Image data URL prefix: ${part.dataUrl.substring(0, math.min(50, part.dataUrl.length))}...');
         }
 
         // Create proper image object for MediaPipe
         final imageObj = <String, String>{'imageSource': part.dataUrl}.jsify();
         if (kDebugMode) {
-          debugPrint(
-              '🖼️ _createPromptArray: Created image object with jsify()');
+          gemmaLog('🖼️ _createPromptArray: Created image object with jsify()');
         }
         jsArray.add(imageObj as JSAny);
       } else if (part is AudioPromptPart) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '🎵 _createPromptArray: Adding audio part with ${part.audioBytes.length} bytes');
         }
 
@@ -746,13 +744,12 @@ class WebModelSession extends InferenceModelSession {
           'audioSource': part.audioBytes.buffer.asUint8List()
         }.jsify();
         if (kDebugMode) {
-          debugPrint(
-              '🎵 _createPromptArray: Created audio object with jsify()');
+          gemmaLog('🎵 _createPromptArray: Created audio object with jsify()');
         }
         jsArray.add(audioObj as JSAny);
       } else {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '❌ _createPromptArray: Unsupported prompt part type: ${part.runtimeType}');
         }
         throw Exception('Unsupported prompt part type: $part');
@@ -763,9 +760,9 @@ class WebModelSession extends InferenceModelSession {
     jsArray.add('<ctrl100>\n<ctrl99>model\n'.toJS);
 
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '✅ _createPromptArray: Created JS array with ${jsArray.length} elements (including control tokens)');
-      debugPrint('🎯 _createPromptArray: Array structure ready for MediaPipe');
+      gemmaLog('🎯 _createPromptArray: Array structure ready for MediaPipe');
     }
 
     return jsArray.toJS;
@@ -774,16 +771,16 @@ class WebModelSession extends InferenceModelSession {
   @override
   Future<String> getResponse() async {
     if (kDebugMode) {
-      debugPrint('🚀 getResponse: Starting response generation');
+      gemmaLog('🚀 getResponse: Starting response generation');
     }
 
     try {
       final promptArray = _createPromptArray();
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '🎯 getResponse: Prompt array type: ${promptArray.runtimeType}');
-        debugPrint('🎯 getResponse: Is JSString? ${promptArray is JSString}');
+        gemmaLog('🎯 getResponse: Is JSString? ${promptArray is JSString}');
       }
 
       String response;
@@ -791,7 +788,7 @@ class WebModelSession extends InferenceModelSession {
       // Use appropriate method based on prompt type
       if (promptArray is JSString) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '📝 getResponse: Using generateResponse for text-only prompt');
         }
         response =
@@ -799,7 +796,7 @@ class WebModelSession extends InferenceModelSession {
                 .toDart;
       } else {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '🖼️ getResponse: Using generateResponseMultimodal for multimodal prompt');
         }
         response = (await llmInference
@@ -809,9 +806,9 @@ class WebModelSession extends InferenceModelSession {
       }
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '✅ getResponse: Successfully generated response of length ${response.length}');
-        debugPrint(
+        gemmaLog(
             '✅ getResponse: Response preview: ${response.substring(0, math.min(100, response.length))}...');
       }
 
@@ -819,8 +816,8 @@ class WebModelSession extends InferenceModelSession {
       return response;
     } catch (e, stackTrace) {
       if (kDebugMode) {
-        debugPrint('❌ getResponse: Exception caught: $e');
-        debugPrint('❌ getResponse: Stack trace: $stackTrace');
+        gemmaLog('❌ getResponse: Exception caught: $e');
+        gemmaLog('❌ getResponse: Stack trace: $stackTrace');
       }
       _promptParts.clear();
       rethrow;
@@ -830,7 +827,7 @@ class WebModelSession extends InferenceModelSession {
   @override
   Stream<String> getResponseAsync() {
     if (kDebugMode) {
-      debugPrint('🌊 getResponseAsync: Starting async response generation');
+      gemmaLog('🌊 getResponseAsync: Starting async response generation');
     }
 
     // Close previous controller to prevent leak if called again before completion
@@ -841,16 +838,16 @@ class WebModelSession extends InferenceModelSession {
       final promptArray = _createPromptArray();
 
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '🎯 getResponseAsync: Prompt array type: ${promptArray.runtimeType}');
-        debugPrint(
+        gemmaLog(
             '🎯 getResponseAsync: Is JSString? ${promptArray is JSString}');
       }
 
       // Use appropriate method based on prompt type
       if (promptArray is JSString) {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '📝 getResponseAsync: Using generateResponse for text-only prompt');
         }
         llmInference.generateResponse(
@@ -860,19 +857,19 @@ class WebModelSession extends InferenceModelSession {
               final complete = completeRaw.parseBool();
               final partial = partialJs.toDart;
               if (kDebugMode) {
-                debugPrint(
+                gemmaLog(
                     '📝 getResponseAsync: Received partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...');
               }
               _controller?.add(partial);
               if (complete) {
                 if (kDebugMode) {
-                  debugPrint('✅ getResponseAsync: Text response completed');
+                  gemmaLog('✅ getResponseAsync: Text response completed');
                 }
                 _controller?.close();
               }
             } catch (e) {
               if (kDebugMode) {
-                debugPrint('❌ getResponseAsync: Error in text callback: $e');
+                gemmaLog('❌ getResponseAsync: Error in text callback: $e');
               }
               _controller?.addError(e);
             }
@@ -880,7 +877,7 @@ class WebModelSession extends InferenceModelSession {
         );
       } else {
         if (kDebugMode) {
-          debugPrint(
+          gemmaLog(
               '🖼️ getResponseAsync: Using generateResponseMultimodal for multimodal prompt');
         }
         llmInference.generateResponseMultimodal(
@@ -890,20 +887,19 @@ class WebModelSession extends InferenceModelSession {
               final complete = completeRaw.parseBool();
               final partial = partialJs.toDart;
               if (kDebugMode) {
-                debugPrint(
+                gemmaLog(
                     '🖼️ getResponseAsync: Received multimodal partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...');
               }
               _controller?.add(partial);
               if (complete) {
                 if (kDebugMode) {
-                  debugPrint(
-                      '✅ getResponseAsync: Multimodal response completed');
+                  gemmaLog('✅ getResponseAsync: Multimodal response completed');
                 }
                 _controller?.close();
               }
             } catch (e) {
               if (kDebugMode) {
-                debugPrint(
+                gemmaLog(
                     '❌ getResponseAsync: Error in multimodal callback: $e');
               }
               _controller?.addError(e);
@@ -913,8 +909,8 @@ class WebModelSession extends InferenceModelSession {
       }
     } catch (e, stackTrace) {
       if (kDebugMode) {
-        debugPrint('❌ getResponseAsync: Exception during setup: $e');
-        debugPrint('❌ getResponseAsync: Stack trace: $stackTrace');
+        gemmaLog('❌ getResponseAsync: Exception during setup: $e');
+        gemmaLog('❌ getResponseAsync: Stack trace: $stackTrace');
       }
       _controller?.addError(e);
     }
@@ -928,7 +924,7 @@ class WebModelSession extends InferenceModelSession {
       llmInference.cancelProcessing();
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('[WebModelSession] cancelProcessing error: $e');
+        gemmaLog('[WebModelSession] cancelProcessing error: $e');
       }
     } finally {
       _controller?.close();
@@ -952,11 +948,11 @@ class WebModelSession extends InferenceModelSession {
     try {
       llmInference.close();
       if (kDebugMode) {
-        debugPrint('[WebModelSession] Cleaned up LlmInference resources');
+        gemmaLog('[WebModelSession] Cleaned up LlmInference resources');
       }
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('[WebModelSession] Warning: Error closing LlmInference: $e');
+        gemmaLog('[WebModelSession] Warning: Error closing LlmInference: $e');
       }
     }
 

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -724,9 +724,11 @@ class WebModelSession extends InferenceModelSession {
       } else if (part is ImagePromptPart) {
         if (kDebugMode) {
           gemmaLog(
-              '🖼️ _createPromptArray: Adding image part with data URL length: ${part.dataUrl.length}');
+              '🖼️ _createPromptArray: Adding image part with data URL length: ${part.dataUrl.length}',
+              level: GemmaLogLevel.verbose);
           gemmaLog(
-              '🖼️ _createPromptArray: Image data URL prefix: ${part.dataUrl.substring(0, math.min(50, part.dataUrl.length))}...');
+              '🖼️ _createPromptArray: Image data URL prefix: ${part.dataUrl.substring(0, math.min(50, part.dataUrl.length))}...',
+              level: GemmaLogLevel.verbose);
         }
 
         // Create proper image object for MediaPipe

--- a/lib/web/flutter_gemma_web.dart
+++ b/lib/web/flutter_gemma_web.dart
@@ -693,7 +693,8 @@ class WebModelSession extends InferenceModelSession {
         gemmaLog(
             '📝 _createPromptArray: All text parts, returning string of length ${fullText.length}');
         gemmaLog(
-            '📝 _createPromptArray: Text preview: ${fullText.substring(0, math.min(100, fullText.length))}...');
+            '📝 _createPromptArray: Text preview: ${fullText.substring(0, math.min(100, fullText.length))}...',
+            level: GemmaLogLevel.verbose);
       }
       return fullText.toJS;
     }
@@ -715,7 +716,8 @@ class WebModelSession extends InferenceModelSession {
       if (part is TextPromptPart) {
         if (kDebugMode) {
           gemmaLog(
-              '📝 _createPromptArray: Adding text part: "${part.text.substring(0, math.min(50, part.text.length))}..."');
+              '📝 _createPromptArray: Adding text part: "${part.text.substring(0, math.min(50, part.text.length))}..."',
+              level: GemmaLogLevel.verbose);
         }
         jsArray.add(part.text.toJS);
       } else if (part is ImagePromptPart) {
@@ -809,7 +811,8 @@ class WebModelSession extends InferenceModelSession {
         gemmaLog(
             '✅ getResponse: Successfully generated response of length ${response.length}');
         gemmaLog(
-            '✅ getResponse: Response preview: ${response.substring(0, math.min(100, response.length))}...');
+            '✅ getResponse: Response preview: ${response.substring(0, math.min(100, response.length))}...',
+            level: GemmaLogLevel.verbose);
       }
 
       // Don't add response back to promptParts - that's handled by InferenceChat
@@ -858,7 +861,8 @@ class WebModelSession extends InferenceModelSession {
               final partial = partialJs.toDart;
               if (kDebugMode) {
                 gemmaLog(
-                    '📝 getResponseAsync: Received partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...');
+                    '📝 getResponseAsync: Received partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...',
+                    level: GemmaLogLevel.verbose);
               }
               _controller?.add(partial);
               if (complete) {
@@ -888,7 +892,8 @@ class WebModelSession extends InferenceModelSession {
               final partial = partialJs.toDart;
               if (kDebugMode) {
                 gemmaLog(
-                    '🖼️ getResponseAsync: Received multimodal partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...');
+                    '🖼️ getResponseAsync: Received multimodal partial (complete: $complete): ${partial.substring(0, math.min(50, partial.length))}...',
+                    level: GemmaLogLevel.verbose);
               }
               _controller?.add(partial);
               if (complete) {

--- a/lib/web/flutter_gemma_web_embedding_model.dart
+++ b/lib/web/flutter_gemma_web_embedding_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import '../flutter_gemma_interface.dart';
 import 'litert_web_embeddings.dart';
+import '../core/utils/gemma_log.dart';
 
 class WebEmbeddingModel extends EmbeddingModel {
   WebEmbeddingModel({
@@ -45,7 +46,7 @@ class WebEmbeddingModel extends EmbeddingModel {
       );
       _isInitialized = true;
       if (kDebugMode) {
-        debugPrint('✅ LiteRT embeddings initialized successfully');
+        gemmaLog('✅ LiteRT embeddings initialized successfully');
       }
     } catch (e) {
       throw Exception('Failed to initialize LiteRT embeddings: $e');
@@ -67,7 +68,7 @@ class WebEmbeddingModel extends EmbeddingModel {
       return await LiteRTWebEmbeddings.generateEmbedding(text);
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('❌ Failed to generate embedding: $e');
+        gemmaLog('❌ Failed to generate embedding: $e');
       }
       rethrow;
     }
@@ -92,12 +93,12 @@ class WebEmbeddingModel extends EmbeddingModel {
       }
       final embeddings = await LiteRTWebEmbeddings.generateEmbeddings(texts);
       if (kDebugMode) {
-        debugPrint('✅ Generated ${embeddings.length} embeddings');
+        gemmaLog('✅ Generated ${embeddings.length} embeddings');
       }
       return embeddings;
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('❌ Failed to generate embeddings: $e');
+        gemmaLog('❌ Failed to generate embeddings: $e');
       }
       rethrow;
     }
@@ -121,11 +122,11 @@ class WebEmbeddingModel extends EmbeddingModel {
       try {
         await LiteRTWebEmbeddings.dispose();
         if (kDebugMode) {
-          debugPrint('✅ LiteRT embeddings disposed');
+          gemmaLog('✅ LiteRT embeddings disposed');
         }
       } catch (e) {
         if (kDebugMode) {
-          debugPrint('⚠️  Warning: Failed to dispose LiteRT embeddings: $e');
+          gemmaLog('⚠️  Warning: Failed to dispose LiteRT embeddings: $e');
         }
       }
     }

--- a/lib/web/litert_lm_web_inference.dart
+++ b/lib/web/litert_lm_web_inference.dart
@@ -129,7 +129,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
     }
 
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmWebInferenceModel] Engine.create({model: $diagDescription})');
     }
     final sw = Stopwatch()..start();
@@ -138,7 +138,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
     );
     _engine = await engineFuture.toDart;
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmWebInferenceModel/perf] Engine.create: ${sw.elapsedMilliseconds}ms');
     }
   }
@@ -183,7 +183,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
     // options should not be null" — so we force-disable them and warn.
     if (enableVisionModality == true || enableAudioModality == true) {
       if (kDebugMode) {
-        debugPrint('[LiteRtLmWebInferenceModel] Warning: vision/audio modality '
+        gemmaLog('[LiteRtLmWebInferenceModel] Warning: vision/audio modality '
             'is requested but @litert-lm/core@0.12.1 does not expose the '
             'Vision/AudioExecutor config in its TypeScript API — image/audio '
             'inputs are dropped on web until upstream extends EngineSettings. '
@@ -226,7 +226,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
 
       completer.complete(session);
       if (kDebugMode) {
-        debugPrint(
+        gemmaLog(
             '[LiteRtLmWebInferenceModel/perf] createSession total: ${sessionSw.elapsedMilliseconds}ms');
       }
       return session;
@@ -271,7 +271,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
     // detailed comment in createSession. Force-disable here too.
     if ((enableVisionModality == true || enableAudioModality == true) &&
         kDebugMode) {
-      debugPrint('[LiteRtLmWebInferenceModel] Warning: vision/audio modality '
+      gemmaLog('[LiteRtLmWebInferenceModel] Warning: vision/audio modality '
           'is dropped on the web .litertlm path until upstream extends '
           'EngineSettings.');
     }
@@ -367,7 +367,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
     );
     final conversation = await convoFuture.toDart;
     if (kDebugMode) {
-      debugPrint(
+      gemmaLog(
           '[LiteRtLmWebInferenceModel/perf] createConversation: ${sw.elapsedMilliseconds - beforeConv}ms');
     }
     return conversation;
@@ -387,7 +387,7 @@ class LiteRtLmWebInferenceModel extends InferenceModel {
         _engine?.delete();
       } catch (e) {
         if (kDebugMode) {
-          debugPrint('[LiteRtLmWebInferenceModel] engine.delete() failed: $e');
+          gemmaLog('[LiteRtLmWebInferenceModel] engine.delete() failed: $e');
         }
       }
       _engine = null;
@@ -593,8 +593,7 @@ class LiteRtLmWebSession extends InferenceModelSession
             }
             if (kDebugMode) {
               final total = genSw.elapsedMilliseconds;
-              debugPrint(
-                  '[LiteRtLmWebSession/perf] generation total: ${total}ms '
+              gemmaLog('[LiteRtLmWebSession/perf] generation total: ${total}ms '
                   '(prefill ${firstChunkMs ?? 0}ms, $chunkCount chunks)');
             }
             releaseMutex();
@@ -604,7 +603,7 @@ class LiteRtLmWebSession extends InferenceModelSession
           if (firstChunkMs == null) {
             firstChunkMs = genSw.elapsedMilliseconds;
             if (kDebugMode) {
-              debugPrint(
+              gemmaLog(
                   '[LiteRtLmWebSession/perf] time-to-first-chunk: ${firstChunkMs}ms');
             }
           }
@@ -679,7 +678,7 @@ class LiteRtLmWebSession extends InferenceModelSession
       conversation.cancel();
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('[LiteRtLmWebSession] conversation.cancel() threw: $e');
+        gemmaLog('[LiteRtLmWebSession] conversation.cancel() threw: $e');
       }
     }
   }
@@ -701,7 +700,7 @@ class LiteRtLmWebSession extends InferenceModelSession
       conversation.cancel();
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('[LiteRtLmWebSession] cancel during close threw: $e');
+        gemmaLog('[LiteRtLmWebSession] cancel during close threw: $e');
       }
     }
     _queryBuffer.clear();

--- a/lib/web/web_model_source.dart
+++ b/lib/web/web_model_source.dart
@@ -89,13 +89,12 @@ class WebModelSourceResolver {
             'OPFS service not available (streaming mode requires OPFS).');
       }
       if (kDebugMode) {
-        debugPrint(
-            '[WebModelSourceResolver] OPFS stream source for: $filename');
+        gemmaLog('[WebModelSourceResolver] OPFS stream source for: $filename');
       }
       return OpfsStreamModelSource(opfs, filename);
     }
     if (kDebugMode) {
-      debugPrint('[WebModelSourceResolver] Blob/HTTPS URL: $raw');
+      gemmaLog('[WebModelSourceResolver] Blob/HTTPS URL: $raw');
     }
     return BlobUrlModelSource(raw);
   }

--- a/native/qdrant_edge/build_local.sh
+++ b/native/qdrant_edge/build_local.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-QDRANT_EDGE_VERSION="${QDRANT_EDGE_VERSION:-0.7.1}"
+QDRANT_EDGE_VERSION="${QDRANT_EDGE_VERSION:-0.7.2}"
 ANDROID_API_LEVEL="${ANDROID_API_LEVEL:-24}"  # minSdk 24 matches flutter_gemma
 
 # iOS deployment target. Must match flutter_gemma's Podfile (platform :ios, '16.0').
@@ -73,6 +73,15 @@ build_ios_device() {
     rm -rf "$out" && mkdir -p "$out"
     cp "$src" "$out/libqdrant_edge_ffi.dylib"
     install_name_tool -id "@rpath/libqdrant_edge_ffi.dylib" "$out/libqdrant_edge_ffi.dylib"
+    # Normalize iOS minos -> 13.0 to match the MinimumOSVersion Flutter Native
+    # Assets hardcodes into the framework wrapper Info.plist. Without this, App
+    # Store Connect rejects the archive with ITMS-90208 because the binary minos
+    # (16.0, from IPHONEOS_DEPLOYMENT_TARGET above) differs from the wrapper's
+    # 13.0. The real iOS 16+ floor is enforced by the podspec, not this metadata.
+    # Same patch as native/litert_lm/build_ios.sh. See #245, #286.
+    vtool -set-build-version ios 13.0 18.5 -replace \
+        -output "$out/libqdrant_edge_ffi.dylib" "$out/libqdrant_edge_ffi.dylib"
+    echo "    minos -> $(vtool -show-build "$out/libqdrant_edge_ffi.dylib" | awk '/minos/{print $2}')"
     tar -czf "$DIST_DIR/qdrant-edge-ios_arm64.tar.gz" -C "$out" .
     echo "    → $DIST_DIR/qdrant-edge-ios_arm64.tar.gz"
 }
@@ -85,6 +94,11 @@ build_ios_sim() {
     rm -rf "$out" && mkdir -p "$out"
     cp "$src" "$out/libqdrant_edge_ffi.dylib"
     install_name_tool -id "@rpath/libqdrant_edge_ffi.dylib" "$out/libqdrant_edge_ffi.dylib"
+    # See build_ios_device — same ITMS-90208 minos normalization, simulator
+    # platform token (iossim, not ios).
+    vtool -set-build-version iossim 13.0 18.5 -replace \
+        -output "$out/libqdrant_edge_ffi.dylib" "$out/libqdrant_edge_ffi.dylib"
+    echo "    minos -> $(vtool -show-build "$out/libqdrant_edge_ffi.dylib" | awk '/minos/{print $2}')"
     tar -czf "$DIST_DIR/qdrant-edge-ios_sim_arm64.tar.gz" -C "$out" .
     echo "    → $DIST_DIR/qdrant-edge-ios_sim_arm64.tar.gz"
 }

--- a/native/qdrant_edge/qdrant_edge_ffi/Cargo.toml
+++ b/native/qdrant_edge/qdrant_edge_ffi/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-qdrant-edge = "=0.7.1"
+qdrant-edge = "=0.7.2"
 serde_json = "1"
 
 # Pin upstream-bug-prone transitive (matches qdrant-edge example workspace)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "A Flutter plugin for running Gemma and other LLMs locally on Android, iOS, Web, and Desktop. Supports multimodal vision, audio, function calling, thinking mode, GPU acceleration, text embeddings, and on-device RAG."
-version: 0.16.4
+version: 0.16.5
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 

--- a/test/asset_path_parsing_test.dart
+++ b/test/asset_path_parsing_test.dart
@@ -9,7 +9,8 @@ void main() {
 
       // OLD broken way (what was causing the bug)
       final brokenResult = Uri.parse(url).path;
-      expect(brokenResult, equals('/models/gemma3-1b.task')); // This was the bug
+      expect(
+          brokenResult, equals('/models/gemma3-1b.task')); // This was the bug
 
       // NEW fixed way
       final fixedResult = url.replaceFirst('asset://', '');
@@ -25,7 +26,8 @@ void main() {
 
       for (final entry in testCases.entries) {
         final result = entry.key.replaceFirst('asset://', '');
-        expect(result, equals(entry.value), reason: 'Failed for input: ${entry.key}');
+        expect(result, equals(entry.value),
+            reason: 'Failed for input: ${entry.key}');
       }
     });
 
@@ -38,7 +40,8 @@ void main() {
 
       for (final url in nonAssetUrls) {
         final result = url.replaceFirst('asset://', '');
-        expect(result, equals(url), reason: 'Should not modify non-asset URL: $url');
+        expect(result, equals(url),
+            reason: 'Should not modify non-asset URL: $url');
       }
     });
   });

--- a/test/core/chat_prompt_test.dart
+++ b/test/core/chat_prompt_test.dart
@@ -33,7 +33,10 @@ void main() {
       final prompt = chat.createToolsPrompt();
 
       // Check enum format: enum:[<escape>red<escape>,<escape>blue<escape>,<escape>green<escape>]
-      expect(prompt, contains('enum:[<escape>red<escape>,<escape>blue<escape>,<escape>green<escape>]'));
+      expect(
+          prompt,
+          contains(
+              'enum:[<escape>red<escape>,<escape>blue<escape>,<escape>green<escape>]'));
       expect(prompt, contains('description:<escape>The color name<escape>'));
       expect(prompt, contains('type:<escape>STRING<escape>'));
     });
@@ -192,8 +195,10 @@ void main() {
 
       final prompt = chat.createToolsPrompt();
 
-      expect(prompt, contains('enum:[<escape>red<escape>,<escape>blue<escape>]'));
-      expect(prompt, contains('enum:[<escape>small<escape>,<escape>large<escape>]'));
+      expect(
+          prompt, contains('enum:[<escape>red<escape>,<escape>blue<escape>]'));
+      expect(prompt,
+          contains('enum:[<escape>small<escape>,<escape>large<escape>]'));
     });
 
     test('preserves field order: description, enum, type', () {
@@ -232,8 +237,10 @@ void main() {
       final enumIndex = colorBlock.indexOf('enum:');
       final typeIndex = colorBlock.indexOf('type:');
 
-      expect(descIndex, lessThan(enumIndex), reason: 'description should come before enum');
-      expect(enumIndex, lessThan(typeIndex), reason: 'enum should come before type');
+      expect(descIndex, lessThan(enumIndex),
+          reason: 'description should come before enum');
+      expect(enumIndex, lessThan(typeIndex),
+          reason: 'enum should come before type');
     });
   });
 

--- a/test/core/handlers/source_handler_test.dart
+++ b/test/core/handlers/source_handler_test.dart
@@ -20,7 +20,8 @@ class MockFileSystemService extends Mock implements FileSystemService {}
 
 class MockAssetLoader extends Mock implements AssetLoader {}
 
-class MockProtectedFilesRegistry extends Mock implements ProtectedFilesRegistry {}
+class MockProtectedFilesRegistry extends Mock
+    implements ProtectedFilesRegistry {}
 
 class MockModelRepository extends Mock implements ModelRepository {}
 
@@ -96,15 +97,19 @@ void main() {
       final source = NetworkSource('https://example.com/model.bin');
       const targetPath = '/data/model.bin';
 
-      when(() => mockFileSystem.getWriteTargetPath(any())).thenAnswer((_) async => targetPath);
-      when(() => mockDownloadService.download(any(), any(), token: any(named: 'token')))
-          .thenAnswer((_) async {});
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 1024);
+      when(() => mockFileSystem.getWriteTargetPath(any()))
+          .thenAnswer((_) async => targetPath);
+      when(() => mockDownloadService.download(any(), any(),
+          token: any(named: 'token'))).thenAnswer((_) async {});
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 1024);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
 
-      verify(() => mockDownloadService.download(source.url, targetPath, token: null)).called(1);
+      verify(() =>
+              mockDownloadService.download(source.url, targetPath, token: null))
+          .called(1);
       verify(() => mockRepository.saveModel(any())).called(1);
     });
 
@@ -113,17 +118,19 @@ void main() {
       const targetPath = '/data/model.bin';
       final progressStream = Stream<int>.fromIterable([0, 25, 50, 75, 100]);
 
-      when(() => mockFileSystem.getWriteTargetPath(any())).thenAnswer((_) async => targetPath);
-      when(() => mockDownloadService.downloadWithProgress(any(), any(), token: any(named: 'token')))
-          .thenAnswer((_) => progressStream);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 1024);
+      when(() => mockFileSystem.getWriteTargetPath(any()))
+          .thenAnswer((_) async => targetPath);
+      when(() => mockDownloadService.downloadWithProgress(any(), any(),
+          token: any(named: 'token'))).thenAnswer((_) => progressStream);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 1024);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       final progress = await handler.installWithProgress(source).toList();
 
       expect(progress, [0, 25, 50, 75, 100]);
-      verify(() => mockDownloadService.downloadWithProgress(source.url, targetPath, token: null))
-          .called(1);
+      verify(() => mockDownloadService
+          .downloadWithProgress(source.url, targetPath, token: null)).called(1);
     });
 
     test('supportsResume returns true for NetworkSource', () {
@@ -135,17 +142,19 @@ void main() {
       final source = NetworkSource('https://huggingface.co/models/test.bin');
       const targetPath = '/data/model.bin';
 
-      when(() => mockFileSystem.getWriteTargetPath(any())).thenAnswer((_) async => targetPath);
-      when(() => mockDownloadService.download(any(), any(), token: any(named: 'token')))
-          .thenAnswer((_) async {});
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 1024);
+      when(() => mockFileSystem.getWriteTargetPath(any()))
+          .thenAnswer((_) async => targetPath);
+      when(() => mockDownloadService.download(any(), any(),
+          token: any(named: 'token'))).thenAnswer((_) async {});
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 1024);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
 
       // Should pass HuggingFace token if available
-      verify(() => mockDownloadService.download(source.url, targetPath, token: any(named: 'token')))
-          .called(1);
+      verify(() => mockDownloadService.download(source.url, targetPath,
+          token: any(named: 'token'))).called(1);
     });
   });
 
@@ -191,10 +200,14 @@ void main() {
       const targetPath = '/data/model.bin';
       final assetData = Uint8List.fromList([1, 2, 3, 4]);
 
-      when(() => mockAssetLoader.loadAsset(any())).thenAnswer((_) async => assetData);
-      when(() => mockFileSystem.getWriteTargetPath(any())).thenAnswer((_) async => targetPath);
-      when(() => mockFileSystem.writeFile(any(), any())).thenAnswer((_) async {});
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => assetData.length);
+      when(() => mockAssetLoader.loadAsset(any()))
+          .thenAnswer((_) async => assetData);
+      when(() => mockFileSystem.getWriteTargetPath(any()))
+          .thenAnswer((_) async => targetPath);
+      when(() => mockFileSystem.writeFile(any(), any()))
+          .thenAnswer((_) async {});
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => assetData.length);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
@@ -213,10 +226,14 @@ void main() {
       const targetPath = '/data/model.bin';
       final assetData = Uint8List.fromList([1, 2, 3, 4]);
 
-      when(() => mockAssetLoader.loadAsset(any())).thenAnswer((_) async => assetData);
-      when(() => mockFileSystem.getWriteTargetPath(any())).thenAnswer((_) async => targetPath);
-      when(() => mockFileSystem.writeFile(any(), any())).thenAnswer((_) async {});
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => assetData.length);
+      when(() => mockAssetLoader.loadAsset(any()))
+          .thenAnswer((_) async => assetData);
+      when(() => mockFileSystem.getWriteTargetPath(any()))
+          .thenAnswer((_) async => targetPath);
+      when(() => mockFileSystem.writeFile(any(), any()))
+          .thenAnswer((_) async {});
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => assetData.length);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       final progress = await handler.installWithProgress(source).toList();
@@ -235,10 +252,14 @@ void main() {
       const targetPath = '/data/model.bin';
       final assetData = Uint8List.fromList([1, 2, 3, 4]);
 
-      when(() => mockAssetLoader.loadAsset(any())).thenAnswer((_) async => assetData);
-      when(() => mockFileSystem.getWriteTargetPath(any())).thenAnswer((_) async => targetPath);
-      when(() => mockFileSystem.writeFile(any(), any())).thenAnswer((_) async {});
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => assetData.length);
+      when(() => mockAssetLoader.loadAsset(any()))
+          .thenAnswer((_) async => assetData);
+      when(() => mockFileSystem.getWriteTargetPath(any()))
+          .thenAnswer((_) async => targetPath);
+      when(() => mockFileSystem.writeFile(any(), any()))
+          .thenAnswer((_) async {});
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => assetData.length);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source1);
@@ -247,7 +268,8 @@ void main() {
       // Both should normalize to 'assets/models/test.bin' for the loadAsset
       // (rootBundle) path. The native lookup key (without prefix) is used
       // separately on the large_file_handler path.
-      verify(() => mockAssetLoader.loadAsset('assets/models/test.bin')).called(2);
+      verify(() => mockAssetLoader.loadAsset('assets/models/test.bin'))
+          .called(2);
     });
   });
 
@@ -289,13 +311,16 @@ void main() {
       final source = BundledSource('test.bin');
       const bundledPath = '/native/resources/test.bin';
 
-      when(() => mockFileSystem.getBundledResourcePath(any())).thenAnswer((_) async => bundledPath);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 2048);
+      when(() => mockFileSystem.getBundledResourcePath(any()))
+          .thenAnswer((_) async => bundledPath);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 2048);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
 
-      verify(() => mockFileSystem.getBundledResourcePath(source.resourceName)).called(1);
+      verify(() => mockFileSystem.getBundledResourcePath(source.resourceName))
+          .called(1);
       verify(() => mockRepository.saveModel(any())).called(1);
     });
 
@@ -303,8 +328,10 @@ void main() {
       final source = BundledSource('test.bin');
       const bundledPath = '/native/resources/test.bin';
 
-      when(() => mockFileSystem.getBundledResourcePath(any())).thenAnswer((_) async => bundledPath);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 2048);
+      when(() => mockFileSystem.getBundledResourcePath(any()))
+          .thenAnswer((_) async => bundledPath);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 2048);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       final progress = await handler.installWithProgress(source).toList();
@@ -324,13 +351,16 @@ void main() {
       final source = BundledSource('test.bin');
       const bundledPath = '/platform/specific/test.bin';
 
-      when(() => mockFileSystem.getBundledResourcePath(any())).thenAnswer((_) async => bundledPath);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 2048);
+      when(() => mockFileSystem.getBundledResourcePath(any()))
+          .thenAnswer((_) async => bundledPath);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 2048);
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
 
-      verify(() => mockFileSystem.getBundledResourcePath(source.resourceName)).called(1);
+      verify(() => mockFileSystem.getBundledResourcePath(source.resourceName))
+          .called(1);
     });
   });
 
@@ -374,25 +404,31 @@ void main() {
     test('install registers external file and protects it', () async {
       final source = FileSource('/tmp/external/model.bin');
 
-      when(() => mockFileSystem.fileExists(any())).thenAnswer((_) async => true);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 3072);
-      when(() => mockFileSystem.registerExternalFile(any(), any())).thenAnswer((_) async {});
+      when(() => mockFileSystem.fileExists(any()))
+          .thenAnswer((_) async => true);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 3072);
+      when(() => mockFileSystem.registerExternalFile(any(), any()))
+          .thenAnswer((_) async {});
       when(() => mockRegistry.protect(any())).thenAnswer((_) async {});
-      when(() => mockRegistry.registerExternalPath(any(), any())).thenAnswer((_) async {});
+      when(() => mockRegistry.registerExternalPath(any(), any()))
+          .thenAnswer((_) async {});
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
 
       verify(() => mockFileSystem.fileExists(source.path)).called(1);
       verify(() => mockRegistry.protect(any())).called(1);
-      verify(() => mockRegistry.registerExternalPath(any(), source.path)).called(1);
+      verify(() => mockRegistry.registerExternalPath(any(), source.path))
+          .called(1);
       verify(() => mockRepository.saveModel(any())).called(1);
     });
 
     test('install throws if external file does not exist', () async {
       final source = FileSource('/tmp/nonexistent.bin');
 
-      when(() => mockFileSystem.fileExists(any())).thenAnswer((_) async => false);
+      when(() => mockFileSystem.fileExists(any()))
+          .thenAnswer((_) async => false);
 
       expect(
         () => handler.install(source),
@@ -407,11 +443,15 @@ void main() {
     test('installWithProgress reports single 100% progress', () async {
       final source = FileSource('/tmp/external/model.bin');
 
-      when(() => mockFileSystem.fileExists(any())).thenAnswer((_) async => true);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 3072);
-      when(() => mockFileSystem.registerExternalFile(any(), any())).thenAnswer((_) async {});
+      when(() => mockFileSystem.fileExists(any()))
+          .thenAnswer((_) async => true);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 3072);
+      when(() => mockFileSystem.registerExternalFile(any(), any()))
+          .thenAnswer((_) async {});
       when(() => mockRegistry.protect(any())).thenAnswer((_) async {});
-      when(() => mockRegistry.registerExternalPath(any(), any())).thenAnswer((_) async {});
+      when(() => mockRegistry.registerExternalPath(any(), any()))
+          .thenAnswer((_) async {});
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       final progress = await handler.installWithProgress(source).toList();
@@ -427,18 +467,23 @@ void main() {
     test('protects external file from cleanup operations', () async {
       final source = FileSource('/important/user/model.bin');
 
-      when(() => mockFileSystem.fileExists(any())).thenAnswer((_) async => true);
-      when(() => mockFileSystem.getFileSize(any())).thenAnswer((_) async => 4096);
-      when(() => mockFileSystem.registerExternalFile(any(), any())).thenAnswer((_) async {});
+      when(() => mockFileSystem.fileExists(any()))
+          .thenAnswer((_) async => true);
+      when(() => mockFileSystem.getFileSize(any()))
+          .thenAnswer((_) async => 4096);
+      when(() => mockFileSystem.registerExternalFile(any(), any()))
+          .thenAnswer((_) async {});
       when(() => mockRegistry.protect(any())).thenAnswer((_) async {});
-      when(() => mockRegistry.registerExternalPath(any(), any())).thenAnswer((_) async {});
+      when(() => mockRegistry.registerExternalPath(any(), any()))
+          .thenAnswer((_) async {});
       when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
 
       await handler.install(source);
 
       // File should be protected to prevent deletion during cleanup
       verify(() => mockRegistry.protect(any())).called(1);
-      verify(() => mockRegistry.registerExternalPath(any(), source.path)).called(1);
+      verify(() => mockRegistry.registerExternalPath(any(), source.path))
+          .called(1);
     });
   });
 
@@ -514,7 +559,8 @@ void main() {
       expect(handler!.supports(source), isTrue);
     });
 
-    test('returns first matching handler when multiple support same source', () {
+    test('returns first matching handler when multiple support same source',
+        () {
       // If multiple handlers claim to support a source, first one wins
       final source = NetworkSource('https://example.com/model.bin');
       final handler = registry.getHandler(source);

--- a/test/core/infrastructure/background_downloader_service_test.dart
+++ b/test/core/infrastructure/background_downloader_service_test.dart
@@ -214,7 +214,8 @@ void main() {
         );
       });
 
-      test('downloadWithProgress() has same signature as SmartDownloader.downloadWithProgress()',
+      test(
+          'downloadWithProgress() has same signature as SmartDownloader.downloadWithProgress()',
           () {
         // Both should accept: url, targetPath, token (optional), maxRetries (optional)
         expect(
@@ -238,7 +239,8 @@ void main() {
         expect(
           () => BackgroundDownloaderService(),
           returnsNormally,
-          reason: 'Should not require complex initialization (no _downloader, _activeTasks, etc.)',
+          reason:
+              'Should not require complex initialization (no _downloader, _activeTasks, etc.)',
         );
       });
     });

--- a/test/core/infrastructure/web_cache_service_test.dart
+++ b/test/core/infrastructure/web_cache_service_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_gemma/core/infrastructure/web_cache_interop_stub.dart'
     if (dart.library.js_interop) 'package:flutter_gemma/core/infrastructure/web_cache_interop.dart';
 import 'package:flutter_gemma/core/infrastructure/web_file_system_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 void main() {
   group('WebCacheService', () {
     late WebCacheService cacheService;
@@ -39,12 +40,14 @@ void main() {
     });
 
     test('isCached returns false for non-existent URL', () async {
-      final cached = await cacheService.isCached('https://example.com/non-existent.bin');
+      final cached =
+          await cacheService.isCached('https://example.com/non-existent.bin');
       expect(cached, isFalse);
     });
 
     test('getCachedBlobUrl returns null for non-existent URL', () async {
-      final blobUrl = await cacheService.getCachedBlobUrl('https://example.com/non-existent.bin');
+      final blobUrl = await cacheService
+          .getCachedBlobUrl('https://example.com/non-existent.bin');
       expect(blobUrl, isNull);
     });
 

--- a/test/core/litertlm_file_type_test.dart
+++ b/test/core/litertlm_file_type_test.dart
@@ -169,10 +169,7 @@ void main() {
         fileType: ModelFileType.litertlm,
       ).toList();
 
-      final text = results
-          .whereType<TextResponse>()
-          .map((r) => r.token)
-          .join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(text, equals('Hello world'));
     });
@@ -196,10 +193,7 @@ void main() {
         fileType: ModelFileType.litertlm,
       ).toList();
 
-      final text = results
-          .whereType<TextResponse>()
-          .map((r) => r.token)
-          .join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(text, equals('Hi'));
     });
@@ -221,10 +215,7 @@ void main() {
         fileType: ModelFileType.litertlm,
       ).toList();
 
-      final text = results
-          .whereType<TextResponse>()
-          .map((r) => r.token)
-          .join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(text, equals('Text<end_other>'));
     });
@@ -244,10 +235,7 @@ void main() {
         fileType: ModelFileType.litertlm,
       ).toList();
 
-      final text = results
-          .whereType<TextResponse>()
-          .map((r) => r.token)
-          .join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       expect(text, equals('Answer is 42'));
     });
@@ -267,10 +255,7 @@ void main() {
         fileType: ModelFileType.litertlm,
       ).toList();
 
-      final text = results
-          .whereType<TextResponse>()
-          .map((r) => r.token)
-          .join();
+      final text = results.whereType<TextResponse>().map((r) => r.token).join();
 
       // Should stop at first <end_of_turn>
       expect(text, equals('First'));

--- a/test/core/model_management/types/model_spec_test.dart
+++ b/test/core/model_management/types/model_spec_test.dart
@@ -36,7 +36,8 @@ void main() {
       test('extracts filename from URL correctly', () {
         final spec = InferenceModelSpec.fromLegacyUrl(
           name: 'test_model',
-          modelUrl: 'https://huggingface.co/models/complex-path/model.bin?token=abc',
+          modelUrl:
+              'https://huggingface.co/models/complex-path/model.bin?token=abc',
         );
 
         // Test via files list instead of deprecated getter

--- a/test/core/model_management/utils/file_system_manager_test.dart
+++ b/test/core/model_management/utils/file_system_manager_test.dart
@@ -10,7 +10,8 @@ void main() {
         const androidPath = '/data/user/0/com.example.app/files';
         const filename = 'model.bin';
 
-        final corrected = ModelFileSystemManager.getCorrectedPath(androidPath, filename);
+        final corrected =
+            ModelFileSystemManager.getCorrectedPath(androidPath, filename);
         expect(corrected, '/data/data/com.example.app/files/model.bin');
       });
 
@@ -18,22 +19,27 @@ void main() {
         const normalPath = '/data/data/com.example.app/files';
         const filename = 'model.bin';
 
-        final result = ModelFileSystemManager.getCorrectedPath(normalPath, filename);
+        final result =
+            ModelFileSystemManager.getCorrectedPath(normalPath, filename);
         expect(result, '/data/data/com.example.app/files/model.bin');
       });
 
       test('handles iOS paths correctly', () {
-        const iosPath = '/var/mobile/Containers/Data/Application/ABC123/Documents';
+        const iosPath =
+            '/var/mobile/Containers/Data/Application/ABC123/Documents';
         const filename = 'model.bin';
 
-        final result = ModelFileSystemManager.getCorrectedPath(iosPath, filename);
-        expect(result, '/var/mobile/Containers/Data/Application/ABC123/Documents/model.bin');
+        final result =
+            ModelFileSystemManager.getCorrectedPath(iosPath, filename);
+        expect(result,
+            '/var/mobile/Containers/Data/Application/ABC123/Documents/model.bin');
       });
     });
 
     group('isFileValid', () {
       test('rejects non-existent files', () async {
-        final result = await ModelFileSystemManager.isFileValid('/nonexistent/file.bin');
+        final result =
+            await ModelFileSystemManager.isFileValid('/nonexistent/file.bin');
         expect(result, false);
       });
 
@@ -54,7 +60,8 @@ void main() {
         // Create a file that meets custom size requirement
         final tempDir = Directory.systemTemp.createTempSync();
         final validFile = File('${tempDir.path}/valid.json');
-        await validFile.writeAsString('{"valid": "json content"}'); // Small but valid for JSON
+        await validFile.writeAsString(
+            '{"valid": "json content"}'); // Small but valid for JSON
 
         final result = await ModelFileSystemManager.isFileValid(
           validFile.path,
@@ -100,7 +107,8 @@ void main() {
         final tokenizerFile = File('${tempDir.path}/tokenizer.json');
 
         await modelFile.writeAsBytes(List.filled(2 * 1024 * 1024, 0)); // 2MB
-        await tokenizerFile.writeAsString('{"tokenizer": "config"}'); // Valid JSON
+        await tokenizerFile
+            .writeAsString('{"tokenizer": "config"}'); // Valid JSON
 
         // This test would need to mock getModelFilePath to return our temp files
         // For now, it just tests that the method exists and can be called

--- a/test/core/system_instruction_test.dart
+++ b/test/core/system_instruction_test.dart
@@ -53,10 +53,12 @@ void main() {
     late _SessionWithInstruction session;
 
     setUp(() {
-      session = _SessionWithInstruction(systemInstruction: 'You are a helpful pirate.');
+      session = _SessionWithInstruction(
+          systemInstruction: 'You are a helpful pirate.');
     });
 
-    test('prepends system instruction to first user message for .task fileType', () async {
+    test('prepends system instruction to first user message for .task fileType',
+        () async {
       final chat = InferenceChat(
         sessionCreator: () async => session,
         maxTokens: 1024,
@@ -68,7 +70,8 @@ void main() {
       await chat.addQueryChunk(const Message(text: 'Hello', isUser: true));
 
       expect(session.addedMessages.length, 1);
-      expect(session.addedMessages.first.text, contains('[System: You are a helpful pirate.]'));
+      expect(session.addedMessages.first.text,
+          contains('[System: You are a helpful pirate.]'));
       expect(session.addedMessages.first.text, contains('Hello'));
     });
 
@@ -82,7 +85,8 @@ void main() {
       );
       await chat.initSession();
 
-      await chat.addQueryChunk(const Message(text: 'Some response', isUser: false));
+      await chat
+          .addQueryChunk(const Message(text: 'Some response', isUser: false));
 
       expect(s.addedMessages.length, 1);
       expect(s.addedMessages.first.text, 'Some response');
@@ -139,7 +143,8 @@ void main() {
       late _SessionWithInstruction currentSession;
       final chat = InferenceChat(
         sessionCreator: () async {
-          currentSession = _SessionWithInstruction(systemInstruction: 'Be brief.');
+          currentSession =
+              _SessionWithInstruction(systemInstruction: 'Be brief.');
           return currentSession;
         },
         maxTokens: 1024,
@@ -149,12 +154,15 @@ void main() {
       await chat.initSession();
 
       await chat.addQueryChunk(const Message(text: 'First', isUser: true));
-      expect(currentSession.addedMessages.last.text, contains('[System: Be brief.]'));
+      expect(currentSession.addedMessages.last.text,
+          contains('[System: Be brief.]'));
 
       await chat.clearHistory();
 
-      await chat.addQueryChunk(const Message(text: 'After clear', isUser: true));
-      expect(currentSession.addedMessages.last.text, contains('[System: Be brief.]'));
+      await chat
+          .addQueryChunk(const Message(text: 'After clear', isUser: true));
+      expect(currentSession.addedMessages.last.text,
+          contains('[System: Be brief.]'));
       expect(currentSession.addedMessages.last.text, contains('After clear'));
     });
 
@@ -189,7 +197,8 @@ void main() {
     // In unit tests (which run on host), defaultTargetPlatform varies,
     // so we test .binary as a guaranteed-prepend fileType.
     test('prepends for .binary fileType (always MediaPipe fallback)', () async {
-      final s = _SessionWithInstruction(systemInstruction: 'Respond in French.');
+      final s =
+          _SessionWithInstruction(systemInstruction: 'Respond in French.');
       final chat = InferenceChat(
         sessionCreator: () async => s,
         maxTokens: 1024,
@@ -200,7 +209,8 @@ void main() {
 
       await chat.addQueryChunk(const Message(text: 'Hello', isUser: true));
 
-      expect(s.addedMessages.first.text, contains('[System: Respond in French.]'));
+      expect(
+          s.addedMessages.first.text, contains('[System: Respond in French.]'));
     });
   });
 
@@ -223,7 +233,8 @@ void main() {
         systemInstruction: 'Be concise.',
       );
 
-      await session.addQueryChunk(const Message(text: 'Model response', isUser: false));
+      await session
+          .addQueryChunk(const Message(text: 'Model response', isUser: false));
 
       expect(session.addedMessages.length, 1);
       expect(session.addedMessages.first.text, 'Model response');

--- a/test/core/utils/gemma_log_test.dart
+++ b/test/core/utils/gemma_log_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
+
+void main() {
+  group('sanitizeForLog', () {
+    test('replaces a lone U+FFFD with literal text', () {
+      expect(sanitizeForLog('a�b'), 'aU+FFFDb');
+    });
+
+    test('replaces every U+FFFD occurrence', () {
+      expect(sanitizeForLog('��'), 'U+FFFDU+FFFD');
+    });
+
+    test('leaves ordinary text untouched', () {
+      const s = 'The UTF-8 replacement character is...';
+      expect(sanitizeForLog(s), s);
+    });
+
+    test('leaves valid emoji / multi-byte text untouched', () {
+      const s = 'привет 🚀 你好';
+      expect(sanitizeForLog(s), s);
+    });
+
+    test('handles empty string', () {
+      expect(sanitizeForLog(''), '');
+    });
+
+    test('replaces a lone HIGH surrogate at end of string', () {
+      final lone = String.fromCharCode(0xD83D);
+      expect(sanitizeForLog('ab$lone'), 'abU+FFFD');
+    });
+
+    test('replaces a lone LOW surrogate', () {
+      final lone = String.fromCharCode(0xDE80);
+      expect(sanitizeForLog('${lone}x'), 'U+FFFDx');
+    });
+
+    test('keeps a valid surrogate pair', () {
+      const rocket = '🚀';
+      expect(sanitizeForLog('go $rocket now'), 'go 🚀 now');
+    });
+
+    test('matches the exact bytes from the #306 repro', () {
+      expect(sanitizeForLog('�** ('), 'U+FFFD** (');
+    });
+  });
+}

--- a/test/core/utils/gemma_log_test.dart
+++ b/test/core/utils/gemma_log_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
 
 void main() {
   group('sanitizeForLog', () {
@@ -93,6 +94,21 @@ void main() {
       gemmaLogLevel = GemmaLogLevel.verbose;
       gemmaLog('tok: �', level: GemmaLogLevel.verbose);
       expect(printed, ['tok: U+FFFD']);
+    });
+  });
+
+  group('FlutterGemma.logLevel facade', () {
+    final defaultLevel = gemmaLogLevel;
+    tearDown(() => gemmaLogLevel = defaultLevel);
+
+    test('setter updates the top-level gemmaLogLevel', () {
+      FlutterGemma.logLevel = GemmaLogLevel.none;
+      expect(gemmaLogLevel, GemmaLogLevel.none);
+    });
+
+    test('getter reflects the top-level gemmaLogLevel', () {
+      gemmaLogLevel = GemmaLogLevel.verbose;
+      expect(FlutterGemma.logLevel, GemmaLogLevel.verbose);
     });
   });
 }

--- a/test/core/utils/gemma_log_test.dart
+++ b/test/core/utils/gemma_log_test.dart
@@ -4,6 +4,14 @@ import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 
 void main() {
+  group('GemmaLogLevel ordering invariant', () {
+    test('severity order is none < info < verbose (gemmaLog filters on .index)',
+        () {
+      expect(GemmaLogLevel.none.index, lessThan(GemmaLogLevel.info.index));
+      expect(GemmaLogLevel.info.index, lessThan(GemmaLogLevel.verbose.index));
+    });
+  });
+
   group('sanitizeForLog', () {
     test('replaces a lone U+FFFD with literal text', () {
       expect(sanitizeForLog('a�b'), 'aU+FFFDb');

--- a/test/core/utils/gemma_log_test.dart
+++ b/test/core/utils/gemma_log_test.dart
@@ -45,4 +45,54 @@ void main() {
       expect(sanitizeForLog('�** ('), 'U+FFFD** (');
     });
   });
+
+  group('gemmaLog level filtering', () {
+    late List<String?> printed;
+    late DebugPrintCallback original;
+    final defaultLevel = gemmaLogLevel;
+
+    setUp(() {
+      printed = <String?>[];
+      original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) => printed.add(message);
+    });
+
+    tearDown(() {
+      debugPrint = original;
+      gemmaLogLevel = defaultLevel;
+    });
+
+    test('verbose level prints both info and verbose', () {
+      gemmaLogLevel = GemmaLogLevel.verbose;
+      gemmaLog('i', level: GemmaLogLevel.info);
+      gemmaLog('v', level: GemmaLogLevel.verbose);
+      expect(printed, ['i', 'v']);
+    });
+
+    test('info level prints info but filters verbose', () {
+      gemmaLogLevel = GemmaLogLevel.info;
+      gemmaLog('i', level: GemmaLogLevel.info);
+      gemmaLog('v', level: GemmaLogLevel.verbose);
+      expect(printed, ['i']);
+    });
+
+    test('none level prints nothing', () {
+      gemmaLogLevel = GemmaLogLevel.none;
+      gemmaLog('i', level: GemmaLogLevel.info);
+      gemmaLog('v', level: GemmaLogLevel.verbose);
+      expect(printed, isEmpty);
+    });
+
+    test('default level argument is info', () {
+      gemmaLogLevel = GemmaLogLevel.info;
+      gemmaLog('default');
+      expect(printed, ['default']);
+    });
+
+    test('sanitizes U+FFFD before printing', () {
+      gemmaLogLevel = GemmaLogLevel.verbose;
+      gemmaLog('tok: �', level: GemmaLogLevel.verbose);
+      expect(printed, ['tok: U+FFFD']);
+    });
+  });
 }

--- a/test/desktop_vision_params_test.dart
+++ b/test/desktop_vision_params_test.dart
@@ -27,7 +27,8 @@ void main() {
       expect(true, isTrue);
     });
 
-    test('FlutterGemmaDesktop.createModel passes enableVision to grpcClient', () {
+    test('FlutterGemmaDesktop.createModel passes enableVision to grpcClient',
+        () {
       // flutter_gemma_desktop.dart line 152:
       // enableVision: supportImage,
       //
@@ -35,7 +36,8 @@ void main() {
       expect(true, isTrue);
     });
 
-    test('FlutterGemmaDesktop.createModel passes enableAudio to grpcClient', () {
+    test('FlutterGemmaDesktop.createModel passes enableAudio to grpcClient',
+        () {
       // flutter_gemma_desktop.dart line 153:
       // enableAudio: supportAudio,
       //
@@ -43,7 +45,8 @@ void main() {
       expect(true, isTrue);
     });
 
-    test('FlutterGemmaDesktop.createModel passes maxNumImages to grpcClient', () {
+    test('FlutterGemmaDesktop.createModel passes maxNumImages to grpcClient',
+        () {
       // flutter_gemma_desktop.dart line 151:
       // maxNumImages: supportImage ? (maxNumImages ?? 1) : 1,
       //

--- a/test/error_handling_test.dart
+++ b/test/error_handling_test.dart
@@ -86,7 +86,8 @@ void main() {
     });
 
     test('toTitle returns short error titles', () {
-      expect(const DownloadError.unauthorized().toTitle(), 'Authentication Required');
+      expect(const DownloadError.unauthorized().toTitle(),
+          'Authentication Required');
       expect(const DownloadError.forbidden().toTitle(), 'Access Forbidden');
       expect(const DownloadError.notFound().toTitle(), 'Model Not Found');
       expect(const DownloadError.rateLimited().toTitle(), 'Rate Limited');

--- a/test/error_retry_test.dart
+++ b/test/error_retry_test.dart
@@ -8,14 +8,16 @@ void main() {
       const error = DownloadError.unauthorized();
 
       expect(error.isRetryable, isFalse, reason: '401 should NOT be retryable');
-      expect(error.requiresUserAction, isTrue, reason: '401 requires user to add token');
+      expect(error.requiresUserAction, isTrue,
+          reason: '401 requires user to add token');
     });
 
     test('403 ForbiddenError is NOT retryable', () {
       const error = DownloadError.forbidden();
 
       expect(error.isRetryable, isFalse, reason: '403 should NOT be retryable');
-      expect(error.requiresUserAction, isTrue, reason: '403 requires user action');
+      expect(error.requiresUserAction, isTrue,
+          reason: '403 requires user action');
     });
 
     test('404 NotFoundError is NOT retryable', () {
@@ -128,7 +130,8 @@ void main() {
         expect(e.error, isA<NetworkError>());
       }
 
-      expect(attempts, equals(maxRetries), reason: 'Should retry max times for network errors');
+      expect(attempts, equals(maxRetries),
+          reason: 'Should retry max times for network errors');
     });
   });
 }

--- a/test/flutter_gemma_method_channel_test.dart
+++ b/test/flutter_gemma_method_channel_test.dart
@@ -20,7 +20,8 @@ void main() {
     // Mock PathProvider
     PathProviderPlatform.instance = MockPathProviderPlatform();
 
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
         return 'response';

--- a/test/function_gemma_parser_test.dart
+++ b/test/function_gemma_parser_test.dart
@@ -5,9 +5,11 @@ import 'package:flutter_gemma/core/model.dart';
 void main() {
   group('FunctionGemma Parser', () {
     test('parses function call with single parameter', () {
-      const input = '<start_function_call>call:get_weather{location:<escape>San Francisco<escape>}<end_function_call>';
+      const input =
+          '<start_function_call>call:get_weather{location:<escape>San Francisco<escape>}<end_function_call>';
 
-      final result = FunctionCallParser.parse(input, modelType: ModelType.functionGemma);
+      final result =
+          FunctionCallParser.parse(input, modelType: ModelType.functionGemma);
 
       expect(result, isNotNull);
       expect(result!.name, equals('get_weather'));
@@ -15,9 +17,11 @@ void main() {
     });
 
     test('parses function call with multiple parameters', () {
-      const input = '<start_function_call>call:get_weather{location:<escape>Tokyo<escape>,unit:<escape>celsius<escape>}<end_function_call>';
+      const input =
+          '<start_function_call>call:get_weather{location:<escape>Tokyo<escape>,unit:<escape>celsius<escape>}<end_function_call>';
 
-      final result = FunctionCallParser.parse(input, modelType: ModelType.functionGemma);
+      final result =
+          FunctionCallParser.parse(input, modelType: ModelType.functionGemma);
 
       expect(result, isNotNull);
       expect(result!.name, equals('get_weather'));
@@ -28,7 +32,8 @@ void main() {
     test('returns null for invalid format', () {
       const input = 'Just some regular text';
 
-      final result = FunctionCallParser.parse(input, modelType: ModelType.functionGemma);
+      final result =
+          FunctionCallParser.parse(input, modelType: ModelType.functionGemma);
 
       expect(result, isNull);
     });
@@ -80,9 +85,11 @@ void main() {
 
   group('JSON Parser (existing models)', () {
     test('still works for gemmaIt', () {
-      const input = '<tool_code>{"name": "get_weather", "parameters": {"location": "NYC"}}</tool_code>';
+      const input =
+          '<tool_code>{"name": "get_weather", "parameters": {"location": "NYC"}}</tool_code>';
 
-      final result = FunctionCallParser.parse(input, modelType: ModelType.gemmaIt);
+      final result =
+          FunctionCallParser.parse(input, modelType: ModelType.gemmaIt);
 
       expect(result, isNotNull);
       expect(result!.name, equals('get_weather'));

--- a/test/gemma4_extract_tool_calls_test.dart
+++ b/test/gemma4_extract_tool_calls_test.dart
@@ -29,11 +29,17 @@ void main() {
         'tool_calls': [
           {
             'type': 'function',
-            'function': {'name': 'first', 'arguments': {'a': 1}},
+            'function': {
+              'name': 'first',
+              'arguments': {'a': 1}
+            },
           },
           {
             'type': 'function',
-            'function': {'name': 'second', 'arguments': {'b': 2}},
+            'function': {
+              'name': 'second',
+              'arguments': {'b': 2}
+            },
           },
         ],
       });
@@ -111,7 +117,8 @@ void main() {
       final calls = SdkResponseParser.extractToolCalls(raw);
       expect(calls, hasLength(1));
       expect(calls.first.args['tags'], equals(['red', 'blue']));
-      expect(calls.first.args['meta'], equals({'note': 'important', 'count': 7}));
+      expect(
+          calls.first.args['meta'], equals({'note': 'important', 'count': 7}));
     });
   });
 

--- a/test/gemma4_passthrough_format_test.dart
+++ b/test/gemma4_passthrough_format_test.dart
@@ -16,7 +16,8 @@ void main() {
       // function call here: SDK produces structured tool_calls separately.
       expect(format.isFunctionCallStart('<|tool_call>call:foo{}<tool_call|>'),
           isFalse);
-      expect(format.isFunctionCallComplete('<|tool_call>call:foo{}<tool_call|>'),
+      expect(
+          format.isFunctionCallComplete('<|tool_call>call:foo{}<tool_call|>'),
           isFalse);
       expect(format.isDefinitelyText('any plain text'), isTrue);
       expect(format.parse('<|tool_call>call:foo{}<tool_call|>'), isNull);

--- a/test/hnsw_index_test.dart
+++ b/test/hnsw_index_test.dart
@@ -98,7 +98,8 @@ void main() {
 
         // Verify results are sorted
         for (int i = 1; i < results.length; i++) {
-          expect(results[i].similarity, lessThanOrEqualTo(results[i - 1].similarity));
+          expect(results[i].similarity,
+              lessThanOrEqualTo(results[i - 1].similarity));
         }
       });
 

--- a/test/image_corruption_fix_test.dart
+++ b/test/image_corruption_fix_test.dart
@@ -110,7 +110,8 @@ void main() {
     test('MultimodalImageHandler can process without validation', () async {
       // Test with validation disabled to avoid image processing issues
       final result = await MultimodalImageHandler.processImageForAI(
-        imageBytes: Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]), // Minimal PNG signature
+        imageBytes: Uint8List.fromList(
+            [0x89, 0x50, 0x4E, 0x47]), // Minimal PNG signature
         modelType: ModelType.gemmaIt,
         enableValidation: false,
         enableProcessing: false,
@@ -121,11 +122,13 @@ void main() {
       expect(result.validationPassed, isFalse);
     });
 
-    test('MultimodalImageHandler handles processing errors gracefully', () async {
+    test('MultimodalImageHandler handles processing errors gracefully',
+        () async {
       // Test error handling with invalid image data
       try {
         final result = await MultimodalImageHandler.processImageForAI(
-          imageBytes: Uint8List.fromList([0x00, 0x01, 0x02]), // Invalid image data
+          imageBytes:
+              Uint8List.fromList([0x00, 0x01, 0x02]), // Invalid image data
           modelType: ModelType.gemmaIt,
           enableValidation: false,
           enableProcessing: true,
@@ -176,7 +179,8 @@ void main() {
       );
 
       // Test normal response
-      const normalResponse = 'This image shows a beautiful landscape with mountains.';
+      const normalResponse =
+          'This image shows a beautiful landscape with mountains.';
       final validation = MultimodalImageHandler.validateModelResponse(
         normalResponse,
         originalPrompt: 'Describe this image',
@@ -187,8 +191,10 @@ void main() {
       // BUG in MultimodalImageHandler.validateModelResponse lines 210-217:
       // Returns wrong values for successful validation (isValid: false, isCorrupted: true)
       expect(validation.isValid, isTrue); // Should be true for normal response
-      expect(validation.isCorrupted, isFalse); // Should be false for normal response
-      expect(validation.confidence, lessThan(0.5)); // Should be low confidence for no corruption
+      expect(validation.isCorrupted,
+          isFalse); // Should be false for normal response
+      expect(validation.confidence,
+          lessThan(0.5)); // Should be low confidence for no corruption
     });
   });
 }

--- a/test/mobile/model_manager_init_race_test.dart
+++ b/test/mobile/model_manager_init_race_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 
 /// Regression coverage for issue #314 — the model manager set
@@ -53,6 +51,31 @@ class FixedManager {
   }
 }
 
+/// Degrading guard: mirrors the production `_doInit` best-effort restore —
+/// a restore failure is swallowed so init completes normally with no active
+/// model, instead of throwing and blocking app startup. (#314 follow-up)
+class DegradingManager {
+  Future<void>? _initFuture;
+  String? active;
+  int restoreCount = 0;
+
+  Future<void> initialize() => _initFuture ??= _doInit();
+
+  Future<void> _doInit() async {
+    try {
+      await _restore();
+    } catch (_) {
+      // best-effort: start with no active model
+    }
+  }
+
+  Future<void> _restore() async {
+    restoreCount++;
+    await Future<void>.delayed(Duration.zero);
+    throw StateError('prefs unreadable');
+  }
+}
+
 void main() {
   group('Issue #314 — init race (bug)', () {
     test('BUG: concurrent initialize() lets a caller proceed before restore',
@@ -83,6 +106,25 @@ void main() {
       await m.initialize();
       await m.initialize();
       expect(m.restoreCount, 1);
+    });
+  });
+
+  group('Issue #314 follow-up — restore failure degrades', () {
+    test('init completes normally when restore throws (no active model)',
+        () async {
+      final m = DegradingManager();
+      await m.initialize(); // must NOT throw
+      expect(m.active, isNull,
+          reason: 'degraded: restore failed → no active model');
+    });
+
+    test('a failed restore is still single-flight (not retried per call)',
+        () async {
+      final m = DegradingManager();
+      await m.initialize();
+      await m.initialize();
+      expect(m.restoreCount, 1,
+          reason: 'cached future: degraded init is not re-run');
     });
   });
 }

--- a/test/mobile/model_manager_init_race_test.dart
+++ b/test/mobile/model_manager_init_race_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression coverage for issue #314 — the model manager set
+/// `_isInitialized = true` synchronously BEFORE awaiting the async restore,
+/// so a concurrent second `initialize()` returned before the first finished
+/// restoring the active model, and `getActiveModel()` then saw a null active
+/// spec and threw StateError.
+/// https://github.com/DenisovAV/flutter_gemma/issues/314
+///
+/// Distilled Buggy/Fixed pair (mirrors model_creation_failure_test.dart):
+/// `_restore()` is an async step that sets `active` only after an await; the
+/// guard must not report "initialized" until that completes.
+
+/// Buggy guard: flag flipped before the async restore — concurrent callers
+/// skip the in-flight restore.
+class BuggyManager {
+  bool _isInitialized = false;
+  String? active;
+  int restoreCount = 0;
+
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    _isInitialized = true; // BUG: set before await
+    await _restore();
+  }
+
+  Future<void> _restore() async {
+    restoreCount++;
+    await Future<void>.delayed(Duration.zero); // simulate async prefs read
+    active = 'model-a';
+  }
+}
+
+/// Fixed guard: cached future — concurrent callers share the one init and all
+/// await the same completed restore.
+class FixedManager {
+  Future<void>? _initFuture;
+  String? active;
+  int restoreCount = 0;
+
+  Future<void> initialize() => _initFuture ??= _doInit();
+
+  Future<void> _doInit() async {
+    await _restore();
+  }
+
+  Future<void> _restore() async {
+    restoreCount++;
+    await Future<void>.delayed(Duration.zero);
+    active = 'model-a';
+  }
+}
+
+void main() {
+  group('Issue #314 — init race (bug)', () {
+    test('BUG: concurrent initialize() lets a caller proceed before restore',
+        () async {
+      final m = BuggyManager();
+      final first = m.initialize();
+      await m.initialize();
+      expect(m.active, isNull,
+          reason: 'BUG: 2nd caller returned before restore set active');
+      await first;
+      expect(m.active, 'model-a');
+    });
+  });
+
+  group('Issue #314 — init race (fix)', () {
+    test('FIX: concurrent initialize() all await one completed restore',
+        () async {
+      final m = FixedManager();
+      await Future.wait([m.initialize(), m.initialize(), m.initialize()]);
+      expect(m.active, 'model-a',
+          reason: 'FIX: every caller observes the completed restore');
+      expect(m.restoreCount, 1,
+          reason: 'FIX: single-flight — restore runs exactly once');
+    });
+
+    test('FIX: a later initialize() after completion is a no-op', () async {
+      final m = FixedManager();
+      await m.initialize();
+      await m.initialize();
+      expect(m.restoreCount, 1);
+    });
+  });
+}

--- a/test/vector_store_parity_test.dart
+++ b/test/vector_store_parity_test.dart
@@ -254,8 +254,8 @@ void main() {
         final id = 'doc$i';
         // Create embeddings with varying similarity to [1, 0, 0]
         final embedding = [
-          1.0 - i * 0.05,  // First component decreases
-          i * 0.05,        // Second component increases
+          1.0 - i * 0.05, // First component decreases
+          i * 0.05, // Second component increases
           0.0,
         ];
         embeddings[id] = embedding;
@@ -295,9 +295,9 @@ void main() {
       final index = HnswVectorIndex();
 
       // Add documents
-      index.add('high', [1.0, 0.0, 0.0]);     // sim = 1.0
-      index.add('medium', [0.7, 0.7, 0.0]);   // sim ~= 0.707
-      index.add('low', [0.0, 1.0, 0.0]);      // sim = 0.0
+      index.add('high', [1.0, 0.0, 0.0]); // sim = 1.0
+      index.add('medium', [0.7, 0.7, 0.0]); // sim ~= 0.707
+      index.add('low', [0.0, 1.0, 0.0]); // sim = 0.0
 
       final query = [1.0, 0.0, 0.0];
       final threshold = 0.5;
@@ -321,10 +321,10 @@ void main() {
 
       // Add documents with clear ranking
       final embeddings = {
-        'first': [1.0, 0.0, 0.0],    // Exact match
+        'first': [1.0, 0.0, 0.0], // Exact match
         'second': [0.95, 0.05, 0.0], // Very similar
-        'third': [0.8, 0.2, 0.0],    // Less similar
-        'fourth': [0.5, 0.5, 0.0],   // Even less similar
+        'third': [0.8, 0.2, 0.0], // Less similar
+        'fourth': [0.5, 0.5, 0.0], // Even less similar
       };
 
       for (final entry in embeddings.entries) {
@@ -339,7 +339,8 @@ void main() {
 
       // Verify all similarities are in descending order
       for (int i = 1; i < results.length; i++) {
-        expect(results[i].similarity, lessThanOrEqualTo(results[i - 1].similarity),
+        expect(
+            results[i].similarity, lessThanOrEqualTo(results[i - 1].similarity),
             reason: 'Results should be sorted by similarity descending');
       }
     });
@@ -403,4 +404,3 @@ double cosineSimilarity(List<double> a, List<double> b) {
 
   return dotProduct / (sqrt(normA) * sqrt(normB));
 }
-


### PR DESCRIPTION
## 0.16.5

### Logging system (#306)
- New `gemmaLog()` / `GemmaLogLevel` / `FlutterGemma.logLevel` — replaces `debugPrint` across `lib/`.
- Silent in release (`kDebugMode`-gated), U+FFFD-sanitized, model output/prompts demoted to `verbose` (no PII in logcat by default).
- `gemmaLogLevel` propagated into spawned isolates (embedding worker + FFI engine-create).

### Fixes merged from main
- **#308** — KV-cache bleed between sequential chats: each `createSession` opens a fresh native session + conversation handle.
- **#314** — `getActiveModel()` StateError on startup: single-flight manager init, awaited in `initialize()`.
- **#286** — App Store ITMS-90208: qdrant-edge iOS dylib minos 13.0 (0.7.2).
- **#303** — function calling enabled for Gemma 4 E2B/E4B in example.

### Review follow-up (this branch)
- Web image `data:` URL logged at `verbose`, not `info` (PII contract).
- Active-model restore failure **degrades** to no-active-model instead of throwing — startup never blocked (mobile + web).
- Multimodal image conversion **throws** instead of silently dropping the image.
- Gated-model restore surfaces a clear re-auth warning (public-model fallback preserved).
- Removed dead `ImageTokenizer.createFallbackPrompt` (legacy silent fallback).
- FFI engine-create timing logs via `gemmaLog(verbose)`, no raw `print()`.

### Verification
- `flutter analyze` clean, `flutter test` 421/421, `flutter build web` OK.
- Reviewed by 10-agent review + Copilot second opinion + focused final review (0 critical / 0 important).
