### PR TITLE
docs: site versions → 1.0.2 + maxTokens troubleshooting; release skill covers site

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -62,6 +62,9 @@ If **any** dylib changed → must re-publish GitHub Release archives **and** upd
 ### 1c. patch_c_api.sh / build_*.sh / WORKSPACE patch changed?
 This implies (1b) — verify dylibs were actually rebuilt against the new patches. If not, rebuild before continuing (see "Rebuild native dylibs" below).
 
+### 1d. Website (`website/`, fluttergemma.dev) — ALWAYS in scope
+Every release touches the site. At minimum the package versions hardcoded in its docs must be bumped to the just-published versions (Step 12a) — this is required even for a version-only release. On top of that, any new/changed public API, breaking change, or common pitfall must be documented (Step 12b). Don't defer to "later" — stale docs outlive the release.
+
 ## Step 2: Bump versions
 
 Always:
@@ -291,6 +294,38 @@ The `.github/workflows/release.yml` triggers on `v*.*.*` tag push and creates a 
 gh run list --workflow release.yml --limit 3
 gh release view v0.14.1
 ```
+
+## Step 12: Reflect the release on the website (fluttergemma.dev)
+
+**MANDATORY ON EVERY RELEASE.** The docs site lives in this repo at `website/` (Jaspr static site → Firebase Hosting). Stale docs are a support-burden multiplier — every doc that still shows the old version or omits a new API generates issues.
+
+### 12a. ALWAYS bump the package versions shown on the site (even for a pure version-only release)
+
+The site hardcodes `^X.Y.Z` in pubspec snippets across the docs — these MUST match the versions you just published, or new users copy-paste outdated deps. This is required **every single release**, regardless of whether code changed. Find every stale reference:
+```bash
+cd website
+grep -rnE "flutter_gemma[a-z_]*: *\^?[0-9]+\.[0-9]+\.[0-9]+" content/
+```
+Update each `^X.Y.Z` for all six packages (`flutter_gemma`, `flutter_gemma_litertlm`, `flutter_gemma_mediapipe`, `flutter_gemma_embeddings`, `flutter_gemma_rag_qdrant`, `flutter_gemma_rag_sqlite`) to the just-published versions. Common spots: `installation.md`, `getting-started.md`, `migration.md`, `packages.md`. Cross-check against pub.dev so the site never lags the published packages.
+
+### 12b. Update docs for any behavior/API change
+- **New / changed public API** → the topic doc that covers it (e.g. a new `createSession` param → `getting-started.md`; multimodal → `multimodal.md`; models → `models.md`).
+- **Breaking changes / migrations** → `migration.md`.
+- **A bug class users hit** → `troubleshooting.md` (e.g. the #318 `maxTokens` vs `maxOutputTokens` confusion belongs here).
+
+### 12c. Deploy — it's automatic on merge to main
+
+**You do NOT run a manual deploy.** `.github/workflows/firebase-hosting-merge.yml` auto-deploys to Firebase Hosting (`aichat-c0c27`, target `fluttergemma`, https://fluttergemma.dev → live channel) on every push to `main` that touches `website/**` or `packages/flutter_gemma/example/**`. So:
+
+1. Commit the `website/` changes (same author rule, no AI attribution) on your release branch / PR.
+2. When the PR merges to `main`, the workflow builds the Jaspr SSG + the Flutter web example (`/try`) and deploys automatically.
+3. Verify the run + spot-check the live page:
+   ```bash
+   gh run list --workflow firebase-hosting-merge.yml --limit 3
+   # then open https://fluttergemma.dev/docs/... and confirm the change is live
+   ```
+
+A manual `./deploy.sh` exists in `website/` for local one-off deploys (it does the same build + `firebase deploy`), but the merge workflow is the normal path — don't run it by hand unless the workflow is broken. The site is NOT on pub.dev; `dart pub publish` never touches it — only this workflow (or `deploy.sh`) does.
 
 ## Common gotchas
 

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,12 +29,12 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.0.0                 # core — always required
-  flutter_gemma_litertlm: ^1.0.0        # add if you run .litertlm models
-  flutter_gemma_mediapipe: ^1.0.0       # add if you run .task / .bin models
-  flutter_gemma_embeddings: ^1.0.0      # add if you compute embeddings
-  flutter_gemma_rag_qdrant: ^1.0.0      # add for native on-device RAG
-  flutter_gemma_rag_sqlite: ^1.0.0      # add for web (or native sqlite) RAG
+  flutter_gemma: ^1.0.2                 # core — always required
+  flutter_gemma_litertlm: ^1.0.2        # add if you run .litertlm models
+  flutter_gemma_mediapipe: ^1.0.2       # add if you run .task / .bin models
+  flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings
+  flutter_gemma_rag_qdrant: ^1.0.1      # add for native on-device RAG
+  flutter_gemma_rag_sqlite: ^1.0.1      # add for web (or native sqlite) RAG
 ```
 
 Pick by what you actually used in 0.16.x:

--- a/website/content/docs/troubleshooting.md
+++ b/website/content/docs/troubleshooting.md
@@ -17,9 +17,24 @@ glibc, Windows DXC, stale GPU shader cache) see
 ## Memory
 
 - **iOS:** ensure `Runner.entitlements` contains the memory entitlements and the Podfile sets `platform :ios, '16.0'`. See [Installation → iOS](/docs/installation#ios).
-- Reduce `maxTokens` if you hit memory pressure.
+- Reduce `maxTokens` if you hit memory pressure — but **keep it at 1024 or higher for `.litertlm` models** (see "maxTokens vs maxOutputTokens" below). To shorten replies, use `maxOutputTokens`, not a smaller `maxTokens`.
 - Use smaller models (1B-2B parameters) for devices with <6GB RAM. Multimodal models (Gemma 4, Gemma3n) need 8GB+.
 - Close sessions and models when not needed; monitor usage with `sizeInTokens()`.
+
+## maxTokens vs maxOutputTokens
+
+`maxTokens` (on `getActiveModel`/`createModel`) is the **context window** — the total budget shared by the input (system prompt + history + your message) **and** the generated output (the KV-cache size). It is **not** the reply length.
+
+`.litertlm` models require a context window of at least **1024**. Passing a smaller `maxTokens` (e.g. `100`) used to crash with `DYNAMIC_UPDATE_SLICE failed to prepare` / `Failed to allocate tensors` (even on CPU — the failure is at graph compile, before the backend runs). As of **1.0.2** a too-small `maxTokens` is clamped up to 1024 automatically with a log warning.
+
+To limit how many tokens the model **generates**, use `maxOutputTokens` on `createSession`/`openSession`/`createChat`/`openChat` instead:
+
+```dart
+final model = await FlutterGemma.getActiveModel(maxTokens: 1024); // context window
+final chat = await model.createChat(maxOutputTokens: 100);        // reply cap
+```
+
+(`maxOutputTokens` is honored on `.litertlm`; the MediaPipe `.task` path has no session-level output cap and ignores it.)
 
 ## iOS
 


### PR DESCRIPTION
Brings the website docs in line with the 1.0.2 release and teaches the release skill to keep the site in sync.

## Website (`website/`)
- **`migration.md`**: package versions bumped to the published ones — `^1.0.2` for core / litertlm / mediapipe, `^1.0.1` for embeddings / qdrant / sqlite.
- **`troubleshooting.md`**: new "maxTokens vs maxOutputTokens" section, and fixed the old "reduce `maxTokens` if you hit memory pressure" tip — that advice is exactly what led users into the #318 `DYNAMIC_UPDATE_SLICE` crash. It now says to keep `maxTokens` >= 1024 on `.litertlm` and use `maxOutputTokens` to shorten replies.

On merge, `firebase-hosting-merge.yml` redeploys the site automatically (paths include `website/**`).

## Release skill (`.claude/skills/release/SKILL.md`)
- Step 1d: the website is always in release scope — at minimum its hardcoded package versions must match what was just published.
- Step 12: mandatory step to bump those versions (with a grep to find them), document any behavior/API change, and a note that the deploy is automatic on merge to main (no manual `./deploy.sh`).

jaspr build verified clean locally.