### PR TITLE
chore(genkit_hybrid): prep for first pub.dev release

### DIFF
--- a/packages/genkit_flutter_gemma/CHANGELOG.md
+++ b/packages/genkit_flutter_gemma/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+- Bump `genkit` to `^0.14.1` and `schemantic` to `^0.2.0`. No API or behavioral changes; tests green against the new versions.
+
 ## 0.4.1
 
 - Move the package into the [flutter_gemma monorepo](https://github.com/DenisovAV/flutter_gemma) (`packages/genkit_flutter_gemma`); `repository`/`homepage` links updated accordingly. No API or behavioral changes.

--- a/packages/genkit_flutter_gemma/example/pubspec.yaml
+++ b/packages/genkit_flutter_gemma/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_gemma_litertlm: ^1.0.0
   flutter_gemma_mediapipe: ^1.0.0
   flutter_gemma_embeddings: ^1.0.0
-  genkit: ^0.13.0
+  genkit: ^0.14.1
   genkit_flutter_gemma:
     path: ../
 

--- a/packages/genkit_flutter_gemma/pubspec.yaml
+++ b/packages/genkit_flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 issue_tracker: https://github.com/DenisovAV/flutter_gemma/issues
@@ -20,10 +20,10 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  genkit: ^0.13.0
+  genkit: ^0.14.1
   flutter_gemma: ^1.0.1
   http: ^1.2.0
-  schemantic: ^0.1.2
+  schemantic: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/genkit_hybrid/.pubignore
+++ b/packages/genkit_hybrid/.pubignore
@@ -1,0 +1,2 @@
+# Internal planning/spec artifacts — not package docs, keep out of the published archive.
+docs/

--- a/packages/genkit_hybrid/README.md
+++ b/packages/genkit_hybrid/README.md
@@ -5,9 +5,13 @@ existing Genkit models (on-device, cloud, anything) behind one routing policy. T
 is an ordinary `Model` — your app still calls a single `ai.generate`.
 
 ```dart
+import 'package:genkit/genkit.dart';
 import 'package:genkit_hybrid/genkit_hybrid.dart';
 
-// onDeviceModel and cloudModel are ordinary Genkit Models you already have.
+final ai = Genkit();
+
+// onDeviceModel and cloudModel are ordinary Genkit Models you already have —
+// e.g. from genkit_flutter_gemma (on-device) and genkit_google_genai (cloud).
 final smart = hybridModelOnDeviceCloud(
   onDevice: onDeviceModel,
   cloud: cloudModel,
@@ -17,6 +21,9 @@ final smart = hybridModelOnDeviceCloud(
     offline: kOnDevice,
   ),
 );
+
+// The hybrid model is an ordinary Model — register it, then use it like any other.
+ai.registry.register(smart);
 
 final res = await ai.generate(model: smart, prompt: 'Hello!');
 ```

--- a/packages/genkit_hybrid/example/genkit_hybrid_example.dart
+++ b/packages/genkit_hybrid/example/genkit_hybrid_example.dart
@@ -1,13 +1,39 @@
-// ignore_for_file: unused_import
+import 'package:genkit/genkit.dart';
 import 'package:genkit_hybrid/genkit_hybrid.dart';
 
-/// Minimal illustration. `onDeviceModel` and `cloudModel` are ordinary Genkit
-/// Models provided by the host app (e.g. from genkit_flutter_gemma and googleAI).
-void buildHybrid(/* Model onDeviceModel, Model cloudModel */) {
-  // Prefer on-device, fall back to cloud on failure/offline:
-  // final smart = hybridModelOnDeviceCloud(
-  //   onDevice: onDeviceModel,
-  //   cloud: cloudModel,
-  //   strategy: FallbackStrategy([kOnDevice, kCloud]),
-  // );
+/// Runnable illustration of [hybridModelOnDeviceCloud].
+///
+/// In a real app, `onDevice` and `cloud` come from provider plugins
+/// (e.g. genkit_flutter_gemma for on-device, genkit_google_genai for cloud).
+/// Here they're trivial in-memory [Model]s so the example runs as-is.
+Future<void> main() async {
+  final ai = Genkit();
+
+  final onDeviceModel = _echoModel('on-device', 'answered on-device');
+  final cloudModel = _echoModel('cloud', 'answered in the cloud');
+
+  // Prefer on-device, fall back to cloud on a transient failure / offline.
+  final smart = hybridModelOnDeviceCloud(
+    onDevice: onDeviceModel,
+    cloud: cloudModel,
+    strategy: FallbackStrategy([kOnDevice, kCloud]),
+  );
+
+  // A hybrid model is an ordinary Genkit Model — register it, then generate.
+  ai.registry.register(smart);
+
+  final res = await ai.generate(model: smart, prompt: 'Hello!');
+  print(res.text);
 }
+
+/// A minimal [Model] that returns a fixed string — stands in for a real provider.
+Model _echoModel(String name, String text) => Model(
+  name: name,
+  fn: (request, context) async => ModelResponse(
+    finishReason: FinishReason.stop,
+    message: Message(
+      role: Role.model,
+      content: [TextPart(text: text)],
+    ),
+  ),
+);

--- a/packages/genkit_hybrid/lib/src/hybrid_model.dart
+++ b/packages/genkit_hybrid/lib/src/hybrid_model.dart
@@ -46,11 +46,13 @@ Model hybridModel({
   return Model(
     name: name,
     fn: (request, context) async {
-      final order = strategy.route(RoutingContext(
-        request: request,
-        branchKeys: frozenBranches.keys.toSet(),
-        isStreaming: context.streamingRequested,
-      ));
+      final order = strategy.route(
+        RoutingContext(
+          request: request,
+          branchKeys: frozenBranches.keys.toSet(),
+          isStreaming: context.streamingRequested,
+        ),
+      );
 
       if (order.isEmpty) {
         throw GenkitException(

--- a/packages/genkit_hybrid/lib/src/strategies/connectivity.dart
+++ b/packages/genkit_hybrid/lib/src/strategies/connectivity.dart
@@ -15,6 +15,7 @@ class ConnectivityStrategy implements RoutingStrategy {
   final String _offline;
 
   @override
-  List<String> route(RoutingContext context) =>
-      [_isOnline() ? _online : _offline];
+  List<String> route(RoutingContext context) => [
+    _isOnline() ? _online : _offline,
+  ];
 }

--- a/packages/genkit_hybrid/lib/src/strategies/with_fallback.dart
+++ b/packages/genkit_hybrid/lib/src/strategies/with_fallback.dart
@@ -6,7 +6,7 @@ import '../routing_strategy.dart';
 /// [inner] are not duplicated (inner order preserved, then remaining tail).
 class WithFallback implements RoutingStrategy {
   WithFallback(this._inner, {required List<String> fallbackOrder})
-      : _fallbackOrder = List.unmodifiable(fallbackOrder);
+    : _fallbackOrder = List.unmodifiable(fallbackOrder);
 
   final RoutingStrategy _inner;
   final List<String> _fallbackOrder;

--- a/packages/genkit_hybrid/pubspec.yaml
+++ b/packages/genkit_hybrid/pubspec.yaml
@@ -4,6 +4,12 @@ version: 0.1.0
 homepage: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/genkit_hybrid
 repository: https://github.com/DenisovAV/flutter_gemma
 issue_tracker: https://github.com/DenisovAV/flutter_gemma/issues
+topics:
+  - genkit
+  - llm
+  - ai
+  - on-device
+  - routing
 
 environment:
   sdk: '>=3.12.0 <4.0.0'

--- a/packages/genkit_hybrid/pubspec.yaml
+++ b/packages/genkit_hybrid/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  genkit: ^0.13.0
+  genkit: ^0.14.1
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/genkit_hybrid/test/exports_test.dart
+++ b/packages/genkit_hybrid/test/exports_test.dart
@@ -7,16 +7,27 @@ void main() {
     expect(kCloud, 'cloud');
     expect(
       FallbackStrategy(['cloud']).route(
-        const RoutingContext(request: null, branchKeys: {'cloud'}, isStreaming: false),
+        const RoutingContext(
+          request: null,
+          branchKeys: {'cloud'},
+          isStreaming: false,
+        ),
       ),
       ['cloud'],
     );
     expect(PreRoutingStrategy((_) => 'cloud'), isA<RoutingStrategy>());
     expect(
-      ConnectivityStrategy(isOnline: () => true, online: 'cloud', offline: 'onDevice'),
+      ConnectivityStrategy(
+        isOnline: () => true,
+        online: 'cloud',
+        offline: 'onDevice',
+      ),
       isA<RoutingStrategy>(),
     );
-    expect(InputSizeStrategy(threshold: 1, small: 'a', large: 'b'), isA<RoutingStrategy>());
+    expect(
+      InputSizeStrategy(threshold: 1, small: 'a', large: 'b'),
+      isA<RoutingStrategy>(),
+    );
     expect(FirstMatch(const []), isA<RoutingStrategy>());
     expect(
       WithFallback(FallbackStrategy(['cloud']), fallbackOrder: const []),

--- a/packages/genkit_hybrid/test/fakes.dart
+++ b/packages/genkit_hybrid/test/fakes.dart
@@ -37,7 +37,10 @@ Model fakeModel({
       }
       return ModelResponse(
         finishReason: FinishReason.stop,
-        message: Message(role: Role.model, content: [TextPart(text: text)]),
+        message: Message(
+          role: Role.model,
+          content: [TextPart(text: text)],
+        ),
       );
     },
   );

--- a/packages/genkit_hybrid/test/hybrid_model_test.dart
+++ b/packages/genkit_hybrid/test/hybrid_model_test.dart
@@ -42,8 +42,16 @@ void main() {
     var deviceCalls = 0, cloudCalls = 0;
     final model = hybridModel(
       branches: {
-        'onDevice': fakeModel(name: 'd', text: 'from-device', onCall: () => deviceCalls++),
-        'cloud': fakeModel(name: 'c', text: 'from-cloud', onCall: () => cloudCalls++),
+        'onDevice': fakeModel(
+          name: 'd',
+          text: 'from-device',
+          onCall: () => deviceCalls++,
+        ),
+        'cloud': fakeModel(
+          name: 'c',
+          text: 'from-cloud',
+          onCall: () => cloudCalls++,
+        ),
       },
       strategy: _Pick(['cloud']),
     );
@@ -58,7 +66,11 @@ void main() {
     final model = hybridModel(
       branches: {
         'onDevice': fakeModel(name: 'd', throwBeforeToken: true),
-        'cloud': fakeModel(name: 'c', text: 'recovered', onCall: () => cloudCalls++),
+        'cloud': fakeModel(
+          name: 'c',
+          text: 'recovered',
+          onCall: () => cloudCalls++,
+        ),
       },
       strategy: _Pick(['onDevice', 'cloud']),
     );
@@ -77,7 +89,11 @@ void main() {
     );
     expect(
       () => model.fn(_req(), _blockingCtx),
-      throwsA(predicate<StateError>((e) => e.message.contains('fail-before-token:c2'))),
+      throwsA(
+        predicate<StateError>(
+          (e) => e.message.contains('fail-before-token:c2'),
+        ),
+      ),
     );
   });
 
@@ -86,7 +102,10 @@ void main() {
       branches: {'cloud': fakeModel(name: 'c')},
       strategy: _Pick([]),
     );
-    expect(() => model.fn(_req(), _blockingCtx), throwsA(isA<GenkitException>()));
+    expect(
+      () => model.fn(_req(), _blockingCtx),
+      throwsA(isA<GenkitException>()),
+    );
   });
 
   test('unknown branch key throws config error', () async {
@@ -94,29 +113,44 @@ void main() {
       branches: {'cloud': fakeModel(name: 'c')},
       strategy: _Pick(['nope']),
     );
-    expect(() => model.fn(_req(), _blockingCtx), throwsA(isA<GenkitException>()));
-  });
-
-  test('permanent GenkitException (e.g. bad auth) does NOT fall back', () async {
-    var cloudCalls = 0;
-    final authFailModel = Model(
-      name: 'auth-fail',
-      fn: (request, context) async =>
-          throw GenkitException('bad key', status: StatusCodes.PERMISSION_DENIED),
-    );
-    final model = hybridModel(
-      branches: {
-        'cloud': authFailModel,
-        'onDevice': fakeModel(name: 'd', text: 'should-not-run', onCall: () => cloudCalls++),
-      },
-      strategy: _Pick(['cloud', 'onDevice']),
-    );
     expect(
       () => model.fn(_req(), _blockingCtx),
       throwsA(isA<GenkitException>()),
     );
-    expect(cloudCalls, 0); // permanent error propagated; second branch NOT tried
   });
+
+  test(
+    'permanent GenkitException (e.g. bad auth) does NOT fall back',
+    () async {
+      var cloudCalls = 0;
+      final authFailModel = Model(
+        name: 'auth-fail',
+        fn: (request, context) async => throw GenkitException(
+          'bad key',
+          status: StatusCodes.PERMISSION_DENIED,
+        ),
+      );
+      final model = hybridModel(
+        branches: {
+          'cloud': authFailModel,
+          'onDevice': fakeModel(
+            name: 'd',
+            text: 'should-not-run',
+            onCall: () => cloudCalls++,
+          ),
+        },
+        strategy: _Pick(['cloud', 'onDevice']),
+      );
+      expect(
+        () => model.fn(_req(), _blockingCtx),
+        throwsA(isA<GenkitException>()),
+      );
+      expect(
+        cloudCalls,
+        0,
+      ); // permanent error propagated; second branch NOT tried
+    },
+  );
 
   test('transient GenkitException (UNAVAILABLE) DOES fall back', () async {
     var deviceCalls = 0;
@@ -128,7 +162,11 @@ void main() {
     final model = hybridModel(
       branches: {
         'cloud': unavailable,
-        'onDevice': fakeModel(name: 'd', text: 'recovered', onCall: () => deviceCalls++),
+        'onDevice': fakeModel(
+          name: 'd',
+          text: 'recovered',
+          onCall: () => deviceCalls++,
+        ),
       },
       strategy: _Pick(['cloud', 'onDevice']),
     );
@@ -137,47 +175,66 @@ void main() {
     expect(res.message!.content.first.text, 'recovered');
   });
 
-  test('streaming: branch fails before first token -> next branch used', () async {
-    final s = _streamingCtx();
-    final model = hybridModel(
-      branches: {
-        'onDevice': fakeModel(name: 'd', throwBeforeToken: true),
-        'cloud': fakeModel(name: 'c', text: 'done', chunks: ['he', 'llo']),
-      },
-      strategy: _Pick(['onDevice', 'cloud']),
-    );
-    final res = await model.fn(_req(), s.ctx);
-    expect(s.received, ['he', 'llo']);
-    expect(res.message!.content.first.text, 'done');
-  });
+  test(
+    'streaming: branch fails before first token -> next branch used',
+    () async {
+      final s = _streamingCtx();
+      final model = hybridModel(
+        branches: {
+          'onDevice': fakeModel(name: 'd', throwBeforeToken: true),
+          'cloud': fakeModel(name: 'c', text: 'done', chunks: ['he', 'llo']),
+        },
+        strategy: _Pick(['onDevice', 'cloud']),
+      );
+      final res = await model.fn(_req(), s.ctx);
+      expect(s.received, ['he', 'llo']);
+      expect(res.message!.content.first.text, 'done');
+    },
+  );
 
-  test('streaming: branch fails AFTER first token -> propagates, no re-route', () async {
-    final s = _streamingCtx();
-    var cloudCalls = 0;
-    final model = hybridModel(
-      branches: {
-        'onDevice': fakeModel(name: 'd', chunks: ['partial'], throwAfterToken: true),
-        'cloud': fakeModel(name: 'c', text: 'should-not-run', onCall: () => cloudCalls++),
-      },
-      strategy: _Pick(['onDevice', 'cloud']),
-    );
-    await expectLater(
-        () => model.fn(_req(), s.ctx), throwsA(isA<StateError>()));
-    expect(s.received, ['partial']); // first token already delivered
-    expect(cloudCalls, 0);           // NOT re-routed mid-stream
-  });
+  test(
+    'streaming: branch fails AFTER first token -> propagates, no re-route',
+    () async {
+      final s = _streamingCtx();
+      var cloudCalls = 0;
+      final model = hybridModel(
+        branches: {
+          'onDevice': fakeModel(
+            name: 'd',
+            chunks: ['partial'],
+            throwAfterToken: true,
+          ),
+          'cloud': fakeModel(
+            name: 'c',
+            text: 'should-not-run',
+            onCall: () => cloudCalls++,
+          ),
+        },
+        strategy: _Pick(['onDevice', 'cloud']),
+      );
+      await expectLater(
+        () => model.fn(_req(), s.ctx),
+        throwsA(isA<StateError>()),
+      );
+      expect(s.received, ['partial']); // first token already delivered
+      expect(cloudCalls, 0); // NOT re-routed mid-stream
+    },
+  );
 
-  test('hybridModel uses a custom name when provided, defaults to "hybrid"', () {
-    final a = hybridModel(
-      branches: {'cloud': fakeModel(name: 'c')},
-      strategy: _Pick(['cloud']),
-    );
-    final b = hybridModel(
-      branches: {'cloud': fakeModel(name: 'c')},
-      strategy: _Pick(['cloud']),
-      name: 'router-A',
-    );
-    expect(a.name, 'hybrid');
-    expect(b.name, 'router-A');
-  });
+  test(
+    'hybridModel uses a custom name when provided, defaults to "hybrid"',
+    () {
+      final a = hybridModel(
+        branches: {'cloud': fakeModel(name: 'c')},
+        strategy: _Pick(['cloud']),
+      );
+      final b = hybridModel(
+        branches: {'cloud': fakeModel(name: 'c')},
+        strategy: _Pick(['cloud']),
+        name: 'router-A',
+      );
+      expect(a.name, 'hybrid');
+      expect(b.name, 'router-A');
+    },
+  );
 }

--- a/packages/genkit_hybrid/test/integration_test.dart
+++ b/packages/genkit_hybrid/test/integration_test.dart
@@ -71,10 +71,7 @@ void main() {
       // Register the hybrid model so the Genkit registry can find it by name.
       ai.registry.register(smart);
 
-      final res = await ai.generate(
-        model: smart,
-        prompt: 'hi',
-      );
+      final res = await ai.generate(model: smart, prompt: 'hi');
 
       expect(res.text, equals('CLOUD'));
 
@@ -96,10 +93,7 @@ void main() {
 
       ai.registry.register(smart);
 
-      final res = await ai.generate(
-        model: smart,
-        prompt: 'hi',
-      );
+      final res = await ai.generate(model: smart, prompt: 'hi');
 
       expect(res.text, equals('RECOVERED'));
 

--- a/packages/genkit_hybrid/test/routing_strategy_test.dart
+++ b/packages/genkit_hybrid/test/routing_strategy_test.dart
@@ -33,22 +33,36 @@ void main() {
   test('RoutingStrategy can be implemented and returns ordered keys', () {
     final s = _ConstStrategy(['cloud', 'onDevice']);
     const ctx = RoutingContext(
-      request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false,
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
     );
     expect(s.route(ctx), ['cloud', 'onDevice']);
   });
 
   test('PreRoutingStrategy wraps a function and returns single key', () {
     final s = PreRoutingStrategy((c) => c.isStreaming ? 'cloud' : 'onDevice');
-    const stream = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: true);
-    const block = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const stream = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: true,
+    );
+    const block = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(stream), ['cloud']);
     expect(s.route(block), ['onDevice']);
   });
 
   test('FallbackStrategy returns its fixed order regardless of context', () {
     final s = FallbackStrategy(['onDevice', 'cloud']);
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['onDevice', 'cloud']);
   });
 
@@ -59,63 +73,121 @@ void main() {
       online: 'cloud',
       offline: 'onDevice',
     );
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['cloud']);
     online = false;
     expect(s.route(ctx), ['onDevice']);
   });
 
   test('InputSizeStrategy routes by total prompt char length', () {
-    final s = InputSizeStrategy(threshold: 10, small: 'onDevice', large: 'cloud');
-    final shortReq = ModelRequest(messages: [
-      Message(role: Role.user, content: [TextPart(text: 'hi')]),
-    ]);
-    final longReq = ModelRequest(messages: [
-      Message(role: Role.user, content: [TextPart(text: 'this is a long prompt')]),
-    ]);
-    RoutingContext ctx(ModelRequest r) =>
-        RoutingContext(request: r, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    final s = InputSizeStrategy(
+      threshold: 10,
+      small: 'onDevice',
+      large: 'cloud',
+    );
+    final shortReq = ModelRequest(
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'hi')],
+        ),
+      ],
+    );
+    final longReq = ModelRequest(
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'this is a long prompt')],
+        ),
+      ],
+    );
+    RoutingContext ctx(ModelRequest r) => RoutingContext(
+      request: r,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx(shortReq)), ['onDevice']);
     expect(s.route(ctx(longReq)), ['cloud']);
   });
 
   test('InputSizeStrategy treats null request as size 0 (small)', () {
-    final s = InputSizeStrategy(threshold: 10, small: 'onDevice', large: 'cloud');
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    final s = InputSizeStrategy(
+      threshold: 10,
+      small: 'onDevice',
+      large: 'cloud',
+    );
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['onDevice']);
   });
 
   test('FirstMatch returns first non-empty child result; skips empty', () {
     final s = FirstMatch([
-      _ConstStrategy([]),            // no decision -> skipped
-      _ConstStrategy(['cloud']),     // first match
-      _ConstStrategy(['onDevice']),  // never reached
+      _ConstStrategy([]), // no decision -> skipped
+      _ConstStrategy(['cloud']), // first match
+      _ConstStrategy(['onDevice']), // never reached
     ]);
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['cloud']);
   });
 
   test('FirstMatch returns empty when all children are empty', () {
     final s = FirstMatch([_ConstStrategy([]), _ConstStrategy([])]);
-    const ctx = RoutingContext(request: null, branchKeys: {'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), isEmpty);
   });
 
   test('WithFallback appends fallback tail to inner pick', () {
-    final s = WithFallback(_ConstStrategy(['cloud']), fallbackOrder: ['onDevice']);
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    final s = WithFallback(
+      _ConstStrategy(['cloud']),
+      fallbackOrder: ['onDevice'],
+    );
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['cloud', 'onDevice']);
   });
 
   test('WithFallback de-dupes keys already chosen by inner strategy', () {
-    final s = WithFallback(_ConstStrategy(['onDevice']), fallbackOrder: ['onDevice', 'cloud']);
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    final s = WithFallback(
+      _ConstStrategy(['onDevice']),
+      fallbackOrder: ['onDevice', 'cloud'],
+    );
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['onDevice', 'cloud']);
   });
 
   test('WithFallback returns just the tail when inner is empty', () {
-    final s = WithFallback(_ConstStrategy([]), fallbackOrder: ['onDevice', 'cloud']);
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    final s = WithFallback(
+      _ConstStrategy([]),
+      fallbackOrder: ['onDevice', 'cloud'],
+    );
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['onDevice', 'cloud']);
   });
 
