### PR TITLE
fix(website): genkit docs broke the SSG deploy (yaml highlighter crash)

### DIFF
--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -18,7 +18,7 @@ with the on-device model exactly as it would with any cloud provider.
 
 ### Add to pubspec.yaml
 
-```yaml
+```
 dependencies:
   genkit_flutter_gemma: ^0.4.0
   flutter_gemma: ^1.0.0
@@ -137,7 +137,7 @@ flutter_gemma and works with **any** pair of Genkit models.
 
 ### Add to pubspec.yaml
 
-```yaml
+```
 dependencies:
   genkit_hybrid: ^0.1.0
   genkit: any


### PR DESCRIPTION
## Problem
The website **Deploy to Firebase Hosting (merge)** workflow failed on the #331 merge commit. CI Tests passed (tests don't build the site), but the Jaspr SSG build crashed while generating `/docs/genkit`:

```
[ERROR] Null check operator used on a null value
#0  new Highlighter (package:syntax_highlight_lite/.../syntax_highlighter.dart:110:32)
#1  CodeBlock.create (package:jaspr_content/components/code_block.dart:51:31)
```

## Root cause
`genkit.md` (added in #331) used ```` ```yaml ```` fenced code blocks for the pubspec snippets. `syntax_highlight_lite` ships no YAML grammar — the highlighter returns null and the null-check crashes the build. Every other docs page uses only ```` ```dart ````.

The PR CI didn't catch it because the Firebase deploy workflow runs on push-to-main, not on pull_request.

## Fix
Drop the `yaml` language tag on the two pubspec blocks (bare fences), matching the 10 other bare blocks already in the same file. The snippets render without YAML syntax colouring; the build succeeds.

## Verification
Reproduced the failure locally with `jaspr build` (route 5/13 `/docs/genkit` crashed), applied the fix, rebuilt → `Completed building project to /build/jaspr` with no errors.