### PR TITLE
fix(genkit): align Claude skill wiring

### DIFF
--- a/packages/genkit_flutter_gemma/.claude/commands/review-pr.md
+++ b/packages/genkit_flutter_gemma/.claude/commands/review-pr.md
@@ -1,10 +1,10 @@
 # Genkit Flutter Gemma PR Review
 
-Run comprehensive PR review with 5 parallel agents.
+Run a comprehensive PR review with 5 parallel agents.
 
 ## Usage
 
-```
+```bash
 /review-pr 1          # Review PR by number
 /review-pr            # Review current branch vs main
 ```
@@ -13,13 +13,22 @@ Run comprehensive PR review with 5 parallel agents.
 
 ### Step 1: Get the diff
 
+Start from the repository root, not the package directory:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+```
+
 **If PR number provided:**
+
 ```bash
 gh pr view {number} --json title,body,files --jq '.title'
 gh pr diff {number} > /tmp/pr-{number}.diff
 ```
 
 **If no PR number:**
+
 ```bash
 BRANCH=$(git branch --show-current)
 PR_NUMBER=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
@@ -42,30 +51,30 @@ Launch all 5 agents simultaneously using the Agent tool. Each agent gets the ful
 
 **Every agent prompt MUST include the following context block** to prevent false positives:
 
-```
-PROJECT CONTEXT — read this before reporting findings:
+```text
+PROJECT CONTEXT - read this before reporting findings:
 
 1. This is a GENKIT PLUGIN wrapping flutter_gemma. We call flutter_gemma's DART API,
    not native code directly. flutter_gemma itself is a native plugin (MediaPipe/LiteRT),
    but that's its responsibility, not ours. Do NOT report "no error wrapping around
-   native calls" — we intentionally let flutter_gemma exceptions propagate with their
+   native calls" - we intentionally let flutter_gemma exceptions propagate with their
    original stack traces.
 
-2. The .g.dart files are MANUALLY MAINTAINED (build_runner is broken). This is
-   documented in CLAUDE.md. Report real drift between .dart and .g.dart, but don't
-   suggest "run build_runner" as a fix.
+2. The .g.dart files are MANUALLY MAINTAINED. Report real drift between .dart and
+   .g.dart, but fix both files by hand unless the maintainer explicitly asks to
+   regenerate. Do not suggest "run build_runner" as the default fix.
 
 3. `fileType` in FlutterGemmaModelConfig is a FORWARD-LOOKING parameter stored for
-   identification. flutter_gemma's getActiveModel() doesn't need it — the model is
+   identification. flutter_gemma's getActiveModel() doesn't need it - the model is
    already installed. This is NOT a bug.
 
-4. `dispose()` clears the Dart action cache. InferenceModel is a Dart object — native
+4. `dispose()` clears the Dart action cache. InferenceModel is a Dart object - native
    resources are managed by flutter_gemma's platform channel, not by us. GC handles
    cleanup. Do NOT report "native resource leak" for dispose().
 
 5. `toolChoice` defaulting to `auto` for unrecognized values is a DESIGN CHOICE, not
    a silent failure. The JSON schema already constrains valid values at the Genkit UI
-   level. If an unknown string arrives, `auto` is a safe fallback — same behavior as
+   level. If an unknown string arrives, `auto` is a safe fallback - same behavior as
    most LLM APIs. The embedder throws on unknown backend because there's no safe default
    for hardware selection. Different domains, different strategies.
 
@@ -73,7 +82,7 @@ PROJECT CONTEXT — read this before reporting findings:
    classes, abstracting one-time operations, or adding layers of indirection. Keep
    suggestions proportional to project scale.
 
-7. Bare `catch (e)` in config parsing (fromJson) is intentional — it catches any
+7. Bare `catch (e)` in config parsing (fromJson) is intentional - it catches any
    deserialization error (TypeError, CastError, etc.) and wraps as INVALID_ARGUMENT.
    This is a system boundary where we validate external input. Do NOT suggest catching
    only specific types.
@@ -88,23 +97,24 @@ PROJECT CONTEXT — read this before reporting findings:
 **subagent_type:** `general-purpose`
 
 **Prompt template:**
-```
+
+```text
 You are reviewing a Genkit Dart plugin (genkit_flutter_gemma) that bridges flutter_gemma for on-device AI inference.
 
 {PROJECT CONTEXT BLOCK}
 
-Read CLAUDE.md for project conventions, then review the diff.
+Read packages/genkit_flutter_gemma/CLAUDE.md for project conventions, then review the diff.
 
 CHECKLIST:
 1. PLUGIN CONTRACT: GenkitPlugin interface correctly implemented (list(), resolve()). Action caching in _resolvedActions
-2. MODEL ACTION: Future-chain lock correctness — no race conditions. InferenceModel caching logic (invalidation on config change)
-3. CONVERTER LAYER: Genkit ↔ flutter_gemma type boundary — request_converter, response_converter, tool_converter. No data loss in conversion. Pay special attention to multi-part extraction (parallel tool calls in history must not be dropped)
+2. MODEL ACTION: Future-chain lock correctness - no race conditions. InferenceModel caching logic (invalidation on config change)
+3. CONVERTER LAYER: Genkit <-> flutter_gemma type boundary - request_converter, response_converter, tool_converter. No data loss in conversion. Pay special attention to multi-part extraction (parallel tool calls in history must not be dropped)
 4. OPTIONS: FlutterGemmaModelOptions and .g.dart in sync. JSON schema matches fields. All new options wired through to createChat()
-5. RUNTIME ABSTRACTION: FlutterGemmaRuntime interface — production vs test implementations consistent
+5. RUNTIME ABSTRACTION: FlutterGemmaRuntime interface - production vs test implementations consistent
 6. EMBEDDER: Caching, backend invalidation, document-to-text extraction
 7. SEPARATION OF CONCERNS: Converters don't import model/plugin. Model doesn't import plugin
 
-Report findings as: CRITICAL / IMPORTANT / MINOR with file:line references. Only report real issues — not stylistic preferences or over-engineering suggestions.
+Report findings as: CRITICAL / IMPORTANT / MINOR with file:line references. Only report real issues - not stylistic preferences or over-engineering suggestions.
 ```
 
 ### Agent 2: Code Quality