@@ -123,13 +195,21 @@ void main() {
     final input = ['onDevice', 'cloud'];
     final s = FallbackStrategy(input);
     input.add('mutated'); // mutate AFTER construction
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['onDevice', 'cloud']); // unaffected by mutation
   });
 
   test('FallbackStrategy returns an unmodifiable list', () {
     final s = FallbackStrategy(['onDevice', 'cloud']);
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(() => s.route(ctx).add('x'), throwsUnsupportedError);
   });
 
@@ -141,22 +221,43 @@ void main() {
     final tail = ['onDevice'];
     final s = WithFallback(_ConstStrategy(['cloud']), fallbackOrder: tail);
     tail.add('mutated'); // mutate AFTER construction
-    const ctx = RoutingContext(request: null, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['cloud', 'onDevice']); // unaffected
   });
 
   test('PreRoutingStrategy treats empty-string return as no decision', () {
     final s = PreRoutingStrategy((_) => '');
-    const ctx = RoutingContext(request: null, branchKeys: {'cloud'}, isStreaming: false);
+    const ctx = RoutingContext(
+      request: null,
+      branchKeys: {'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), isEmpty);
   });
 
   test('InputSizeStrategy: size equal to threshold routes to small', () {
-    final s = InputSizeStrategy(threshold: 10, small: 'onDevice', large: 'cloud');
-    final exactReq = ModelRequest(messages: [
-      Message(role: Role.user, content: [TextPart(text: '1234567890')]), // exactly 10 chars
-    ]);
-    final ctx = RoutingContext(request: exactReq, branchKeys: {'onDevice', 'cloud'}, isStreaming: false);
+    final s = InputSizeStrategy(
+      threshold: 10,
+      small: 'onDevice',
+      large: 'cloud',
+    );
+    final exactReq = ModelRequest(
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: '1234567890')],
+        ), // exactly 10 chars
+      ],
+    );
+    final ctx = RoutingContext(
+      request: exactReq,
+      branchKeys: {'onDevice', 'cloud'},
+      isStreaming: false,
+    );
     expect(s.route(ctx), ['onDevice']); // == threshold -> small
   });
 }

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -140,13 +140,16 @@ flutter_gemma and works with **any** pair of Genkit models.
 ```
 dependencies:
   genkit_hybrid: ^0.1.0
-  genkit: any
+  genkit: ^0.14.0
 ```
 
 ### Basic usage
 
 ```dart
+import 'package:genkit/genkit.dart';
 import 'package:genkit_hybrid/genkit_hybrid.dart';
+
+final ai = Genkit();
 
 // onDeviceModel and cloudModel are ordinary Genkit Models you already have.
 final smart = hybridModelOnDeviceCloud(
@@ -158,6 +161,9 @@ final smart = hybridModelOnDeviceCloud(
     offline: kOnDevice,
   ),
 );
+
+// A hybrid model is an ordinary Model — register it, then use it like any other.
+ai.registry.register(smart);
 
 final response = await ai.generate(model: smart, prompt: 'Hello!');
 ```

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -20,7 +20,7 @@ with the on-device model exactly as it would with any cloud provider.
 
 ```
 dependencies:
-  genkit_flutter_gemma: ^0.4.1
+  genkit_flutter_gemma: ^0.4.2
   flutter_gemma: ^1.0.2
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -20,13 +20,13 @@ with the on-device model exactly as it would with any cloud provider.
 
 ```
 dependencies:
