### PR TITLE
chore(release): bump ios/macos podspec to 1.0.3

### DIFF
--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.16.3'
+  s.version          = '1.0.3'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,

--- a/packages/flutter_gemma/macos/flutter_gemma.podspec
+++ b/packages/flutter_gemma/macos/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '0.16.3'
+  s.version          = '1.0.3'
   s.summary          = 'Flutter Gemma - Run Gemma AI models locally on desktop'
   s.description      = <<-DESC
 Flutter plugin for running Gemma AI models locally on macOS using LiteRT-LM.


### PR DESCRIPTION
The native plugin podspec `s.version` was stuck at **0.16.3** — it was never bumped through any of the 1.0.x releases. Sync it to the pubspec version (1.0.3) before publishing `flutter_gemma 1.0.3` to pub.dev.

Surfaced by the release pre-flight version-consistency check (release skill Step 2). ios + macos podspecs only; no code change.

Blocks: publishing 1.0.3 (the podspec ships in the pub package, so it should match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)