@@ -112,12 +122,13 @@ Report findings as: CRITICAL / IMPORTANT / MINOR with file:line references. Only
 **subagent_type:** `pr-review-toolkit:code-reviewer`
 
 **Prompt:**
-```
-Review the PR for genkit_flutter_gemma — a Genkit Dart plugin wrapping flutter_gemma.
+
+```text
+Review the PR for genkit_flutter_gemma - a Genkit Dart plugin wrapping flutter_gemma.
 
 {PROJECT CONTEXT BLOCK}
 
-Focus on recently changed files. Check: null safety, proper async/await patterns, Stream handling (no leaks), const constructors where possible, prefer_single_quotes lint rule, no unused imports. Read CLAUDE.md for project conventions.
+Focus on recently changed files. Check: null safety, proper async/await patterns, Stream handling (no leaks), const constructors where possible, prefer_single_quotes lint rule, no unused imports. Read packages/genkit_flutter_gemma/CLAUDE.md for project conventions.
 ```
 
 ### Agent 3: Type Design
@@ -125,7 +136,8 @@ Focus on recently changed files. Check: null safety, proper async/await patterns
 **subagent_type:** `pr-review-toolkit:type-design-analyzer`
 
 **Prompt:**
-```
+
+```text
 Analyze any new or modified types in this PR for genkit_flutter_gemma.
 
 {PROJECT CONTEXT BLOCK}
@@ -140,17 +152,18 @@ KEY CONCERN: The .g.dart files are manually maintained. Check that concrete clas
 **subagent_type:** `pr-review-toolkit:silent-failure-hunter`
 
 **Prompt:**
-```
+
+```text
 Check all changed files in genkit_flutter_gemma for silent failures, inadequate error handling, catch blocks that swallow errors, and inappropriate fallback behavior.
 
 {PROJECT CONTEXT BLOCK}
 
 Key areas to check:
-- Media resolution (data:/file:/http:) — these error paths matter
-- Streaming chunk accumulation — data loss during accumulation is a real bug
-- Model caching invalidation — wrong cache key = wrong model reuse
-- Request converter extraction — must handle ALL parts, not just first match (e.g. parallel tool calls)
-- Response converter — all ModelResponse subtypes must be handled
+- Media resolution (data:/file:/http:) - these error paths matter
+- Streaming chunk accumulation - data loss during accumulation is a real bug
+- Model caching invalidation - wrong cache key = wrong model reuse
+- Request converter extraction - must handle ALL parts, not just first match (e.g. parallel tool calls)
+- Response converter - all ModelResponse subtypes must be handled
 
 DO NOT flag:
 - toolChoice defaulting to auto (intentional, see context)
@@ -164,7 +177,8 @@ DO NOT flag:
 **subagent_type:** `pr-review-toolkit:pr-test-analyzer`
 
 **Prompt:**
-```
+
+```text
 Review test coverage for genkit_flutter_gemma.
 
 {PROJECT CONTEXT BLOCK}
@@ -176,7 +190,7 @@ Check:
 - Are converter tests comprehensive for new response types?
 - Does FakeInferenceModel capture enough createChat() parameters for verification?
 
-Focus on REAL gaps — features that are implemented but have zero test coverage. Don't suggest testing framework internals or obvious paths.
+Focus on REAL gaps - features that are implemented but have zero test coverage. Don't suggest testing framework internals or obvious paths.
 ```
 
 ---