-  genkit_flutter_gemma: ^0.4.0
-  flutter_gemma: ^1.0.0
+  genkit_flutter_gemma: ^0.4.1
+  flutter_gemma: ^1.0.2
   # Add the inference engine(s) you need:
-  flutter_gemma_litertlm: ^1.0.0   # .litertlm models (mobile + desktop)
-  flutter_gemma_mediapipe: ^1.0.0  # .task / .bin models (mobile + web)
+  flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)
+  flutter_gemma_mediapipe: ^1.0.2  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
-  flutter_gemma_embeddings: ^1.0.0
+  flutter_gemma_embeddings: ^1.0.1
 ```
 
 ### Setup


### PR DESCRIPTION
Product + docs review before publishing `genkit_hybrid` 0.1.0 (it's documented on the site + linked in the footer but **not yet on pub.dev** → currently a broken install). Fixes the gaps that would make a weak first impression:

## genkit_hybrid
- **README quick-start now runs** — added the required `ai.registry.register(smart)` step, defined `ai`, and pointed at where the input models come from (`genkit_flutter_gemma` / `genkit_google_genai`). As written before, the headline example failed with "model not found".
- **example/** — replaced the all-commented stub with a runnable example (two in-memory models → register → generate).
- **pubspec** — added `topics` for pub.dev discoverability.
- **.pubignore** — keep internal `docs/` (planning + spec notes) out of the published archive (also clears the pub "rename docs→doc" warning).
- `dart format` across the package.

## docs
- Bump version pins in `website/content/docs/genkit.md` to published versions: `genkit_flutter_gemma ^0.4.1`, `flutter_gemma`/`litertlm`/`mediapipe ^1.0.2`, `embeddings ^1.0.1`.

Verified: `dart analyze` clean · 32 tests pass · `dart pub publish --dry-run` 0 warnings (bar the commit-state notice). After this merges, `genkit_hybrid` can be published, which makes the site's install instruction + footer link valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)