### PR TITLE
fix(android): declare libOpenCL.so in plugin manifest — complete #324 Mali GPU fix

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.3
+- Declare `libOpenCL.so` (+ `-car`/`-pixel` ICDs) in the plugin manifest — completes the #324 Mali GPU fix (1.1.1 only opened the SP-HAL door).
+
 ## 1.1.2
 - Migrate Android module to Built-in Kotlin — apply KGP only on AGP < 9, ready for AGP 9+ (#323).
 - Add optional `downloadUpdatesStream`/`fileSystemService` injection to `FlutterGemma.initialize` (#342, thanks @hughesyadaddy).

--- a/packages/flutter_gemma/android/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/android/src/main/AndroidManifest.xml
@@ -22,5 +22,15 @@
              encoder (#324). Merged into every consumer app via manifest merger
              so the GPU path works without each app re-declaring it. -->
         <uses-native-library android:name="libvndksupport.so" android:required="false"/>
+        <!-- libvndksupport.so only opens the door to the SP-HAL namespace; the
+             OpenCL ICD itself must ALSO be declared or the second hop
+             (android_load_sphal_library("libOpenCL.so")) is denied, OpenCL
+             still fails to load, and the Mali freeze persists (#324). Declare
+             the base loader name plus the two vendor-specific ICD names some
+             devices use. All required="false" — pure namespace declarations,
+             inert on devices that lack them, never block install. -->
+        <uses-native-library android:name="libOpenCL.so" android:required="false"/>
+        <uses-native-library android:name="libOpenCL-car.so" android:required="false"/>
+        <uses-native-library android:name="libOpenCL-pixel.so" android:required="false"/>
     </application>
 </manifest>

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.1.2
+version: 1.1.3
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma


### PR DESCRIPTION
## What

Completes the #324 fix. **1.1.1** added `libvndksupport.so` to the plugin manifest, which lets the v0.13.x LiteRT-LM OpenCL loader reach the SP-HAL namespace — but that's only the *first* hop. The loader then does `android_load_sphal_library("libOpenCL.so")`, and that **second hop is denied unless `libOpenCL.so` is also declared**. So on devices where the SDK doesn't otherwise pull in OpenCL, the chain still breaks → WebGPU fallback → Mali hard-freeze persists.

The **example app** declared the full chain (`libOpenCL.so` + `-car`/`-pixel` ICDs), so the example never froze and our smoke runs didn't catch it. The **plugin manifest** stopped at `libvndksupport.so`, so consumer apps got the incomplete chain.

## Fix

Port the three OpenCL ICD declarations from the example into the **plugin** manifest (`packages/flutter_gemma/android/src/main/AndroidManifest.xml`) so they merge into every consumer app:

```xml
<uses-native-library android:name="libOpenCL.so" android:required="false"/>
<uses-native-library android:name="libOpenCL-car.so" android:required="false"/>
<uses-native-library android:name="libOpenCL-pixel.so" android:required="false"/>
```

All `required="false"` — pure namespace declarations, inert on devices that lack them, never block install.

## Credit / verification

Root-caused by @ieliofficial in #324 via side-by-side 1.1.0/1.1.1 manifest diff + pub-cache inspection, confirmed on Pixel 7a / Android 17 (`gemma-4-E2B-it.litertlm`): with all three declared, OpenCL loads, every subgraph uses `LITERT_CL`, no WebGPU fallback, no freeze.

Bumps core `1.1.2 → 1.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TxvhjJqRzxkRi8kSnFe7A