@@ -186,8 +200,8 @@ Focus on REAL gaps — features that are implemented but have zero test coverage
 After all agents complete:
 
 1. Collect all findings from all agents
-2. **Filter out false positives** using the project context (agents may still report issues covered by the context block — remove these)
-3. Deduplicate — same file, same line, same concern → keep best description
+2. **Filter out false positives** using the project context (agents may still report issues covered by the context block - remove these)
+3. Deduplicate - same file, same line, same concern -> keep best description
 4. Categorize by severity: CRITICAL > IMPORTANT > MINOR
 5. Group by file path within each severity
 
@@ -196,7 +210,7 @@ After all agents complete:
 Save to `test_reports/pr-reviews/pr-{number}-review.md`:
 
 ```markdown
-# PR Review: #{number} — {title}
+# PR Review: #{number} - {title}
 
 **Branch:** {branch}
 **Date:** {date}

--- a/packages/genkit_flutter_gemma/.claude/skills/upgrade-flutter-gemma/SKILL.md
+++ b/packages/genkit_flutter_gemma/.claude/skills/upgrade-flutter-gemma/SKILL.md
@@ -1,46 +1,71 @@
 ---
 name: upgrade-flutter-gemma
-description: Upgrade flutter_gemma dependency — discover API changes, fix compilation, support new features, update tests, bump version
+description: Upgrade flutter_gemma dependency - discover API changes, fix compilation, support new features, update tests, bump version
 ---
 
 # Upgrade flutter_gemma dependency
 
-Follow these 5 phases sequentially. Do not skip phases. Ask the user before making decisions about new features (Phase 3).
+Follow these phases sequentially. Do not skip phases. Ask the user before making decisions about new features in Phase 3.
+
+## Phase 0: Resolve workspace paths
+
+This package lives inside the `flutter_gemma` monorepo and opts into the root Dart workspace. Always resolve the repo root and package directory before editing or running commands:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PKG_DIR="$REPO_ROOT/packages/genkit_flutter_gemma"
+EXAMPLE_DIR="$PKG_DIR/example"
+test -f "$PKG_DIR/pubspec.yaml"
+cd "$REPO_ROOT"
+```
+
+All package-relative paths below refer to `$PKG_DIR`. Run workspace dependency commands from `$REPO_ROOT`; run example-app commands from `$EXAMPLE_DIR`.
 
 ## Phase 1: Reconnaissance
 
