### PR TITLE
fix(android): declare libvndksupport.so for GPU backend (#324)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,11 @@ Entitlements needed: `extended-virtual-addressing`, `increased-memory-limit`
 
 ### Android
 ```xml
+<!-- libvndksupport.so is required for the GPU backend on Android 12+: the
+     v0.13.x OpenCL loader uses its android_load_sphal_library() to dlopen the
+     vendor OpenCL ICD. Without it OpenCL fails to load → WebGPU fallback →
+     hard-freeze on some Mali drivers (#324). -->
+<uses-native-library android:name="libvndksupport.so" android:required="false"/>
 <uses-native-library android:name="libOpenCL.so" android:required="false"/>
 <uses-native-library android:name="libOpenCL-car.so" android:required="false"/>
 <uses-native-library android:name="libOpenCL-pixel.so" android:required="false"/>

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+- Declare `libvndksupport.so` for the Android GPU backend — fixes Mali GPU hard-freeze on Android 12+ (#324).
+
 ## 1.1.0
 - Add declared-column `Filter` support: `FilterSchema`/`FilterField`/`FilterFieldType` + `configure(FilterSchema)` on `VectorStoreRepository`.
 - Add optional `filterSchema:` to `FlutterGemma.initialize` (threaded to the vector store at registration).

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -295,6 +295,11 @@ use_frameworks! :linkage => :static
 Add to 'AndroidManifest.xml' above tag `</application>`
 
 ```AndroidManifest.xml
+ <!-- Required for the GPU backend on Android 12+: the OpenCL loader uses
+      libvndksupport.so (android_load_sphal_library) to dlopen the vendor
+      OpenCL driver. Without it OpenCL can't load and the engine falls back to
+      WebGPU, which hard-freezes some Mali GPUs on the vision encoder (#324). -->
+ <uses-native-library android:name="libvndksupport.so" android:required="false"/>
  <uses-native-library
      android:name="libOpenCL.so"
      android:required="false"/>

--- a/packages/flutter_gemma/android/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/android/src/main/AndroidManifest.xml
@@ -3,5 +3,13 @@
         <!-- Required for Qualcomm HTP dispatch: lets Bionic resolve libcdsprpc.so
              from the vendor partition when libLiteRtDispatch_Qualcomm.so is loaded. -->
         <uses-native-library android:name="libcdsprpc.so" android:required="false"/>
+        <!-- Required for the GPU backend on Android 12+: the LiteRT-LM OpenCL
+             loader (v0.13.x) uses libvndksupport.so's android_load_sphal_library()
+             to dlopen the vendor OpenCL ICD from the app's linker namespace.
+             Without it OpenCL fails to load and the engine falls back to WebGPU,
+             which hard-freezes some Mali GPU drivers compiling the vision
+             encoder (#324). Merged into every consumer app via manifest merger
+             so the GPU path works without each app re-declaring it. -->
+        <uses-native-library android:name="libvndksupport.so" android:required="false"/>
     </application>
 </manifest>

--- a/packages/flutter_gemma/android/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/android/src/main/AndroidManifest.xml
@@ -1,7 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <!-- Required for Qualcomm HTP dispatch: lets Bionic resolve libcdsprpc.so
-             from the vendor partition when libLiteRtDispatch_Qualcomm.so is loaded. -->
+        <!-- LAYERING NOTE: the <uses-native-library> declarations below serve the
+             opt-in `flutter_gemma_litertlm` engine (its GPU/NPU native backends),
+             NOT the engine-agnostic core. They live here because that engine ships
+             as a Native-Assets FFI package with no Android library module of its
+             own, so it cannot contribute an AndroidManifest to the merge — the
+             core plugin is the only manifest in the graph that can declare them.
+             All are required="false": pure namespace declarations (not loads), so
+             they are inert for apps that never use the GPU/NPU path (the libs are
+             never dlopen'd) and never block install on devices that lack them. -->
+
+        <!-- Required for Qualcomm HTP (NPU) dispatch: lets Bionic resolve
+             libcdsprpc.so from the vendor partition when
+             libLiteRtDispatch_Qualcomm.so is loaded. -->
         <uses-native-library android:name="libcdsprpc.so" android:required="false"/>
         <!-- Required for the GPU backend on Android 12+: the LiteRT-LM OpenCL
              loader (v0.13.x) uses libvndksupport.so's android_load_sphal_library()

--- a/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,14 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- GPU backend (LiteRT-LM): on Android 12+ the app linker namespace
+             can't dlopen the vendor OpenCL ICD without declaring its loader.
+             libvndksupport.so provides android_load_sphal_library(), which the
+             v0.13.x OpenCL loader uses to reach libOpenCL.so in the sphal
+             namespace. Without it OpenCL fails to load and the engine falls
+             back to WebGPU, which hard-freezes some Mali drivers on the vision
+             encoder (#324). Required per Google's LiteRT-LM Android docs. -->
+        <uses-native-library android:name="libvndksupport.so" android:required="false"/>
         <uses-native-library
             android:name="libOpenCL.so"
             android:required="false"/>

--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.0.3'
+  s.version          = '1.1.1'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,

--- a/packages/flutter_gemma/macos/flutter_gemma.podspec
+++ b/packages/flutter_gemma/macos/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.0.3'
+  s.version          = '1.1.1'
   s.summary          = 'Flutter Gemma - Run Gemma AI models locally on desktop'
   s.description      = <<-DESC
 Flutter plugin for running Gemma AI models locally on macOS using LiteRT-LM.

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.1.0
+version: 1.1.1
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma


### PR DESCRIPTION
Fixes **#324** — `flutter_gemma` 1.0.x hard-freezes some Mali devices (Pixel 7a / Tensor G2 / Mali-G710) at the vision-encoder compile when running a multimodal `.litertlm` model on the GPU.

## Root cause
Between native v0.11.0-b and v0.13.x, LiteRT-LM's OpenCL loader switched to loading the vendor OpenCL ICD via `libvndksupport.so` (`android_load_sphal_library`). On **Android 12+** an app's linker namespace can't `dlopen` a vendor driver loader unless it's declared with `<uses-native-library>`. Without it:

```
Failed to load OpenCL library with dlopen: ... library "libvndksupport.so" not found
ml_drift_gpu_accelerator.cc: OpenCL not supported on this platform. Using WebGPU instead.
```

→ OpenCL never loads → the ~2245-op vision encoder falls back to `LITERT_WEBGPU` → the Mali driver hangs compiling it → **device-wide OOM / hard freeze (reboot required)**.

This is a documented requirement — Google's [LiteRT-LM Android docs](https://developers.google.com/edge/litert-lm/android) list `libvndksupport.so` alongside `libOpenCL.so` for the GPU backend. We were missing the declaration.

## Fix
Declare `<uses-native-library android:name="libvndksupport.so" android:required="false"/>`:
- **plugin manifest** (`packages/flutter_gemma/android`) — merges into every consumer app so the GPU path works out of the box;
- example manifest, CLAUDE.md, README.

`required="false"` makes it **harmless for apps that don't use GPU/vision** — it's a namespace declaration, not a load; the lib is never `dlopen`'d on the CPU path, and apps install/run fine on devices without it. Same pattern as the existing `libcdsprpc.so` declaration.

## Verified
Confirmed on the reporter's **Pixel 7a (Tensor G2 / Mali-G710), Android 16 + 17** (the exact config that used to freeze):
- `Loaded OpenCL library with dlopen` → vision encoder (2245 ops) on `LITERT_CL`
- 0 `LITERT_WEBGPU`, 0 `libvndksupport.so not found`
- full multimodal (text + image) works, no freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)