### PR TITLE
fix(website): plain code fences in agent.md — kotlin/xml/yaml crash the SSG highlighter

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -323,18 +323,43 @@ Update each `^X.Y.Z` for the core packages (`flutter_gemma`, `flutter_gemma_lite
 
 **You do NOT run a manual deploy.** `.github/workflows/firebase-hosting-merge.yml` auto-deploys to Firebase Hosting (`aichat-c0c27`, target `fluttergemma`, https://fluttergemma.dev → live channel) on every push to `main` that touches `website/**` or `packages/flutter_gemma/example/**`. So:
 
+0. **PRE-MERGE (do this on the branch, before merging):** build the Jaspr SSG
+   locally to catch a build-time crash BEFORE it takes down the live deploy. The
+   CI job runs the exact same `jaspr build`, so if it fails locally it will fail
+   in CI — but locally you fix it in a branch instead of leaving `main` deployed
+   from the old commit.
+   ```bash
+   cd website && jaspr build    # must end with "Completed building project"; NO "[ERROR]"
+   ```
+   The most common breakage is a **code fence in a `.md` doc with a language the
+   highlighter can't parse.** `syntax_highlight_lite` (via `jaspr_content`) only
+   ships a **Dart** grammar — a ```` ```yaml ````/```` ```xml ````/```` ```kotlin ````/```` ```bash ````
+   fence throws `Null check operator used on a null value` in `Highlighter` and
+   **fails the whole SSG build → the site stays stuck on the previous version.**
+   Every existing doc uses only ```` ```dart ````; for any other language use a
+   **plain fence** (```` ``` ```` with no language tag). Grep before you merge:
+   ```bash
+   grep -rhoE '```[a-z]+' website/content/docs/*.md | sort | uniq -c   # expect: only ```dart
+   ```
 1. Commit the `website/` changes (same author rule, no AI attribution) on your release branch / PR.
 2. When the PR merges to `main`, the workflow builds the Jaspr SSG + the Flutter web example (`/try`) and deploys automatically.
-3. Verify the run + spot-check the live page:
+3. **VERIFY THE MERGE DEPLOY ACTUALLY SUCCEEDED — do NOT assume merge == deployed.**
+   The run failing on the "Build Jaspr site (SSG)" step is silent: pub.dev shows
+   the new package, but fluttergemma.dev still serves the OLD build. Check the
+   run **conclusion**, not just that it triggered:
    ```bash
-   gh run list --workflow firebase-hosting-merge.yml --limit 3
-   # then open https://fluttergemma.dev/docs/... and confirm the change is live
+   gh run list --workflow firebase-hosting-merge.yml --limit 3   # newest must say "success", not "failure"
+   # if failure: gh run view <id> --log-failed | grep -iE 'error|Null check|Highlighter'
+   # then open https://fluttergemma.dev/docs/... and confirm the NEW change is live
    ```
+   If the deploy failed, the fix is another PR (main is a protected branch — you
+   CANNOT push a hotfix directly; branch + PR + merge, same as any change).
 
 A manual `./deploy.sh` exists in `website/` for local one-off deploys (it does the same build + `firebase deploy`), but the merge workflow is the normal path — don't run it by hand unless the workflow is broken. The site is NOT on pub.dev; `dart pub publish` never touches it — only this workflow (or `deploy.sh`) does.
 
 ## Common gotchas
 
+- **Website SSG build fails silently on a non-Dart code fence** — a ```` ```yaml ````/```` ```xml ````/```` ```kotlin ```` fence in any `website/content/docs/*.md` crashes the Jaspr highlighter (Dart-only grammar) → the merge deploy fails → fluttergemma.dev stays on the OLD build while pub.dev shows the new package. Always `jaspr build` the site locally on the branch before merge, use plain fences for non-Dart, and after merge confirm the `firebase-hosting-merge.yml` run says **success** (Step 12c). main is protected — a website hotfix is a new PR, not a direct push.
 - **`native/litert_lm/prebuilt/` excluded from pub package** (`.pubignore`) — end users get dylibs from GitHub Release, NOT from the pub package. Updating local prebuilts without re-uploading them is invisible to users.
 - **iOS dylib must be built from commit `5e0d86b`** (post-v0.10.2). v0.10.2 tag predates `libLiteRtMetalAccelerator.dylib` → ABI mismatch → EXC_BAD_ACCESS in `litert_lm_engine_create` on iPhone GPU. `build_ios.sh` defaults to it; do not override unless you know what you're doing.
 - **`bazelisk clean --expunge` is NOT free** — it forces a full rebuild (~25 min for one platform). Only do it when WORKSPACE patch_cmds changed; otherwise incremental rebuild.

--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -110,7 +110,7 @@ Seven starter skills ship as package assets and cover all four mechanisms:
 
 ## SKILL.md format
 
-```yaml
+```
 ---
 name: kebab-case-id
 description: One-line summary the model uses to pick the skill.
@@ -153,13 +153,13 @@ Most skills need no platform setup. For the platform-specific bits:
   (pre-installed on Windows 11; bundle the bootstrapper for Windows 10).
 - **iOS** — the `create-calendar-event` intent needs a usage description in
   `ios/Runner/Info.plist`:
-  ```xml
+  ```
   <key>NSCalendarsUsageDescription</key>
   <string>Create calendar events from the agent.</string>
   ```
 - **Android** — `schedule_notification` requires core-library desugaring in
   `android/app/build.gradle(.kts)`:
-  ```kotlin
+  ```
   android { compileOptions { isCoreLibraryDesugaringEnabled = true } }
   dependencies { coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4") }
   ```


### PR DESCRIPTION
The merge deploy of #350 failed at **Build Jaspr site (SSG)**: `syntax_highlight_lite` only ships a Dart grammar, so the `kotlin`/`xml`/`yaml` code fences in the new `agent.md` hit a null-check crash in `Highlighter` and took down the whole build — fluttergemma.dev is stuck on the pre-agent version.

Fix: drop the language tags on those three blocks (plain fences, no highlighting). Every other doc uses only ```dart. Verified locally with `jaspr build` (14/14 routes, /docs/agent included).

Also hardens the release skill (Step 12c): build the Jaspr SSG locally before merge, and verify the firebase-hosting-merge run says success — not just that it triggered — so this class of failure is caught next time.

This unblocks the website auto-deploy so the site reflects the just-published flutter_gemma 1.2.0 + flutter_gemma_agent 0.1.0.