-1. Run `dart pub outdated` to identify the available flutter_gemma version
-2. Update `flutter_gemma` version in both:
-   - `pubspec.yaml`
-   - `example/pubspec.yaml`
-3. Run `flutter pub get`
-4. Read the new version's CHANGELOG from pub cache:
+1. Run dependency discovery:
+   ```bash
+   (cd "$PKG_DIR" && dart pub outdated)
+   (cd "$EXAMPLE_DIR" && flutter pub outdated)
    ```
+2. Update the `flutter_gemma` version in both:
+   - `$PKG_DIR/pubspec.yaml`
+   - `$EXAMPLE_DIR/pubspec.yaml`
+3. Refresh dependencies:
+   ```bash
+   (cd "$REPO_ROOT" && dart pub get)
+   (cd "$EXAMPLE_DIR" && flutter pub get)
+   ```
+4. Read the new version's CHANGELOG from pub cache:
+   ```bash
    find ~/.pub-cache/hosted/pub.dev -maxdepth 1 -name "flutter_gemma-*" | sort
    ```
-   Then read the CHANGELOG.md from the latest version directory.
-5. Summarize for the user:
-   - **Breaking changes** (removed/renamed APIs, changed signatures)
-   - **New APIs** (new parameters, methods, enums, classes)
+   Then read the `CHANGELOG.md` from the latest version directory.
+5. Summarize before code edits:
+   - **Breaking changes**: removed/renamed APIs, changed signatures
+   - **New APIs**: new parameters, methods, enums, classes
    - **Bug fixes**
    - **Deprecations**
 
 ## Phase 2: Fix Compilation
 
-1. Run `dart analyze`
-2. Fix all compilation errors. These typically appear in:
+1. Run analysis:
+   ```bash
+   (cd "$PKG_DIR" && dart analyze)
+   ```
+2. Fix all compilation errors. These typically appear in package paths:
 
    **Checklist of files that depend on flutter_gemma API:**
-   - [ ] `lib/src/flutter_gemma_runtime.dart` — `FlutterGemma.getActiveModel()`, `FlutterGemma.getActiveEmbedder()` signatures
-   - [ ] `lib/src/flutter_gemma_model.dart` — `InferenceModel.createChat()` signature, `ModelResponse` pattern matching, `InferenceChat` methods
-   - [ ] `lib/src/flutter_gemma_embedder.dart` — `EmbeddingModel.generateEmbeddings()` signature, `PreferredBackend` enum
-   - [ ] `lib/src/converters/request_converter.dart` — `Message` constructors (`.withImage`, `.withAudio`, `.toolCall`, `.toolResponse`)
-   - [ ] `lib/src/converters/response_converter.dart` — `ModelResponse` subtypes (`TextResponse`, `FunctionCallResponse`, `ParallelFunctionCallResponse`, `ThinkingResponse`)
-   - [ ] `lib/src/converters/tool_converter.dart` — `Tool` constructor
-   - [ ] `lib/src/flutter_gemma_plugin.dart` — `ModelType`, `ModelFileType` enums
-   - [ ] `test/src/fake_runtime.dart` — `FakeInferenceModel`, `FakeInferenceChat`, `FakeEmbeddingModel` must match upstream abstract class signatures
+   - [ ] `lib/src/flutter_gemma_runtime.dart` - `FlutterGemma.getActiveModel()`, `FlutterGemma.getActiveEmbedder()` signatures
+   - [ ] `lib/src/flutter_gemma_model.dart` - `InferenceModel.createChat()` signature, `ModelResponse` pattern matching, `InferenceChat` methods
+   - [ ] `lib/src/flutter_gemma_embedder.dart` - `EmbeddingModel.generateEmbeddings()` signature, `PreferredBackend` enum
+   - [ ] `lib/src/converters/request_converter.dart` - `Message` constructors (`.withImage`, `.withAudio`, `.toolCall`, `.toolResponse`)
+   - [ ] `lib/src/converters/response_converter.dart` - `ModelResponse` subtypes (`TextResponse`, `FunctionCallResponse`, `ParallelFunctionCallResponse`, `ThinkingResponse`)
+   - [ ] `lib/src/converters/tool_converter.dart` - `Tool` constructor
+   - [ ] `lib/src/flutter_gemma_plugin.dart` - `ModelType`, `ModelFileType` enums
+   - [ ] `test/src/fake_runtime.dart` - `FakeInferenceModel`, `FakeInferenceChat`, `FakeEmbeddingModel` must match upstream abstract class signatures
 
