### PR TITLE
Release 1.0.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -180,6 +180,40 @@ for f in "$DIST"/litertlm-*.tar.gz; do
 done
 ```
 
+### ⛔ Three-way checksum consistency — MANDATORY (regression: #316)
+
+`checksums_litertlm.txt` is informational (the build hook does NOT read it —
+it verifies against the `_checksums` map baked into
+`packages/flutter_gemma_litertlm/hook/build.dart`). But a STALE txt is
+dangerous: in #316 a user (`@remingtonc`) hand-verified against the txt during a
+checksum-mismatch debug, the txt said `e24804d9…` while the actual asset was
+`f809c5a2…`, and it sent them down the wrong path. **For every tag you touch,
+the same SHA must appear in all THREE places** — the uploaded `.tar.gz`,
+`checksums_litertlm.txt` on the Release, and the hook's `_checksums` entry.
+Verify after upload:
+
+```bash
+HOOK=packages/flutter_gemma_litertlm/hook/build.dart
+for f in "$DIST"/litertlm-*.tar.gz; do
+  name=$(basename "$f")
+  # 1. actual asset bytes served by GitHub
+  asset=$(curl -sL "https://github.com/DenisovAV/flutter_gemma/releases/download/$RELEASE/$name" | shasum -a 256 | awk '{print $1}')
+  # 2. what checksums_litertlm.txt on the Release claims
+  txt=$(curl -sL "https://github.com/DenisovAV/flutter_gemma/releases/download/$RELEASE/checksums_litertlm.txt" | awk -v n="$name" '$2==n{print $1}')
+  # 3. what the hook expects
+  hook=$(grep -A1 "'$name'" "$HOOK" | grep -oE "[0-9a-f]{64}" | head -1)
+  echo "$name:"
+  echo "  asset=$asset"
+  echo "  txt  =$txt   $([ "$asset" = "$txt" ] && echo OK || echo '❌ STALE TXT')"
+  echo "  hook =$hook   $([ "$asset" = "$hook" ] && echo OK || echo '❌ HOOK MISMATCH — users will fail to build')"
+done
+```
+All three must match for every platform you re-uploaded. If you re-uploaded a
+`.tar.gz` you MUST also re-upload a fresh `checksums_litertlm.txt` in the same
+`gh release upload --clobber` — never one without the other. (#316 is what a
+stale released tag looks like in the wild — see the ⛔ "NEVER overwrite a tag
+referenced by a published plugin version" rule above.)
+
 ## Step 7: Update CHANGELOG.md
 
 Add new section at top. Categories: **App Store / packaging fixes**, **Features**, **Bug fixes**, **Breaking changes**, **Native runtime updates** (if `_nativeVersion` bumped). Reference issue / PR numbers (`#245`, `#239`).

--- a/.github/workflows/build-litertlm-native-windows.yml
+++ b/.github/workflows/build-litertlm-native-windows.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build StreamProxy.dll
         run: |
-          cl /LD /Fe:StreamProxy.dll packages\flutter_gemma\native\litert_lm\stream_proxy.c
+          cl /LD /Fe:StreamProxy.dll packages\flutter_gemma_litertlm\native\litert_lm\stream_proxy.c
 
       - name: Download DirectXShaderCompiler runtime
         run: |

--- a/.github/workflows/build-litertlm-native-windows.yml
+++ b/.github/workflows/build-litertlm-native-windows.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Patch C API
         shell: bash
-        run: bash packages/flutter_gemma/native/litert_lm/patch_c_api.sh C:/LiteRT-LM
+        run: bash packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh C:/LiteRT-LM
 
       - name: Build LiteRtLm.dll
         run: |

--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Build StreamProxy.dll
         run: |
-          cl /LD /Fe:StreamProxy.dll packages\flutter_gemma\native\litert_lm\stream_proxy.c
+          cl /LD /Fe:StreamProxy.dll packages\flutter_gemma_litertlm\native\litert_lm\stream_proxy.c
 
       - name: Download DirectXShaderCompiler runtime
         # WebGPU/DX12 backend on Windows requires dxil.dll + dxcompiler.dll

--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -47,7 +47,7 @@ jobs:
           cd /tmp/LiteRT-LM && git checkout "$LITERTLM_VERSION" && git lfs pull --include="prebuilt/linux_x86_64/*"
 
       - name: Patch C API
-        run: bash packages/flutter_gemma/native/litert_lm/patch_c_api.sh /tmp/LiteRT-LM
+        run: bash packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh /tmp/LiteRT-LM
 
       - name: Build libLiteRtLm.so
         run: |
@@ -57,7 +57,7 @@ jobs:
       - name: Build libStreamProxy.so
         run: |
           gcc -shared -fPIC -o /tmp/libStreamProxy.so \
-            packages/flutter_gemma/native/litert_lm/stream_proxy.c
+            packages/flutter_gemma_litertlm/native/litert_lm/stream_proxy.c
 
       - name: Collect artifacts
         run: |
@@ -95,7 +95,7 @@ jobs:
           cd /tmp/LiteRT-LM && git checkout "$LITERTLM_VERSION" && git lfs pull --include="prebuilt/linux_arm64/*"
 
       - name: Patch C API
-        run: bash packages/flutter_gemma/native/litert_lm/patch_c_api.sh /tmp/LiteRT-LM
+        run: bash packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh /tmp/LiteRT-LM
 
       - name: Build libLiteRtLm.so
         run: |
