### PR TITLE
feat(core): injectable shared FileDownloader updates stream (#342)

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.2
 - Migrate Android module to Built-in Kotlin — apply KGP only on AGP < 9, ready for AGP 9+ (#323).
+- Add optional `downloadUpdatesStream`/`fileSystemService` injection to `FlutterGemma.initialize` (#342, thanks @hughesyadaddy).
 
 ## 1.1.1
 - Declare `libvndksupport.so` for the Android GPU backend — fixes Mali GPU hard-freeze on Android 12+ (#324).

--- a/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
+++ b/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_gemma/core/api/inference_installation_builder.dart';
 import 'package:flutter_gemma/core/api/embedding_installation_builder.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
+import 'package:flutter_gemma/core/services/file_system_service.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/domain/web_storage_mode.dart';
 import 'package:flutter_gemma/core/infrastructure/web_download_service_stub.dart'
@@ -146,6 +147,20 @@ class FlutterGemma {
     // empty default keeps every store in its existing "filters are a safe
     // no-op" mode.
     FilterSchema filterSchema = const FilterSchema(),
+
+    /// Optional host-provided broadcast of download task updates (mobile).
+    ///
+    /// On iOS/Android, events must be [TaskUpdate] values from
+    /// `package:background_downloader` — the same shape as
+    /// [FileDownloader.updates]. Ignored on web. When omitted,
+    /// [SmartDownloader] uses its internal broadcast wrapper.
+    Stream<Object>? downloadUpdatesStream,
+
+    /// Optional custom model file storage (e.g. outside Documents).
+    ///
+    /// [FileSystemService] is defined in core but not exported from the
+    /// public barrel; pass an implementation from your app or tests.
+    FileSystemService? fileSystemService,
   }) async {
     // Migration: enableWebCache takes precedence if provided (for backward compatibility)
     final effectiveStorageMode = enableWebCache != null
@@ -158,6 +173,8 @@ class FlutterGemma {
       webStorageMode: effectiveStorageMode,
       vectorStoreRepository: vectorStore,
       filterSchema: filterSchema,
+      downloadUpdatesStream: downloadUpdatesStream,
+      fileSystemService: fileSystemService,
     );
 
     if (inferenceEngines.isNotEmpty) {

--- a/packages/flutter_gemma/lib/core/di/download_hub/configure_download_updates_stream_mobile.dart
+++ b/packages/flutter_gemma/lib/core/di/download_hub/configure_download_updates_stream_mobile.dart
@@ -1,0 +1,12 @@
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter_gemma/mobile/smart_downloader.dart';
+
+/// Wires a host-provided download hub into [SmartDownloader] (mobile only).
+void configureDownloadUpdatesStream(Stream<Object>? stream) {
+  SmartDownloader.configureDownloadUpdatesStream(stream?.cast<TaskUpdate>());
+}
+
+/// Clears injected hub state (tests, registry [ServiceRegistry.reset]).
+void clearDownloadUpdatesStream() {
+  SmartDownloader.clearConfiguration();
+}

--- a/packages/flutter_gemma/lib/core/di/download_hub/configure_download_updates_stream_stub.dart
+++ b/packages/flutter_gemma/lib/core/di/download_hub/configure_download_updates_stream_stub.dart
@@ -1,0 +1,5 @@
+/// Web stub — download hub injection is mobile-only (background_downloader).
+void configureDownloadUpdatesStream(Stream<Object>? stream) {}
+
+/// Web stub — no-op.
+void clearDownloadUpdatesStream() {}

--- a/packages/flutter_gemma/lib/core/di/service_registry.dart
+++ b/packages/flutter_gemma/lib/core/di/service_registry.dart
@@ -29,6 +29,9 @@ import 'package:flutter_gemma/core/infrastructure/flutter_asset_loader_stub.dart
 import 'package:flutter_gemma/core/infrastructure/shared_preferences_model_repository.dart';
 import 'package:flutter_gemma/core/infrastructure/in_memory_model_repository.dart';
 import 'package:flutter_gemma/core/services/vector_store_repository.dart';
+import 'package:flutter_gemma/core/di/download_hub/configure_download_updates_stream_mobile.dart'
+    if (dart.library.js_interop) 'package:flutter_gemma/core/di/download_hub/configure_download_updates_stream_stub.dart'
+    as download_hub;
 import 'package:flutter_gemma/core/services/vector_store_filter.dart';
 import 'package:flutter_gemma/core/infrastructure/unconfigured_vector_store.dart';
 import 'package:flutter_gemma/core/infrastructure/web_download_service_stub.dart'
@@ -409,6 +412,9 @@ class ServiceRegistry {
   /// - [vectorStoreRepository]: Optional custom repository (for testing)
   /// - [filterSchema]: Declared filterable-metadata fields; applied to the
   ///   vector store via `configure()` before its `initialize()` (default empty)
+  /// - [downloadUpdatesStream]: Optional host download hub (mobile only).
+  ///   Events must be `background_downloader` [TaskUpdate] values. Ignored on
+  ///   web. Non-broadcast streams are wrapped internally.
   /// - Services can be overridden for testing (dependency injection)
   ///
   /// Note: This is async because web platform requires SharedPreferences initialization.
@@ -423,6 +429,7 @@ class ServiceRegistry {
     ProtectedFilesRegistry? protectedFilesRegistry,
     VectorStoreRepository? vectorStoreRepository,
     FilterSchema filterSchema = const FilterSchema(),
+    Stream<Object>? downloadUpdatesStream,
   }) async {
     // Make idempotent - skip if already initialized
     if (_instance != null) {
@@ -440,6 +447,8 @@ class ServiceRegistry {
       return;
     }
 
+    download_hub.configureDownloadUpdatesStream(downloadUpdatesStream);
+
     _instance = await _create(
       huggingFaceToken: huggingFaceToken,
       maxDownloadRetries: maxDownloadRetries,
@@ -456,6 +465,7 @@ class ServiceRegistry {
 
   /// Resets the singleton (primarily for testing)
   static void reset() {
+    download_hub.clearDownloadUpdatesStream();
     _instance = null;
   }
 
@@ -464,6 +474,7 @@ class ServiceRegistry {
   /// Should be called when shutting down the application.
   /// After calling dispose(), you must call initialize() again to use the registry.
   Future<void> dispose() async {
+    download_hub.clearDownloadUpdatesStream();
     // Close VectorStore database connection
     try {
       await _vectorStoreRepository.close();

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter_gemma/core/domain/download_error.dart';
 import 'package:flutter_gemma/core/domain/download_exception.dart';
@@ -79,9 +81,51 @@ class SmartDownloader {
 
   /// Get broadcast stream for FileDownloader updates
   /// Creates the broadcast stream once and reuses it for all downloads
+  /// Optional hub stream configured at init (e.g. host cache client forwarder).
+  static Stream<TaskUpdate>? _configuredDownloadUpdatesStream;
+
+  /// Memoized broadcast wrapper for [_configuredDownloadUpdatesStream].
+  static Stream<TaskUpdate>? _configuredBroadcastStream;
+
+  /// Registers a shared download-updates stream for all SmartDownloader
+  /// paths (new downloads and attach-to-existing).
+  ///
+  /// [stream] may be single- or broadcast; non-broadcast sources are
+  /// wrapped with [Stream.asBroadcastStream] so concurrent downloads can
+  /// each call [Stream.listen].
+  static void configureDownloadUpdatesStream(Stream<TaskUpdate>? stream) {
+    _configuredDownloadUpdatesStream = stream;
+    _configuredBroadcastStream = null;
+  }
+
+  /// Clears injected hub configuration (e.g. registry reset / dispose).
+  static void clearConfiguration() {
+    _configuredDownloadUpdatesStream = null;
+    _configuredBroadcastStream = null;
+    _broadcastStream = null;
+  }
+
+  @visibleForTesting
+  static void resetDownloadUpdatesStreamConfig() => clearConfiguration();
+
+  @visibleForTesting
+  static Stream<TaskUpdate> debugResolveUpdatesStream() =>
+      _resolveUpdatesStream();
+
   static Stream<TaskUpdate> _getUpdatesStream() {
     _broadcastStream ??= FileDownloader().updates.asBroadcastStream();
     return _broadcastStream!;
+  }
+
+  static Stream<TaskUpdate> _resolveUpdatesStream() {
+    final source = _configuredDownloadUpdatesStream;
+    if (source != null) {
+      _configuredBroadcastStream ??= source.isBroadcast
+          ? source
+          : source.asBroadcastStream();
+      return _configuredBroadcastStream!;
+    }
+    return _getUpdatesStream();
   }
 
   /// Downloads a file with smart retry logic and HTTP-aware error handling
@@ -207,6 +251,17 @@ class SmartDownloader {
             },
           );
         })
+        .catchError((Object e, StackTrace st) {
+          // If _ensureConfigured() or a synchronous failure in
+          // _downloadWithSmartRetry throws, surface it on the progress stream
+          // and close it — otherwise the caller's `await for` over
+          // progress.stream hangs forever (the silent-hang class this hub work
+          // exists to prevent).
+          if (!progress.isClosed) {
+            progress.addError(e, st);
+            progress.close();
+          }
+        })
         .whenComplete(() {
           // Clean up cancellation listener when download completes
           cancellationListener?.cancel();
@@ -267,42 +322,65 @@ class SmartDownloader {
         final completer = Completer<void>();
 
         // Attach listener to existing task
-        listener = _getUpdatesStream().listen((update) async {
-          if (update.task.taskId != taskId) return;
+        listener = _resolveUpdatesStream().listen(
+          (update) async {
+            if (update.task.taskId != taskId) return;
 
-          if (update is TaskProgressUpdate) {
-            final percents = (update.progress * 100).round();
-            gemmaLog('📊 Progress (existing): $percents%');
-            if (!progress.isClosed) {
-              progress.add(percents.clamp(0, 100));
-            }
-          } else if (update is TaskStatusUpdate) {
-            gemmaLog('📡 TaskStatusUpdate (existing): ${update.status}');
-            if (update.status == TaskStatus.complete) {
+            if (update is TaskProgressUpdate) {
+              final percents = (update.progress * 100).round();
+              gemmaLog('📊 Progress (existing): $percents%');
               if (!progress.isClosed) {
-                progress.add(100);
-                progress.close();
+                progress.add(percents.clamp(0, 100));
               }
-              await listener?.cancel();
-              completer.complete();
-            } else if (update.status == TaskStatus.failed ||
-                update.status == TaskStatus.canceled) {
-              // Existing task failed - let caller handle retry
-              if (!progress.isClosed) {
-                progress.addError(
-                  DownloadException(
-                    DownloadError.network(
-                      'Existing download failed: ${update.status}',
+            } else if (update is TaskStatusUpdate) {
+              gemmaLog('📡 TaskStatusUpdate (existing): ${update.status}');
+              if (update.status == TaskStatus.complete) {
+                if (!progress.isClosed) {
+                  progress.add(100);
+                  progress.close();
+                }
+                await listener?.cancel();
+                completer.complete();
+              } else if (update.status == TaskStatus.failed ||
+                  update.status == TaskStatus.canceled) {
+                // Existing task failed - let caller handle retry
+                if (!progress.isClosed) {
+                  progress.addError(
+                    DownloadException(
+                      DownloadError.network(
+                        'Existing download failed: ${update.status}',
+                      ),
                     ),
-                  ),
-                );
-                progress.close();
+                  );
+                  progress.close();
+                }
+                await listener?.cancel();
+                completer.complete();
               }
-              await listener?.cancel();
-              completer.complete();
             }
-          }
-        });
+          },
+          onError: (Object error, StackTrace stackTrace) async {
+            if (!progress.isClosed) {
+              progress.addError(error, stackTrace);
+              progress.close();
+            }
+            await listener?.cancel();
+            if (!completer.isCompleted) {
+              completer.completeError(error, stackTrace);
+            }
+          },
+          onDone: () {
+            if (!completer.isCompleted) {
+              completer.completeError(
+                StateError(
+                  'Download updates stream closed before task $taskId '
+                  'completed',
+                ),
+                StackTrace.current,
+              );
+            }
+          },
+        );
 
         onListenerCreated?.call(listener);
         onTaskCreated?.call(taskId);
@@ -356,129 +434,152 @@ class SmartDownloader {
 
       // Listen to broadcast stream to get full status info including HTTP code
       // Using broadcast stream allows multiple downloads and retries
-      listener = _getUpdatesStream().listen((update) async {
-        if (update.task.taskId != task.taskId) return;
+      listener = _resolveUpdatesStream().listen(
+        (update) async {
+          if (update.task.taskId != task.taskId) return;
 
-        gemmaLog(
-          '📡 Received update for task ${task.taskId}: ${update.runtimeType}',
-        );
-
-        if (update is TaskProgressUpdate) {
-          final percents = (update.progress * 100).round();
-          gemmaLog('📊 Progress: $percents%');
-          if (!progress.isClosed) {
-            progress.add(percents.clamp(0, 100));
-          }
-        } else if (update is TaskStatusUpdate) {
           gemmaLog(
-            '📡 TaskStatusUpdate: ${update.status}, HTTP: ${update.responseStatusCode}',
+            '📡 Received update for task ${task.taskId}: ${update.runtimeType}',
           );
 
-          switch (update.status) {
-            case TaskStatus.complete:
-              if (!progress.isClosed) {
-                progress.add(100);
-                progress.close();
-              }
-              await listener?.cancel();
-              completer.complete(); // ✅ Signal completion
-              break;
+          if (update is TaskProgressUpdate) {
+            final percents = (update.progress * 100).round();
+            gemmaLog('📊 Progress: $percents%');
+            if (!progress.isClosed) {
+              progress.add(percents.clamp(0, 100));
+            }
+          } else if (update is TaskStatusUpdate) {
+            gemmaLog(
+              '📡 TaskStatusUpdate: ${update.status}, HTTP: ${update.responseStatusCode}',
+            );
 
-            case TaskStatus.failed:
-              gemmaLog('🔴 SmartDownloader: TaskStatus.failed detected');
-              gemmaLog(
-                '🔴 HTTP Status Code from update: ${update.responseStatusCode}',
-              );
-              gemmaLog('🔴 Exception: ${update.exception}');
-              gemmaLog('🔴 Progress closed: ${progress.isClosed}');
-              gemmaLog('🔴 Current attempt: $currentAttempt');
-
-              // Try to get HTTP code from multiple sources
-              int? httpCode = update.responseStatusCode;
-
-              // If not in responseStatusCode, check exception
-              if (httpCode == null && update.exception != null) {
-                if (update.exception is TaskHttpException) {
-                  httpCode =
-                      (update.exception as TaskHttpException).httpResponseCode;
-                  gemmaLog(
-                    '🔴 HTTP Status Code from TaskHttpException: $httpCode',
-                  );
+            switch (update.status) {
+              case TaskStatus.complete:
+                if (!progress.isClosed) {
+                  progress.add(100);
+                  progress.close();
                 }
-              }
-
-              final resumePending = await _handleFailedDownload(
-                task: task,
-                downloader: downloader,
-                url: url,
-                targetPath: targetPath,
-                token: token,
-                maxRetries: maxRetries,
-                progress: progress,
-                currentAttempt: currentAttempt,
-                httpStatusCode: httpCode,
-                currentListener: listener,
-                cancelToken: cancelToken,
-                onListenerCreated: onListenerCreated,
-                onTaskCreated: onTaskCreated,
-              );
-
-              // Only cleanup if no resume is pending
-              // If resume was triggered, we need to keep listening for the result
-              if (!resumePending) {
                 await listener?.cancel();
-                completer.complete();
-              } else {
-                gemmaLog('🔄 Resume pending - keeping listener active');
-              }
-              break;
+                completer.complete(); // ✅ Signal completion
+                break;
 
-            case TaskStatus.canceled:
-              if (!progress.isClosed) {
-                progress.addError(
-                  const DownloadException(DownloadError.canceled()),
-                  StackTrace.current,
+              case TaskStatus.failed:
+                gemmaLog('🔴 SmartDownloader: TaskStatus.failed detected');
+                gemmaLog(
+                  '🔴 HTTP Status Code from update: ${update.responseStatusCode}',
                 );
-                progress.close();
-              }
-              await listener?.cancel();
-              completer.complete(); // ✅ Signal completion
-              break;
+                gemmaLog('🔴 Exception: ${update.exception}');
+                gemmaLog('🔴 Progress closed: ${progress.isClosed}');
+                gemmaLog('🔴 Current attempt: $currentAttempt');
 
-            case TaskStatus.notFound:
-              gemmaLog(
-                '🔴 SmartDownloader: TaskStatus.notFound detected (404)',
-              );
+                // Try to get HTTP code from multiple sources
+                int? httpCode = update.responseStatusCode;
 
-              // 404 is a non-retryable error - handle immediately
-              // Note: 404 always returns false (no resume), but using same pattern for consistency
-              final resumePending404 = await _handleFailedDownload(
-                task: task,
-                downloader: downloader,
-                url: url,
-                targetPath: targetPath,
-                token: token,
-                maxRetries: maxRetries,
-                progress: progress,
-                currentAttempt: currentAttempt,
-                httpStatusCode: 404,
-                currentListener: listener,
-                cancelToken: cancelToken,
-                onListenerCreated: onListenerCreated,
-                onTaskCreated: onTaskCreated,
-              );
+                // If not in responseStatusCode, check exception
+                if (httpCode == null && update.exception != null) {
+                  if (update.exception is TaskHttpException) {
+                    httpCode = (update.exception as TaskHttpException)
+                        .httpResponseCode;
+                    gemmaLog(
+                      '🔴 HTTP Status Code from TaskHttpException: $httpCode',
+                    );
+                  }
+                }
 
-              if (!resumePending404) {
+                final resumePending = await _handleFailedDownload(
+                  task: task,
+                  downloader: downloader,
+                  url: url,
+                  targetPath: targetPath,
+                  token: token,
+                  maxRetries: maxRetries,
+                  progress: progress,
+                  currentAttempt: currentAttempt,
+                  httpStatusCode: httpCode,
+                  currentListener: listener,
+                  cancelToken: cancelToken,
+                  onListenerCreated: onListenerCreated,
+                  onTaskCreated: onTaskCreated,
+                );
+
+                // Only cleanup if no resume is pending
+                // If resume was triggered, we need to keep listening for the result
+                if (!resumePending) {
+                  await listener?.cancel();
+                  completer.complete();
+                } else {
+                  gemmaLog('🔄 Resume pending - keeping listener active');
+                }
+                break;
+
+              case TaskStatus.canceled:
+                if (!progress.isClosed) {
+                  progress.addError(
+                    const DownloadException(DownloadError.canceled()),
+                    StackTrace.current,
+                  );
+                  progress.close();
+                }
                 await listener?.cancel();
-                completer.complete();
-              }
-              break;
+                completer.complete(); // ✅ Signal completion
+                break;
 
-            default:
-              break;
+              case TaskStatus.notFound:
+                gemmaLog(
+                  '🔴 SmartDownloader: TaskStatus.notFound detected (404)',
+                );
+
+                // 404 is a non-retryable error - handle immediately
+                // Note: 404 always returns false (no resume), but using same pattern for consistency
+                final resumePending404 = await _handleFailedDownload(
+                  task: task,
+                  downloader: downloader,
+                  url: url,
+                  targetPath: targetPath,
+                  token: token,
+                  maxRetries: maxRetries,
+                  progress: progress,
+                  currentAttempt: currentAttempt,
+                  httpStatusCode: 404,
+                  currentListener: listener,
+                  cancelToken: cancelToken,
+                  onListenerCreated: onListenerCreated,
+                  onTaskCreated: onTaskCreated,
+                );
+
+                if (!resumePending404) {
+                  await listener?.cancel();
+                  completer.complete();
+                }
+                break;
+
+              default:
+                break;
+            }
           }
-        }
-      });
+        },
+        onError: (Object error, StackTrace stackTrace) async {
+          if (!progress.isClosed) {
+            progress.addError(error, stackTrace);
+            progress.close();
+          }
+          await listener?.cancel();
+          if (!completer.isCompleted) {
+            completer.completeError(error, stackTrace);
+          }
+        },
+        onDone: () {
+          if (!completer.isCompleted) {
+            completer.completeError(
+              StateError(
+                'Download updates stream closed before task ${task.taskId} '
+                'completed',
+              ),
+              StackTrace.current,
+            );
+          }
+        },
+      );
 
       // Notify about new listener
       onListenerCreated?.call(listener);

--- a/packages/flutter_gemma/test/mobile/download_updates_stream_config_test.dart
+++ b/packages/flutter_gemma/test/mobile/download_updates_stream_config_test.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter_gemma/mobile/smart_downloader.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  tearDown(SmartDownloader.clearConfiguration);
+
+  test('clearConfiguration resets injected hub state', () {
+    SmartDownloader.configureDownloadUpdatesStream(
+      const Stream<TaskUpdate>.empty(),
+    );
+    SmartDownloader.clearConfiguration();
+    SmartDownloader.configureDownloadUpdatesStream(null);
+    expect(SmartDownloader.debugResolveUpdatesStream(), isNotNull);
+  });
+
+  test('wraps single-subscription injected stream for multiple listeners', () {
+    final singleSub = StreamController<TaskUpdate>();
+    SmartDownloader.configureDownloadUpdatesStream(singleSub.stream);
+
+    final resolved = SmartDownloader.debugResolveUpdatesStream();
+    final sub1 = resolved.listen((_) {});
+    final sub2 = resolved.listen((_) {});
+
+    expect(sub1.isPaused, isFalse);
+    expect(sub2.isPaused, isFalse);
+
+    sub1.cancel();
+    sub2.cancel();
+    unawaited(singleSub.close());
+  });
+
+  test('broadcast injected stream is not double-wrapped', () {
+    final hub = StreamController<TaskUpdate>.broadcast();
+    SmartDownloader.configureDownloadUpdatesStream(hub.stream);
+
+    final first = SmartDownloader.debugResolveUpdatesStream();
+    final second = SmartDownloader.debugResolveUpdatesStream();
+
+    expect(identical(first, second), isTrue);
+
+    unawaited(hub.close());
+  });
+
+  test('hub stream error is observable on a second listener', () async {
+    final hub = StreamController<TaskUpdate>.broadcast();
+    SmartDownloader.configureDownloadUpdatesStream(hub.stream);
+
+    final resolved = SmartDownloader.debugResolveUpdatesStream();
+    final errors = <Object>[];
+    // Both listeners must supply onError: on a broadcast stream an error is
+    // delivered to every listener, and any handler-less listener turns it into
+    // an uncaught zone error. SmartDownloader's own listen sites are all
+    // onError-guarded; mirror that here.
+    final sub1 = resolved.listen((_) {}, onError: (_) {});
+    final sub2 = resolved.listen((_) {}, onError: errors.add);
+
+    hub.addError(StateError('hub failure'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(errors, isNotEmpty);
+
+    await sub1.cancel();
+    await sub2.cancel();
+    await hub.close();
+  });
+}


### PR DESCRIPTION
Integrates **#342** (@hughesyadaddy) onto fresh main with the review fixes applied, so it ships in **1.1.2** alongside the Built-in Kotlin migration.

## Feature (credit: @hughesyadaddy)
Optional `downloadUpdatesStream` + `fileSystemService` on `FlutterGemma.initialize`. `FileDownloader().updates` is single-subscription; a host app that already forwards it through its own broadcast hub used to race `SmartDownloader`'s internal `asBroadcastStream()` → model installs stuck at 0%. Now the host can inject the shared hub.

## Review fixes (verified)
The original PR went through a full review; all blocking items are resolved in this integration:
- **Broadcast guard** — `_resolveUpdatesStream()` memoizes `source.isBroadcast ? source : source.asBroadcastStream()`, so concurrent `.listen()` never throws `Bad state`.
- **Hub error/close propagation** — both listen sites forward `onError`→`completeError` and `onDone`→`completeError` (guarded).
- **Core/web layering** — wiring moved behind a `download_hub` conditional-import (mobile impl + web no-op stub); `service_registry` no longer pulls `mobile/smart_downloader` onto the web graph.
- **Added on integration:** a `.catchError` on the `_ensureConfigured` chain — a config failure now surfaces on the progress stream instead of hanging the caller (the silent-hang class this work exists to prevent). Fixed the error-propagation test (a broadcast stream needs `onError` on every listener).

## Verified
- `dart analyze` lib: 0 errors/warnings.
- `flutter test`: 340 core pass; download-stream config tests 4/4.
- `flutter build web`: clean (conditional-import stub compiles, no `background_downloader` on the web graph).

Supersedes #342 (its branch is from an older base; this re-applies the code + fixes on current main with author credit). Ships under `flutter_gemma` 1.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)