-3. Repeat `dart analyze` until clean (0 issues)
+3. Repeat `dart analyze` until clean.
 
 ## Phase 3: Support New Features
 
@@ -49,6 +74,7 @@ Based on the CHANGELOG from Phase 1, decide with the user which new APIs to supp
 For each new feature, the typical integration points are:
 
 ### New parameter in `createChat()` or `createSession()`
+
 1. Add field to `$FlutterGemmaModelOptions` in `lib/src/flutter_gemma_options.dart`
 2. **Manually** update `lib/src/flutter_gemma_options.g.dart`:
    - Constructor parameter
@@ -57,49 +83,58 @@ For each new feature, the typical integration points are:
    - `toJson` serialization
    - `jsonSchema()` property entry
 3. Extract from config and pass in `lib/src/flutter_gemma_model.dart` (`_executeGeneration`)
-4. Update `FakeInferenceModel.createChat()` in `test/src/fake_runtime.dart` — add parameter, store in `last*` field for test assertions
+4. Update `FakeInferenceModel.createChat()` in `test/src/fake_runtime.dart` - add parameter, store in `last*` field for test assertions
 
-### New enum value (e.g. `ModelFileType`)
+### New enum value, such as `ModelFileType`
+
 1. Update comments in `lib/src/flutter_gemma_plugin.dart` (`FlutterGemmaModelConfig.fileType`)
 
 ### New method on `InferenceChat` or `InferenceModel`
+
 1. Add override in `FakeInferenceChat` or `FakeInferenceModel` in `test/src/fake_runtime.dart`
 
 ### Changed model capabilities
-1. Update `supports` map in `lib/src/flutter_gemma_plugin.dart` (`list()` method, ~line 123)
+
+1. Update `supports` map in `lib/src/flutter_gemma_plugin.dart` (`list()` method)
 
 ### Changed message handling
+
 1. Update converters in `lib/src/converters/`
 2. Update `extractSystemInstruction()` if system message handling changed
 
-**IMPORTANT:** The `.g.dart` file is manually maintained (build_runner is broken). Always update it by hand when changing the schema.
+**IMPORTANT:** The `.g.dart` file is manually maintained. Always update it by hand when changing the schema unless the maintainer explicitly asks to regenerate.
 
 ## Phase 4: Tests and Review
 
 1. **Update existing tests** that verify old behavior which has changed
 2. **Add new tests** for each new feature integrated in Phase 3
-3. Run `flutter test` — all tests must pass
-4. Run `/pr-review-toolkit:review-pr` for comprehensive review
-5. Fix any issues found by the review agents
+3. Run package and example tests:
+   ```bash
+   (cd "$PKG_DIR" && flutter test)
+   (cd "$EXAMPLE_DIR" && flutter test)
+   ```
+4. Run `/review-pr` for comprehensive review if the local Claude command is available. If that command is not installed in the current environment, run the same review checklist manually from `packages/genkit_flutter_gemma/.claude/commands/review-pr.md`.
+5. Fix any issues found by the review.
 
 ## Phase 5: Finalize
 
