### PR TITLE
fix(website): correct stale iOS GPU note and version pins

### DIFF
--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,10 +21,10 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.2
-  flutter_gemma: ^1.1.0
+  flutter_gemma: ^1.1.2
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)
-  flutter_gemma_mediapipe: ^1.0.2  # .task / .bin models (mobile + web)
+  flutter_gemma_mediapipe: ^1.0.3  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
   flutter_gemma_embeddings: ^1.0.1
 ```

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,9 +29,9 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.1.0                 # core — always required
+  flutter_gemma: ^1.1.2                 # core — always required
   flutter_gemma_litertlm: ^1.0.2        # add if you run .litertlm models
-  flutter_gemma_mediapipe: ^1.0.2       # add if you run .task / .bin models
+  flutter_gemma_mediapipe: ^1.0.3       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)
   flutter_gemma_rag_sqlite: ^1.1.0      # add for on-device RAG (sqlite-vec; all platforms incl. web)

--- a/website/lib/landing/sections/platform_matrix.dart
+++ b/website/lib/landing/sections/platform_matrix.dart
@@ -54,7 +54,8 @@ class PlatformMatrix extends StatelessComponent {
           p(classes: 'matrix-note', [
             Component.text(
               'NPU support requires Intel LunarLake/PantherLake (Windows). '
-              'iOS GPU pending upstream libLiteRtMetalAccelerator.dylib.',
+              'iOS GPU runs on Metal on device; the Simulator is CPU-only '
+              '(256 MB Metal allocation cap).',
             ),
           ]),
         ]),


### PR DESCRIPTION
## What

Fixes outdated facts on the marketing site, found via a full audit of `website/lib/landing/` + `website/content/docs/` cross-checked against the current codebase.

### Changes (3 files, source only — `website/build/` is gitignored, regenerated on deploy)

1. **`platform_matrix.dart`** — landing matrix note said *"iOS GPU pending upstream libLiteRtMetalAccelerator.dylib"*. That is stale: the runtime now bundles `libLiteRtMetalAccelerator.dylib` for iOS (`flutter_gemma_litertlm/hook/build.dart:188`, not skipped on iOS), and the host build phase copies it into `Runner.app/Frameworks/`. iOS GPU runs on Metal **on device**; the Simulator stays CPU-only (256 MB Metal allocation cap). New copy matches `docs/models.md` and `docs/troubleshooting.md`, which were already correct.

2. **`migration.md`** — bump example pins to current release: `flutter_gemma ^1.1.0 → ^1.1.2`, `flutter_gemma_mediapipe ^1.0.2 → ^1.0.3`.

3. **`genkit.md`** — same two bumps.

### Audited and confirmed NOT stale (left untouched)
- MediaPipe `@0.10.27` (web) / `@litert-lm/core@0.12.1` — match `example/web/index.html`.
- litertlm `1.0.2`, embeddings `1.0.1`, rag_* `1.1.0` — match pubspecs.
- SDK mins (Flutter 3.44 / Dart 3.12 / iOS 16), Android minSdk 30, model + platform matrices — match CLAUDE.md.
- Native runtime tag not hardcoded anywhere on the site.

## Deploy
Source-only; needs `jaspr build` + Firebase deploy after merge to publish on fluttergemma.dev.