@@ -105,7 +105,7 @@ jobs:
       - name: Build libStreamProxy.so
         run: |
           gcc -shared -fPIC -o /tmp/libStreamProxy.so \
-            packages/flutter_gemma/native/litert_lm/stream_proxy.c
+            packages/flutter_gemma_litertlm/native/litert_lm/stream_proxy.c
 
       - name: Collect artifacts
         run: |
@@ -146,7 +146,7 @@ jobs:
 
       - name: Patch C API
         shell: bash
-        run: bash packages/flutter_gemma/native/litert_lm/patch_c_api.sh C:/LiteRT-LM
+        run: bash packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh C:/LiteRT-LM
 
       - name: Build LiteRtLm.dll
         # litert_link_capi_so=true + resolve_symbols_in_exec=false is the same

--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -1,18 +1,16 @@
 name: Build LiteRT-LM Native Libraries
 
 on:
-  push:
-    branches:
-      - main
-      - 'release/**'
-    paths:
-      - '.github/workflows/build-litertlm-native.yml'
+  # Manual only. NO push trigger: this is an expensive multi-platform Bazel
+  # build that publishes native libs — auto-firing it on a branch push would
+  # rebuild with the DEFAULT litertlm_version (not the one you want), which is
+  # exactly how native-v0.13.1 once got the wrong Linux libs. Always dispatch
+  # with an explicit litertlm_version.
   workflow_dispatch:
     inputs:
       litertlm_version:
         description: 'LiteRT-LM ref (tag, branch, or commit SHA)'
         required: true
-        default: '032334d81ff96431492be272e536fbafe094b1e9'
       publish_release:
         description: 'Publish to GitHub Release'
         type: boolean
@@ -28,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +76,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 60
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +126,7 @@ jobs:
       run:
         shell: pwsh
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
       ANDROID_NDK_HOME: ''
       BAZEL_OUTPUT_BASE: 'D:\b'
     steps:
@@ -233,7 +231,7 @@ jobs:
     permissions:
       contents: write
     env:
-      LITERTLM_VERSION: ${{ inputs.litertlm_version || '032334d81ff96431492be272e536fbafe094b1e9' }}
+      LITERTLM_VERSION: ${{ inputs.litertlm_version }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0
+- Stable 1.0 of the modular package split (see 1.0.0-rc.1 below for full notes).
+- dart2wasm-clean public graph — `dart:io` is off the web/wasm import graph.
+- Dropped pigeon from core; value types are plain Dart in `core/domain/platform_types.dart`.
+- SDK floor raised to Dart 3.12 / Flutter 3.44; `large_file_handler` `^0.5.0`.
+
 ## 1.0.0-rc.1
 - **Modular package split**: core `flutter_gemma` + opt-in `flutter_gemma_litertlm` / `flutter_gemma_mediapipe` / `flutter_gemma_embeddings` / `flutter_gemma_rag_qdrant` / `flutter_gemma_rag_sqlite`.
 - **New `FlutterGemma.initialize(inferenceEngines:, embeddingBackends:, vectorStore:)`** — register the opt-in packages you added; core registers none by default.

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -14,7 +14,7 @@
 [Gemma](https://ai.google.dev/gemma) is a family of lightweight, state-of-the art open models built from the same research and technology used to create the Gemini models
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DenisovAV/flutter_gemma/main/assets/gemma3.png" alt="gemma_github_cover">
+  <img src="https://raw.githubusercontent.com/DenisovAV/flutter_gemma/main/packages/flutter_gemma/assets/gemma3.png" alt="gemma_github_cover">
 </p>
 
 Bring the power of Google's lightweight Gemma language models and other on-device LLMs directly to your Flutter applications. With Flutter Gemma, you can seamlessly incorporate advanced AI capabilities into your Flutter applications, all without relying on external servers.
@@ -22,7 +22,7 @@ Bring the power of Google's lightweight Gemma language models and other on-devic
 There is an example of using:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DenisovAV/flutter_gemma/main/assets/gemma.gif" alt="gemma_github_gif">
+  <img src="https://raw.githubusercontent.com/DenisovAV/flutter_gemma/main/packages/flutter_gemma/assets/gemma.gif" alt="gemma_github_gif">
 </p>
 
 ## Features

--- a/packages/flutter_gemma/example/pubspec.lock
+++ b/packages/flutter_gemma/example/pubspec.lock
@@ -209,42 +209,42 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.1"
+    version: "1.0.0"
   flutter_gemma_embeddings:
     dependency: "direct main"
     description:
       path: "../../flutter_gemma_embeddings"
       relative: true
     source: path
-    version: "1.0.0-rc.1"
+    version: "1.0.0"
   flutter_gemma_litertlm:
     dependency: "direct main"
     description:
       path: "../../flutter_gemma_litertlm"
       relative: true
     source: path
-    version: "1.0.0-rc.1"
+    version: "1.0.0"
   flutter_gemma_mediapipe:
     dependency: "direct main"
     description:
       path: "../../flutter_gemma_mediapipe"
       relative: true
     source: path
-    version: "1.0.0-rc.1"
+    version: "1.0.0"
   flutter_gemma_rag_qdrant:
     dependency: "direct main"
     description:
       path: "../../flutter_gemma_rag_qdrant"
       relative: true
     source: path
-    version: "1.0.0-rc.1"
+    version: "1.0.0"
   flutter_gemma_rag_sqlite:
     dependency: "direct main"
     description:
       path: "../../flutter_gemma_rag_sqlite"
       relative: true
     source: path
-    version: "1.0.0-rc.1"
+    version: "1.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.0.0-rc.1
+version: 1.0.0
 resolution: workspace
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma

--- a/packages/flutter_gemma_embeddings/CHANGELOG.md
+++ b/packages/flutter_gemma_embeddings/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+- Stable 1.0.0; spec imports redirected off the `dart:io` mobile lib for a wasm-clean web graph.
+
 ## 1.0.0-rc.1
 - Initial release: on-device text embeddings (Gecko / EmbeddingGemma `.tflite`) via the LiteRT C API + dart:ffi.
 - Provides `LiteRtEmbeddingBackend` (EmbeddingBackendProvider); forward pass runs on a background isolate.

--- a/packages/flutter_gemma_embeddings/hook/build.dart
+++ b/packages/flutter_gemma_embeddings/hook/build.dart
@@ -164,9 +164,9 @@ const _litertlmBundle = _NativeBundle(
   // 16KB page alignment (NDK r28). Built on native-v0.13.1 tag.
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
-        '7dd32e29e0d432372d6f8abeff04be07ab82c649d97225d051a698458d20e7e6',
+        '2c84bdacd4f367a631270a6b3f8ff87e2d11aa019d8e898a2361f40591667024',
     'litertlm-linux_arm64.tar.gz':
-        '6000cfaa7ba6a5939c15087164358ac462420f27cea41f971fdb67a41676f79b',
+        '79ec60b99076e53bd51e1be4bedeb45abb8d724d1bb45c8acc5c171cc4cde7bd',
     'litertlm-windows_x86_64.tar.gz':
         '466b8de4a78218f36fb616a563e7c1e47e7abd24489bfba47ac483bfdf13d63d',
     'litertlm-macos_arm64.tar.gz':

--- a/packages/flutter_gemma_embeddings/hook/build.dart
+++ b/packages/flutter_gemma_embeddings/hook/build.dart
@@ -148,7 +148,7 @@ class _NativeBundle {
 /// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
 const _litertlmBundle = _NativeBundle(
   namespace: 'litertlm',
-  version: '0.12.0-a',
+  version: '0.13.1',
   releaseTagPrefix: 'native-v',
   archivePrefix: 'litertlm',
   mainLibName: 'LiteRtLm',
@@ -159,21 +159,24 @@ const _litertlmBundle = _NativeBundle(
   // in a dedicated PR (tracked: roadmap entry in CHANGELOG for 0.16.0).
   useFlatLayout: true,
   markerFileName: '.flutter_gemma_native_version',
+  // 0.13.1: LiteRT-LM 0.13.1 (bundles LiteRT post-v2.1.5 main). Fixes the
+  // Gemma 4 E2B MTP/speculative-decoding crash (#318). Android .so rebuilt with
+  // 16KB page alignment (NDK r28). Built on native-v0.13.1 tag.
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
-        '930296b010ecc316c6b6fc4ed1c722b275b4064b59b5aad8ff7b858e9149c0d7',
+        '7dd32e29e0d432372d6f8abeff04be07ab82c649d97225d051a698458d20e7e6',
     'litertlm-linux_arm64.tar.gz':
-        '616b2e8cb9903bfd4ee54ca600a9a0cce38ddd16ed3e4b847a6d80e548b9aa60',
+        '6000cfaa7ba6a5939c15087164358ac462420f27cea41f971fdb67a41676f79b',
     'litertlm-windows_x86_64.tar.gz':
-        'b7264091c05001ef84e53761dfee331f761e3a2362b36b28ab2ce39666400d76',
+        '466b8de4a78218f36fb616a563e7c1e47e7abd24489bfba47ac483bfdf13d63d',
     'litertlm-macos_arm64.tar.gz':
-        'a616c6996853cf095fac8c19de1d4dbf9a7434437da7f9bcc167e0e840147e10',
+        '59d7f73d1cb4077ad82fefb0a8d2a506d8c89d61487a7981816dbffe8a3cbe2d',
     'litertlm-ios_arm64.tar.gz':
-        '88620e05382dcb1fdc5d2d985bfc9812f78f1422b4e9f3d1d8dfbafcf727c4ee',
+        'dce231a0c624e0f7e0287eb5e28a78d895f7af5dc0fa7399f89443ce54a5f44f',
     'litertlm-ios_sim_arm64.tar.gz':
-        '54e067fa11ad510280e01f90260e8bda13f905a27f00e7ebc2d7ef5847868bd1',
+        '08724bafac9381a9fde8658ce5a1137f1f5b966d82dd63e32b2e201d617c0b9d',
     'litertlm-android_arm64.tar.gz':
-        'f809c5a29867062cda74186c7ebebd500a2f36d0b6ad6f7ca8eab902af7fc784',
+        '3a976067216e3d3aa55858f4cc8ee10af813d808b6ab132dbd45d6db56fd3be8',
   },
   companions: [
     'GemmaModelConstraintProvider',
@@ -337,8 +340,8 @@ Directory _cacheBaseDir() {
 /// COMMIT POINT: call LAST, only after the dylib files are fully in place.
 void _writeMarker(_NativeBundle bundle) {
   bundle.markerFile().writeAsStringSync(
-        jsonEncode({'version': bundle.version, 'owner': _packageName}),
-      );
+    jsonEncode({'version': bundle.version, 'owner': _packageName}),
+  );
 }
 
 /// Wipe stale per-platform cached files when a bundle's version changes. Cheap
@@ -415,7 +418,11 @@ bool _hasMainLib(Directory dir, _NativeBundle bundle, OS os) {
 ///   2. cached `<cacheBase>/<bundle-namespace>/<dirName>/` from a previous
 ///      `_downloadAndExtract`.
 Directory? _resolveLibDir(
-    _NativeBundle bundle, String dirName, Uri packageRoot, OS os) {
+  _NativeBundle bundle,
+  String dirName,
+  Uri packageRoot,
+  OS os,
+) {
   // Local prebuilts use a per-bundle directory layout under `native/`.
   // LiteRT historically uses `native/litert_lm/prebuilt/`. For new bundles
   // we use `native/<namespace>/prebuilt/`.
@@ -436,7 +443,9 @@ Directory? _resolveLibDir(
 // ============================================================================
 
 Future<Directory?> _downloadAndExtract(
-    _NativeBundle bundle, String dirName) async {
+  _NativeBundle bundle,
+  String dirName,
+) async {
   final archiveName = bundle.archiveName(dirName);
   final expectedChecksum = bundle.checksums[archiveName];
   if (expectedChecksum == null) {
@@ -458,7 +467,8 @@ Future<Directory?> _downloadAndExtract(
 
     final url = '${bundle.releaseBase}/$archiveName';
     stderr.writeln(
-        'flutter_gemma: Downloading ${bundle.namespace} native libs from $url ...');
+      'flutter_gemma: Downloading ${bundle.namespace} native libs from $url ...',
+    );
 
     final client = HttpClient();
     try {
@@ -466,7 +476,8 @@ Future<Directory?> _downloadAndExtract(
       final response = await request.close();
       if (response.statusCode != 200) {
         stderr.writeln(
-            'flutter_gemma: Download failed (HTTP ${response.statusCode})');
+          'flutter_gemma: Download failed (HTTP ${response.statusCode})',
+        );
         return null;
       }
       final sink = archiveFile.openWrite();
@@ -493,13 +504,16 @@ Future<Directory?> _downloadAndExtract(
     if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
     tmpDir.createSync(recursive: true);
     try {
-      final result = await Process.run(
-        'tar',
-        ['-xzf', archiveFile.path, '-C', tmpDir.path],
-      );
+      final result = await Process.run('tar', [
+        '-xzf',
+        archiveFile.path,
+        '-C',
+        tmpDir.path,
+      ]);
       if (result.exitCode != 0) {
         stderr.writeln(
-            'flutter_gemma: ${bundle.namespace} extract failed: ${result.stderr}');
+          'flutter_gemma: ${bundle.namespace} extract failed: ${result.stderr}',
+        );
         return null;
       }
       if (targetDir.existsSync()) targetDir.deleteSync(recursive: true);
@@ -509,7 +523,8 @@ Future<Directory?> _downloadAndExtract(
     }
     archiveFile.deleteSync();
     stderr.writeln(
-        'flutter_gemma: ${bundle.namespace} libs cached to ${targetDir.path}');
+      'flutter_gemma: ${bundle.namespace} libs cached to ${targetDir.path}',
+    );
     return targetDir;
   } catch (e) {
     stderr.writeln('flutter_gemma: ${bundle.namespace} download failed: $e');

--- a/packages/flutter_gemma_embeddings/pubspec.yaml
+++ b/packages/flutter_gemma_embeddings/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_embeddings
 description: "On-device text embeddings (Gecko / EmbeddingGemma .tflite via LiteRT + dart:ffi) for flutter_gemma. Opt-in EmbeddingBackendProvider for on-device RAG."
-version: 1.0.0-rc.1
+version: 1.0.0
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_embeddings
 topics: [embeddings, gemma, litert, rag, on-device]
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^1.0.0-rc.1
+  flutter_gemma: ^1.0.0
   ffi: ^2.1.0
   hooks: ^1.0.0
   code_assets: ^1.0.0

--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+- Stable 1.0.0; spec imports redirected off the `dart:io` mobile lib for a wasm-clean web graph.
+
 ## 1.0.0-rc.1
 - Initial release: LiteRT-LM (`.litertlm`) on-device inference engine for flutter_gemma via dart:ffi.
 - Provides `LiteRtLmEngine` (InferenceEngineProvider). Owns the shared LiteRT-LM native library.

--- a/packages/flutter_gemma_litertlm/hook/build.dart
+++ b/packages/flutter_gemma_litertlm/hook/build.dart
@@ -164,9 +164,9 @@ const _litertlmBundle = _NativeBundle(
   // 16KB page alignment (NDK r28). Built on native-v0.13.1 tag.
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
-        '7dd32e29e0d432372d6f8abeff04be07ab82c649d97225d051a698458d20e7e6',
+        '2c84bdacd4f367a631270a6b3f8ff87e2d11aa019d8e898a2361f40591667024',
     'litertlm-linux_arm64.tar.gz':
-        '6000cfaa7ba6a5939c15087164358ac462420f27cea41f971fdb67a41676f79b',
+        '79ec60b99076e53bd51e1be4bedeb45abb8d724d1bb45c8acc5c171cc4cde7bd',
     'litertlm-windows_x86_64.tar.gz':
         '466b8de4a78218f36fb616a563e7c1e47e7abd24489bfba47ac483bfdf13d63d',
     'litertlm-macos_arm64.tar.gz':

--- a/packages/flutter_gemma_litertlm/hook/build.dart
+++ b/packages/flutter_gemma_litertlm/hook/build.dart
@@ -148,7 +148,7 @@ class _NativeBundle {
 /// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
 const _litertlmBundle = _NativeBundle(
   namespace: 'litertlm',
-  version: '0.12.0-a',
+  version: '0.13.1',
   releaseTagPrefix: 'native-v',
   archivePrefix: 'litertlm',
   mainLibName: 'LiteRtLm',
@@ -159,21 +159,24 @@ const _litertlmBundle = _NativeBundle(
   // in a dedicated PR (tracked: roadmap entry in CHANGELOG for 0.16.0).
   useFlatLayout: true,
   markerFileName: '.flutter_gemma_native_version',
+  // 0.13.1: LiteRT-LM 0.13.1 (bundles LiteRT post-v2.1.5 main). Fixes the
+  // Gemma 4 E2B MTP/speculative-decoding crash (#318). Android .so rebuilt with
+  // 16KB page alignment (NDK r28). Built on native-v0.13.1 tag.
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
-        '930296b010ecc316c6b6fc4ed1c722b275b4064b59b5aad8ff7b858e9149c0d7',
+        '7dd32e29e0d432372d6f8abeff04be07ab82c649d97225d051a698458d20e7e6',
     'litertlm-linux_arm64.tar.gz':
-        '616b2e8cb9903bfd4ee54ca600a9a0cce38ddd16ed3e4b847a6d80e548b9aa60',
+        '6000cfaa7ba6a5939c15087164358ac462420f27cea41f971fdb67a41676f79b',
     'litertlm-windows_x86_64.tar.gz':
-        'b7264091c05001ef84e53761dfee331f761e3a2362b36b28ab2ce39666400d76',
+        '466b8de4a78218f36fb616a563e7c1e47e7abd24489bfba47ac483bfdf13d63d',
     'litertlm-macos_arm64.tar.gz':
-        'a616c6996853cf095fac8c19de1d4dbf9a7434437da7f9bcc167e0e840147e10',
+        '59d7f73d1cb4077ad82fefb0a8d2a506d8c89d61487a7981816dbffe8a3cbe2d',
     'litertlm-ios_arm64.tar.gz':
-        '88620e05382dcb1fdc5d2d985bfc9812f78f1422b4e9f3d1d8dfbafcf727c4ee',
+        'dce231a0c624e0f7e0287eb5e28a78d895f7af5dc0fa7399f89443ce54a5f44f',
     'litertlm-ios_sim_arm64.tar.gz':
-        '54e067fa11ad510280e01f90260e8bda13f905a27f00e7ebc2d7ef5847868bd1',
+        '08724bafac9381a9fde8658ce5a1137f1f5b966d82dd63e32b2e201d617c0b9d',
     'litertlm-android_arm64.tar.gz':
-        'f809c5a29867062cda74186c7ebebd500a2f36d0b6ad6f7ca8eab902af7fc784',
+        '3a976067216e3d3aa55858f4cc8ee10af813d808b6ab132dbd45d6db56fd3be8',
   },
   companions: [
     'GemmaModelConstraintProvider',
@@ -337,8 +340,8 @@ Directory _cacheBaseDir() {
 /// COMMIT POINT: call LAST, only after the dylib files are fully in place.
 void _writeMarker(_NativeBundle bundle) {
   bundle.markerFile().writeAsStringSync(
-        jsonEncode({'version': bundle.version, 'owner': _packageName}),
-      );
+    jsonEncode({'version': bundle.version, 'owner': _packageName}),
+  );
 }
 
 /// Wipe stale per-platform cached files when a bundle's version changes. Cheap
@@ -415,7 +418,11 @@ bool _hasMainLib(Directory dir, _NativeBundle bundle, OS os) {
 ///   2. cached `<cacheBase>/<bundle-namespace>/<dirName>/` from a previous
 ///      `_downloadAndExtract`.
 Directory? _resolveLibDir(
-    _NativeBundle bundle, String dirName, Uri packageRoot, OS os) {
+  _NativeBundle bundle,
+  String dirName,
+  Uri packageRoot,
+  OS os,
+) {
   // Local prebuilts use a per-bundle directory layout under `native/`.
   // LiteRT historically uses `native/litert_lm/prebuilt/`. For new bundles
   // we use `native/<namespace>/prebuilt/`.
@@ -436,7 +443,9 @@ Directory? _resolveLibDir(
 // ============================================================================
 
 Future<Directory?> _downloadAndExtract(
-    _NativeBundle bundle, String dirName) async {
+  _NativeBundle bundle,
+  String dirName,
+) async {
   final archiveName = bundle.archiveName(dirName);
   final expectedChecksum = bundle.checksums[archiveName];
   if (expectedChecksum == null) {
@@ -458,7 +467,8 @@ Future<Directory?> _downloadAndExtract(
 
     final url = '${bundle.releaseBase}/$archiveName';
     stderr.writeln(
-        'flutter_gemma: Downloading ${bundle.namespace} native libs from $url ...');
+      'flutter_gemma: Downloading ${bundle.namespace} native libs from $url ...',
+    );
 
     final client = HttpClient();
     try {
@@ -466,7 +476,8 @@ Future<Directory?> _downloadAndExtract(
       final response = await request.close();
       if (response.statusCode != 200) {
         stderr.writeln(
-            'flutter_gemma: Download failed (HTTP ${response.statusCode})');
+          'flutter_gemma: Download failed (HTTP ${response.statusCode})',
+        );
         return null;
       }
       final sink = archiveFile.openWrite();
@@ -493,13 +504,16 @@ Future<Directory?> _downloadAndExtract(
     if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
     tmpDir.createSync(recursive: true);
     try {
-      final result = await Process.run(
-        'tar',
-        ['-xzf', archiveFile.path, '-C', tmpDir.path],
-      );
+      final result = await Process.run('tar', [
+        '-xzf',
+        archiveFile.path,
+        '-C',
+        tmpDir.path,
+      ]);
       if (result.exitCode != 0) {
         stderr.writeln(
-            'flutter_gemma: ${bundle.namespace} extract failed: ${result.stderr}');
+          'flutter_gemma: ${bundle.namespace} extract failed: ${result.stderr}',
+        );
         return null;
       }
       if (targetDir.existsSync()) targetDir.deleteSync(recursive: true);
@@ -509,7 +523,8 @@ Future<Directory?> _downloadAndExtract(
     }
     archiveFile.deleteSync();
     stderr.writeln(
-        'flutter_gemma: ${bundle.namespace} libs cached to ${targetDir.path}');
+      'flutter_gemma: ${bundle.namespace} libs cached to ${targetDir.path}',
+    );
     return targetDir;
   } catch (e) {
     stderr.writeln('flutter_gemma: ${bundle.namespace} download failed: $e');

--- a/packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh
@@ -701,4 +701,40 @@ else
   fi
 fi
 
+# ── 11. Mirror the minizip/zlib source off the flaky zlib.net ──
+# Upstream's `minizip` http_archive fetches zlib-1.3.1.tar.gz from
+# https://zlib.net/fossils/ — which is chronically unreliable in CI (it
+# intermittently serves corrupted/varying bytes, failing the sha256 check and
+# aborting the whole Bazel build; observed 3x in one release cycle). Prepend the
+# GitHub release asset (github.com/madler/zlib v1.3.1), which is byte-identical
+# (same sha256 9a93b2b7...) and immutable. Bazel tries `urls` in order, so the
+# GitHub mirror is used first and zlib.net stays as a fallback.
+export WORKSPACE_FILE="$DIR/WORKSPACE"
+if [ -f "$WORKSPACE_FILE" ] && ! grep -q "FLUTTER_GEMMA_ZLIB_MIRROR" "$WORKSPACE_FILE"; then
+  python3 - <<'PYEOF'
+import os
+ws = os.environ['WORKSPACE_FILE']
+with open(ws) as f:
+    s = f.read()
+old = '    url = "https://zlib.net/fossils/zlib-1.3.1.tar.gz",'
+new = ('    # FLUTTER_GEMMA_ZLIB_MIRROR: GitHub release first (immutable, same\n'
+       '    # sha256), zlib.net as fallback — zlib.net is flaky in CI.\n'
+       '    urls = [\n'
+       '        "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",\n'
+       '        "https://zlib.net/fossils/zlib-1.3.1.tar.gz",\n'
+       '    ],')
+if old in s:
+    s = s.replace(old, new)
+    with open(ws, 'w') as f:
+        f.write(s)
+    print("  OK: minizip/zlib mirrored to GitHub release (zlib.net as fallback)")
+else:
+    print("  WARN: minizip zlib.net url line not found; skipping zlib mirror")
+PYEOF
+else
+  if [ -f "$WORKSPACE_FILE" ]; then
+    echo "  SKIP: WORKSPACE already has FLUTTER_GEMMA_ZLIB_MIRROR"
+  fi
+fi
+
 echo "Patch complete."

--- a/packages/flutter_gemma_litertlm/pubspec.yaml
+++ b/packages/flutter_gemma_litertlm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_litertlm
 description: "LiteRT-LM (.litertlm) on-device inference engine for flutter_gemma via dart:ffi (5 native platforms) + web. Opt-in InferenceEngineProvider."
-version: 1.0.0-rc.1
+version: 1.0.0
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_litertlm
 topics: [gemma, llm, litert, on-device, ffi]
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^1.0.0-rc.1
+  flutter_gemma: ^1.0.0
   ffi: ^2.1.0
   mutex: ^3.1.0
   hooks: ^1.0.0

--- a/packages/flutter_gemma_mediapipe/CHANGELOG.md
+++ b/packages/flutter_gemma_mediapipe/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+- Stable 1.0.0; spec imports redirected off the `dart:io` mobile lib for a wasm-clean web graph.
+
 ## 1.0.0-rc.1
 - Initial release: MediaPipe (`.task` / `.bin`) on-device inference engine for flutter_gemma.
 - Provides `MediaPipeEngine` (InferenceEngineProvider); bundles Google's MediaPipe Pod/Gradle deps.

--- a/packages/flutter_gemma_mediapipe/pubspec.yaml
+++ b/packages/flutter_gemma_mediapipe/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_mediapipe
 description: "MediaPipe (.task) on-device inference engine for flutter_gemma (Android/iOS/Web). Opt-in package; provides an InferenceEngineProvider. Bundles Google's MediaPipe Pod/Gradle deps."
-version: 1.0.0-rc.1
+version: 1.0.0
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_mediapipe
 topics: [gemma, llm, mediapipe, on-device, ai]
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^1.0.0-rc.1
+  flutter_gemma: ^1.0.0
   mutex: ^3.1.0
   plugin_platform_interface: ^2.0.2
   # Direct import in the pigeon-generated lib/pigeon.g.dart (immutable, etc.).

--- a/packages/flutter_gemma_rag_qdrant/CHANGELOG.md
+++ b/packages/flutter_gemma_rag_qdrant/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+- Stable 1.0.0.
+- Rebuild Android `.so` with 16KB page alignment for Android 15 / Play target SDK 35+ (#319; native tag qdrant-edge-v0.7.3).
+
 ## 1.0.0-rc.1
 - Initial release: qdrant-edge on-device RAG vector store for flutter_gemma (native FFI; ~75× faster search than sqlite).
 - Provides `QdrantVectorStore`; implements VectorStoreRepository. Honors the payload-aware `Filter` DSL.

--- a/packages/flutter_gemma_rag_qdrant/hook/build.dart
+++ b/packages/flutter_gemma_rag_qdrant/hook/build.dart
@@ -153,9 +153,14 @@ class _NativeBundle {
 /// 0.7.2: normalize the iOS device + simulator dylib `minos` to 13.0 via
 /// `vtool -set-build-version` in build_local.sh, so App Store Connect no
 /// longer rejects the archive with ITMS-90208 (#286 regression in 0.7.1).
+///
+/// 0.7.3: rebuild the Android `.so` with 16 KB ELF LOAD-segment alignment
+/// (`-Wl,-z,max-page-size=16384`), required for Android 15 (16 KB pages) and
+/// Google Play target SDK 35+ uploads (#319). The other six platform archives
+/// are carried over byte-identical from 0.7.2 (only Android changed).
 const _qdrantEdgeBundle = _NativeBundle(
   namespace: 'qdrant_edge',
-  version: '0.7.2',
+  version: '0.7.3',
   releaseTagPrefix: 'qdrant-edge-v',
   archivePrefix: 'qdrant-edge',
   mainLibName: 'qdrant_edge_ffi',
@@ -177,7 +182,7 @@ const _qdrantEdgeBundle = _NativeBundle(
     'qdrant-edge-ios_sim_arm64.tar.gz':
         '09579375e4fbf7bea4b43d98b613cc020b1890381f28bbcc416ec8482cdbfc53',
     'qdrant-edge-android_arm64.tar.gz':
-        '957431c31dc01811feef2231141ba40cf1bb1991c42aab2dc800eb75d937de1d',
+        '0fcf783e04d4344d4e9b39d0b3c897c058268f5a0d43458a45d2219e3792dee5',
   },
 );
 
@@ -264,8 +269,8 @@ Directory _cacheBaseDir() {
 /// COMMIT POINT: call LAST, only after the dylib files are fully in place.
 void _writeMarker(_NativeBundle bundle) {
   bundle.markerFile().writeAsStringSync(
-        jsonEncode({'version': bundle.version, 'owner': _packageName}),
-      );
+    jsonEncode({'version': bundle.version, 'owner': _packageName}),
+  );
 }
 
 /// Wipe stale per-platform cached files when a bundle's version changes. Cheap
@@ -342,7 +347,11 @@ bool _hasMainLib(Directory dir, _NativeBundle bundle, OS os) {
 ///   2. cached `<cacheBase>/<bundle-namespace>/<dirName>/` from a previous
 ///      `_downloadAndExtract`.
 Directory? _resolveLibDir(
-    _NativeBundle bundle, String dirName, Uri packageRoot, OS os) {
+  _NativeBundle bundle,
+  String dirName,
+  Uri packageRoot,
+  OS os,
+) {
   // Local prebuilts use a per-bundle directory layout under `native/`.
   // LiteRT historically uses `native/litert_lm/prebuilt/`. For new bundles
   // we use `native/<namespace>/prebuilt/`.
@@ -363,7 +372,9 @@ Directory? _resolveLibDir(
 // ============================================================================
 
 Future<Directory?> _downloadAndExtract(
-    _NativeBundle bundle, String dirName) async {
+  _NativeBundle bundle,
+  String dirName,
+) async {
   final archiveName = bundle.archiveName(dirName);
   final expectedChecksum = bundle.checksums[archiveName];
   if (expectedChecksum == null) {
@@ -385,7 +396,8 @@ Future<Directory?> _downloadAndExtract(
 
     final url = '${bundle.releaseBase}/$archiveName';
     stderr.writeln(
-        'flutter_gemma: Downloading ${bundle.namespace} native libs from $url ...');
+      'flutter_gemma: Downloading ${bundle.namespace} native libs from $url ...',
+    );
 
     final client = HttpClient();
     try {
@@ -393,7 +405,8 @@ Future<Directory?> _downloadAndExtract(
       final response = await request.close();
       if (response.statusCode != 200) {
         stderr.writeln(
-            'flutter_gemma: Download failed (HTTP ${response.statusCode})');
+          'flutter_gemma: Download failed (HTTP ${response.statusCode})',
+        );
         return null;
       }
       final sink = archiveFile.openWrite();
@@ -420,13 +433,16 @@ Future<Directory?> _downloadAndExtract(
     if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
     tmpDir.createSync(recursive: true);
     try {
-      final result = await Process.run(
-        'tar',
-        ['-xzf', archiveFile.path, '-C', tmpDir.path],
-      );
+      final result = await Process.run('tar', [
+        '-xzf',
+        archiveFile.path,
+        '-C',
+        tmpDir.path,
+      ]);
       if (result.exitCode != 0) {
         stderr.writeln(
-            'flutter_gemma: ${bundle.namespace} extract failed: ${result.stderr}');
+          'flutter_gemma: ${bundle.namespace} extract failed: ${result.stderr}',
+        );
         return null;
       }
       if (targetDir.existsSync()) targetDir.deleteSync(recursive: true);
@@ -436,7 +452,8 @@ Future<Directory?> _downloadAndExtract(
     }
     archiveFile.deleteSync();
     stderr.writeln(
-        'flutter_gemma: ${bundle.namespace} libs cached to ${targetDir.path}');
+      'flutter_gemma: ${bundle.namespace} libs cached to ${targetDir.path}',
+    );
     return targetDir;
   } catch (e) {
     stderr.writeln('flutter_gemma: ${bundle.namespace} download failed: $e');

--- a/packages/flutter_gemma_rag_qdrant/native/qdrant_edge/build_local.sh
+++ b/packages/flutter_gemma_rag_qdrant/native/qdrant_edge/build_local.sh
@@ -105,7 +105,12 @@ build_ios_sim() {
 
 build_android_arm64() {
     echo "==> Android arm64 (aarch64-linux-android, NDK $ANDROID_NDK_HOME, API $ANDROID_API_LEVEL)"
-    cargo ndk -t arm64-v8a --platform "$ANDROID_API_LEVEL" -- build --release
+    # 16 KB ELF LOAD-segment alignment — required for Android 15 (16 KB pages)
+    # and Google Play target SDK 35+ uploads (#319). Matches the LiteRT libs'
+    # max-page-size=16384 (#253). Passed as a Rust linker arg so cargo-ndk
+    # threads it through to the NDK linker.
+    RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-z,max-page-size=16384" \
+      cargo ndk -t arm64-v8a --platform "$ANDROID_API_LEVEL" -- build --release
     local src="target/aarch64-linux-android/release/libqdrant_edge_ffi.so"
     local out="$DIST_DIR/qdrant-edge-android_arm64"
     rm -rf "$out" && mkdir -p "$out"

--- a/packages/flutter_gemma_rag_qdrant/pubspec.yaml
+++ b/packages/flutter_gemma_rag_qdrant/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_rag_qdrant
 description: "qdrant-edge on-device RAG vector store for flutter_gemma (native Rust FFI). Opt-in VectorStoreRepository with payload filtering. Native platforms only (no web)."
-version: 1.0.0-rc.1
+version: 1.0.0
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_rag_qdrant
 topics: [rag, qdrant, vector-search, embeddings, on-device]
@@ -24,7 +24,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^1.0.0-rc.1
+  flutter_gemma: ^1.0.0
   ffi: ^2.1.0
   uuid: ^4.0.0
   hooks: ^1.0.0

--- a/packages/flutter_gemma_rag_sqlite/CHANGELOG.md
+++ b/packages/flutter_gemma_rag_sqlite/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+- Stable 1.0.0; RAG logging routed through `gemmaLog` (silent in release builds).
+
 ## 1.0.0-rc.1
 - Initial release: SQLite + HNSW on-device RAG vector store for flutter_gemma.
 - Provides `SqliteVectorStore` (native, sqlite3) and `WebSqliteVectorStore` (web, wa-sqlite); implements VectorStoreRepository.

--- a/packages/flutter_gemma_rag_sqlite/pubspec.yaml
+++ b/packages/flutter_gemma_rag_sqlite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_rag_sqlite
 description: "SQLite + HNSW on-device RAG vector store for flutter_gemma (native sqlite3 + web wa-sqlite). Opt-in package; implements flutter_gemma's VectorStoreRepository."
-version: 1.0.0-rc.1
+version: 1.0.0
 homepage: https://github.com/DenisovAV/flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_rag_sqlite
 topics: [rag, sqlite, vector-search, embeddings, web]
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^1.0.0-rc.1
+  flutter_gemma: ^1.0.0
   sqlite3: ^3.3.0
   local_hnsw: ^1.0.0
 


### PR DESCRIPTION
1.0.0 release prep. Tracks:
- #319 — qdrant Android .so rebuilt with 16KB page alignment (Android 15 / Play target SDK 35+); native tag qdrant-edge-v0.7.3.
- Release skill: ported the #316 three-way checksum-consistency check.
- (incoming) version bump all 6 packages 1.0.0-rc.1 -> 1.0.0 + CHANGELOG.

#318 (MTP crash) is NOT in this release — it needs an upstream LiteRT-LM runtime bump (testing v0.13.1 separately); tracked in #318 with a model-revision workaround.