-1. **Bump version** in `pubspec.yaml`:
-   - Minor bump (e.g. `0.1.1` → `0.2.0`) if there are breaking behavioral changes
-   - Patch bump (e.g. `0.1.1` → `0.1.2`) if only bug fixes / non-breaking additions
-2. **Update `CHANGELOG.md`** — add new version section at the top with:
-   - Breaking changes (prefixed with `**Breaking**:`)
+1. **Bump version** in `$PKG_DIR/pubspec.yaml`:
+   - Minor bump, such as `0.1.1` to `0.2.0`, if there are breaking behavioral changes
+   - Patch bump, such as `0.1.1` to `0.1.2`, if only bug fixes or non-breaking additions
+2. **Update `$PKG_DIR/CHANGELOG.md`** - add new version section at the top with:
+   - Breaking changes prefixed with `**Breaking**:`
    - New features
    - Bug fixes
-3. **Update `README.md`**:
+3. **Update `$PKG_DIR/README.md`**:
    - Options table if new config fields were added
    - Known Limitations section if capabilities changed
-   - Quick Start / examples if API usage changed
-4. **Verify everything:**
+   - Quick Start or examples if API usage changed
+4. **Verify everything from the right roots:**
    ```bash
-   dart analyze
-   flutter test
-   dart pub publish --dry-run
+   (cd "$PKG_DIR" && dart analyze)
+   (cd "$PKG_DIR" && flutter test)
+   (cd "$PKG_DIR" && dart pub publish --dry-run)
+   (cd "$EXAMPLE_DIR" && flutter test)
    ```
    All must pass cleanly.
-5. **Commit** on a feature branch (e.g. `feature/flutter-gemma-X.Y.Z`)
+5. **Commit** on a feature branch from the repo root, such as `feature/flutter-gemma-X.Y.Z`, and include both workspace and example dependency updates.

--- a/packages/genkit_flutter_gemma/CLAUDE.md
+++ b/packages/genkit_flutter_gemma/CLAUDE.md
@@ -4,9 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
+The package lives in the `flutter_gemma` monorepo under
+`packages/genkit_flutter_gemma`. When starting from the monorepo root, use that
+directory explicitly for package commands.
+
 ```bash
 # Get dependencies
-flutter pub get
+dart pub get                         # from monorepo root
+cd packages/genkit_flutter_gemma/example && flutter pub get
 
 # Run all tests
 flutter test
@@ -34,22 +39,22 @@ This is a **Genkit Dart plugin** that bridges [flutter_gemma](https://pub.dev/pa
 
 ### Key abstractions
 
-- **`FlutterGemmaRuntime`** — abstracts flutter_gemma's static API (`FlutterGemma.getActiveModel`, `FlutterGemma.getActiveEmbedder`). Production uses `DefaultFlutterGemmaRuntime`; tests use `FakeRuntime` from `test/src/fake_runtime.dart`.
-- **Model action** (`flutter_gemma_model.dart`) — implements a serialized queue via future-chain lock, caches `InferenceModel` across calls, and delegates to blocking/streaming generation paths.
-- **Embedder action** (`flutter_gemma_embedder.dart`) — caches `EmbeddingModel` with backend invalidation.
+- **`FlutterGemmaRuntime`** - abstracts flutter_gemma's static API (`FlutterGemma.getActiveModel`, `FlutterGemma.getActiveEmbedder`). Production uses `DefaultFlutterGemmaRuntime`; tests use `FakeRuntime` from `test/src/fake_runtime.dart`.
+- **Model action** (`flutter_gemma_model.dart`) - implements a serialized queue via future-chain lock, caches `InferenceModel` across calls, and delegates to blocking/streaming generation paths.
+- **Embedder action** (`flutter_gemma_embedder.dart`) - caches `EmbeddingModel` with backend invalidation.
 
 ### Converter layer (`lib/src/converters/`)
 
-Three converters handle the Genkit ↔ flutter_gemma type boundary:
-- **`request_converter.dart`** — Genkit `Message` → `gemma.Message`. System role is prepended to first user message (flutter_gemma has no system role). Media resolution supports `data:` URIs, `file://`, absolute paths, and HTTP URLs.
-- **`response_converter.dart`** — `gemma.ModelResponse` → Genkit `ModelResponse`/`ModelResponseChunk`. Handles text, function calls (single and parallel), and reasoning/thinking parts.
-- **`tool_converter.dart`** — Genkit `ToolDefinition` → `gemma.Tool`.
+Three converters handle the Genkit <-> flutter_gemma type boundary:
+- **`request_converter.dart`** - Genkit `Message` to `gemma.Message`. System role is prepended to first user message (flutter_gemma has no system role). Media resolution supports `data:` URIs, `file://`, absolute paths, and HTTP URLs.
+- **`response_converter.dart`** - `gemma.ModelResponse` to Genkit `ModelResponse`/`ModelResponseChunk`. Handles text, function calls (single and parallel), and reasoning/thinking parts.
+- **`tool_converter.dart`** - Genkit `ToolDefinition` to `gemma.Tool`.
 
 ### Config options
 
