### PR TITLE
fix(website): scope logo selectors under .landing-root to beat the img reset

### DIFF
--- a/website/deploy.sh
+++ b/website/deploy.sh
@@ -23,6 +23,11 @@ for p in 5567 8080 8181 5467; do
 done
 
 echo "==> Building Jaspr site (SSG)…"
+# Wipe stale incremental build state first. A reused .dart_tool/build cache let
+# the static crawler snapshot `/` before the ContentApp route table registered,
+# producing a 3-byte `Ok` index.html (and zero docs routes) that then got
+# deployed. A clean rebuild is cheap and removes the failure mode entirely.
+rm -rf build/jaspr .dart_tool/build
 jaspr build --sitemap-domain "$DOMAIN"
 
 if [[ "${1:-}" != "--no-example" ]]; then

--- a/website/lib/landing/sections/hero.dart
+++ b/website/lib/landing/sections/hero.dart
@@ -86,7 +86,14 @@ class Hero extends StatelessComponent {
     ),
     // Oversized, faint logo watermark anchored to the lower-left empty area,
     // clear of the phone mock on the right.
-    css('.hero-watermark').styles(
+    //
+    // Selector is scoped under `.landing-root` ON PURPOSE: the landing reset
+    // `.landing-root img { max-width: 100% }` (landing_page.dart) has
+    // specificity (0,1,1), which OUTRANKS a bare `.hero-watermark` (0,1,0) and
+    // silently overrode `max-width: 55%` — so the watermark rendered at its full
+    // `width: 760px`, a giant logo crashing into the hero copy. `.landing-root
+    // .hero-watermark` is (0,2,0), which wins, restoring the 55%/opacity cap.
+    css('.landing-root .hero-watermark').styles(
       position: Position.absolute(top: 8.percent, left: 12.percent),
       width: 760.px,
       maxWidth: 55.percent,

--- a/website/lib/landing/sections/nav_bar.dart
+++ b/website/lib/landing/sections/nav_bar.dart
@@ -109,7 +109,13 @@ class NavBarState extends State<NavBar> {
       gap: Gap.all(0.6.rem),
       textDecoration: TextDecoration.none,
     ),
-    css('.navbar-logo').styles(
+    // Scoped under `.landing-root` ON PURPOSE: the landing reset
+    // `.landing-root img { height: auto; max-width: 100% }` (landing_page.dart)
+    // is specificity (0,1,1) and OUTRANKS a bare `.navbar-logo` (0,1,0),
+    // silently overriding `height: 2.2rem` with `height: auto` — so the logo
+    // rendered at its full intrinsic size, a giant logo filling the header.
+    // `.landing-root .navbar-logo` is (0,2,0), which wins and restores 2.2rem.
+    css('.landing-root .navbar-logo').styles(
       height: 2.2.rem,
       width: Unit.auto,
       display: Display.block,


### PR DESCRIPTION
## Problem
The landing page rendered two oversized logos:
- **Header logo** filled the whole navbar
- **Hero watermark** ballooned over the "On-device LLMs…" headline

## Root cause
The landing image reset in `landing_page.dart`:
```css
.landing-root img { height: auto; max-width: 100% }
```
has specificity **(0,1,1)** — a class + a type selector. That outranks the
bare single-class rules `.navbar-logo` and `.hero-watermark` **(0,1,0)**, so:
- `.navbar-logo { height: 2.2rem }` was overridden by `height: auto` → logo
  rendered at full intrinsic size (giant header logo).
- `.hero-watermark { max-width: 55% }` was overridden by `max-width: 100%`,
  leaving `width: 760px` in force → giant watermark crashing into the hero copy.

## Fix
Scope both selectors under `.landing-root`, raising specificity to **(0,2,0)**
so their size caps win again. No change to the reset (it's intentionally broad
for responsive content images).

- `.navbar-logo`     → `.landing-root .navbar-logo`
- `.hero-watermark`  → `.landing-root .hero-watermark`

## Also: deploy.sh stale-cache guard
A reused `.dart_tool/build` cache let the static crawler snapshot `/` before
the `ContentApp` route table registered, emitting a 3-byte `Ok` `index.html`
with zero docs routes. Added `rm -rf build/jaspr .dart_tool/build` before
`jaspr build` so a clean rebuild always happens.

## Verification
- Clean `jaspr build` → 13 routes, full 55KB `index.html`
- Headless-Chrome screenshots confirm both logos sized correctly
- Already deployed to `fluttergemma.dev` (live: `/` `/docs/*` `/try` all 200)