-`FlutterGemmaModelOptions` is defined via `@Schema()` annotation in `flutter_gemma_options.dart`. Generated via `schemantic` + `build_runner`.
+`FlutterGemmaModelOptions` is defined via `@Schema()` annotation in `flutter_gemma_options.dart`.
 
-**`build_runner` note**: Use `dart pub global run build_runner build --delete-conflicting-outputs` (run `dart pub global activate build_runner` once first). The globally activated build_runner runs as an AOT executable which avoids any native_assets bundling issues.
+**Manual `.g.dart` note**: `flutter_gemma_options.g.dart` is manually maintained in this package. When schema fields change, update both `flutter_gemma_options.dart` and `flutter_gemma_options.g.dart` by hand unless the maintainer explicitly asks to regenerate. Do not treat `build_runner` as the default drift fix.
 
 ### Testing pattern
 
@@ -57,4 +62,4 @@ All tests use `FakeRuntime` + `FakeInferenceModel` + `FakeInferenceChat` from `t
 
 ## Lint rules
 
-Uses `flutter_lints` with `prefer_const_constructors`, `prefer_const_declarations`, `avoid_print`, `prefer_single_quotes` enabled. The `example/test/widget_test.dart` has a pre-existing error (`MyApp` not found) — ignore it.
+Uses `flutter_lints` with `prefer_const_constructors`, `prefer_const_declarations`, `avoid_print`, `prefer_single_quotes` enabled. The `example/test/widget_test.dart` has a pre-existing error (`MyApp` not found) - ignore it.


### PR DESCRIPTION
Clean re-application of **#332** onto current main.

#332 had the right intent but its branch was based on a **stale pre-website main** (force-pushed `feature/import-genkit-pkgs`), so merging it directly would have **deleted the entire `website/` package and the Firebase deploy workflow** (real diff vs main was +140 / −5906 across 64 files). The actual change is just 3 docs/skill files, so I cherry-picked it onto fresh main instead.

## Changes (credit: @robertmanzanillag-jpg)
- Move `review-pr.md` from `.claude/skills/` → `.claude/commands/` so it works as a slash command
- Make `upgrade-flutter-gemma` skill monorepo/workspace-aware (`REPO_ROOT` / `PKG_DIR` / `EXAMPLE_DIR`)
- Replace stale `/pr-review-toolkit:review-pr` with `/review-pr` + manual fallback
- Align `CLAUDE.md`: `.g.dart` is manually maintained

Docs/skill-only, no runtime/code impact. Supersedes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)