### PR TITLE
docs: actualize READMEs + website for 1.2.0, and fix the mobile nav menu

### DIFF
--- a/.github/workflows/website-build-check.yml
+++ b/.github/workflows/website-build-check.yml
@@ -1,0 +1,41 @@
+# Build the fluttergemma.dev website on every PR that touches it — no deploy.
+# Catches SSG / web-build breakage (e.g. a non-Dart code fence that crashes the
+# Jaspr highlighter, or a dart2js API drift in the /try example) BEFORE merge,
+# instead of only discovering it when the merge deploy fails and the live site
+# is left on the previous build.
+name: Website build check (PR)
+on:
+  pull_request:
+    paths:
+      - 'website/**'
+      - 'packages/flutter_gemma/example/**'
+      - '.github/workflows/website-build-check.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter (bundles Dart)
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.44.0'
+          channel: stable
+          cache: true
+
+      - name: Install Jaspr CLI
+        run: dart pub global activate jaspr_cli
+
+      - name: Build Jaspr site (SSG)
+        working-directory: website
+        run: |
+          export PATH="$HOME/.pub-cache/bin:$PATH"
+          dart pub get
+          jaspr build --sitemap-domain "https://fluttergemma.dev"
+
+      - name: Build Flutter web example (live demo at /try)
+        working-directory: packages/flutter_gemma/example
+        run: |
+          flutter pub get
+          flutter build web --release --base-href /try/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,9 @@
 ## Rule 2: NEVER USE `git checkout` ⛔
 - Use Edit tool to manually revert changes. User manages git.
 
-## Rule 3: GIT COMMITS ⛔
-- No "Co-Authored-By: Claude" or AI attribution/footers
+## Rule 3: GIT COMMITS & PR/ISSUE BODIES ⛔
+- No "Co-Authored-By: Claude" or AI attribution/footers — in **commits, PR bodies, PR/issue comments, and release notes**
+- This OVERRIDES the harness default that says "End PR bodies with 🤖 Generated with Claude Code" / "Claude-Session: …" — NEVER add those here, in any git-visible text
 - Always use `--author="Sasha Denisov <denisov.shureg@gmail.com>"`
 
 ## Rule 4: NEVER HARDCODE SECRETS ⛔

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@
 | Gemma 3 1B | ✅ | ❌ | ❌ | Android, iOS, Web, Desktop |
 | Gemma 3 270M | ❌ | ❌ | ❌ | Android, iOS, Web, Desktop |
 | FastVLM 0.5B | ❌ | ❌ | ✅ vision | Desktop (`.litertlm`) |
-| FunctionGemma 270M | ✅ | ❌ | ❌ | Android, iOS, Desktop |
+| FunctionGemma 270M | ✅ | ❌ | ❌ | Android, iOS, Web, Desktop |
 | Phi-4 Mini | ✅ | ❌ | ❌ | Android, iOS, Web, Desktop |
 | DeepSeek R1 | ✅ | ✅ | ❌ | Android, iOS |
 | Qwen3 0.6B | ✅ | ✅ ² | ❌ | Android, iOS, Web, Desktop |

--- a/packages/flutter_gemma/DESKTOP_SUPPORT.md
+++ b/packages/flutter_gemma/DESKTOP_SUPPORT.md
@@ -28,7 +28,8 @@ Detailed setup and reference for running Flutter Gemma on **macOS, Windows, and 
 │   ┌──────────────────────────────────────────────┐ │
 │   │  FlutterGemmaDesktop (lib/desktop/)           │ │
 │   │           ↓                                    │ │
-│   │  LiteRtLmFfiClient (lib/core/ffi/)            │ │
+│   │  LiteRtLmFfiClient                            │ │
+│   │  (flutter_gemma_litertlm/lib/src/ffi/)        │ │
 │   │           ↓ dart:ffi                           │ │
 │   │  ───────────────────────────────────           │ │
 │   │  libLiteRtLm.{dylib,dll,so}                    │ │
@@ -496,5 +497,5 @@ all platform-agnostic. See `lib/flutter_gemma_interface.dart` and the
 [example app](example/) for usage patterns.
 
 For native debugging on iOS / Linux, see comments in
-`lib/core/ffi/litert_lm_client.dart` (search for `stream_proxy_redirect_stderr`
+`flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart` (search for `stream_proxy_redirect_stderr`
 and `_dumpNativeLog`).

--- a/packages/flutter_gemma/DESKTOP_SUPPORT.md
+++ b/packages/flutter_gemma/DESKTOP_SUPPORT.md
@@ -41,7 +41,7 @@ Detailed setup and reference for running Flutter Gemma on **macOS, Windows, and 
 ```
 
 **Native libraries** are fetched at build time by `hook/build.dart` from the
-GitHub release `native-v0.10.2-b`, SHA256-verified, and bundled by Flutter
+GitHub release `native-v0.13.1-a`, SHA256-verified, and bundled by Flutter
 [Native Assets](https://docs.flutter.dev/development/platform-integration/c-interop)
 into the application bundle. End-users only need to add a small
 `post_install` snippet to their **macOS** `Podfile` so the bundled
@@ -79,8 +79,8 @@ For mobile platforms see the main [README](README.md).
 
 ## Requirements
 
-- **Flutter** ≥ 3.24.0
-- **Dart SDK** ≥ 3.6.0
+- **Flutter** ≥ 3.44.0
+- **Dart SDK** ≥ 3.12.0
 - **macOS**: 10.14+, Apple Silicon (arm64)
 - **Windows**: 10/11 64-bit, [Microsoft Visual C++ Redistributable 2019+](https://aka.ms/vs/17/release/vc_redist.x64.exe)
 - **Linux**: glibc ≥ 2.34, libstdc++ ≥ 6.0.30 (Ubuntu 22.04+, Debian 12+, Fedora 36+, RHEL 9+)
@@ -95,19 +95,21 @@ No Java/JVM/JRE required.
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_gemma: ^0.14.0
+  flutter_gemma: ^1.2.0            # core
+  flutter_gemma_litertlm: ^1.0.2   # .litertlm engine — required on desktop
 ```
 
 ```dart
 import 'package:flutter_gemma/flutter_gemma.dart';
-import 'package:flutter_gemma/core/model.dart';
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
 
 Future<void> chat() async {
-  await FlutterGemma.initialize();
+  // Register the LiteRT-LM engine (desktop is .litertlm only).
+  FlutterGemma.initialize(inferenceEngines: const [LiteRtLmEngine()]);
 
   // Install model (downloads on first run, cached after).
   await FlutterGemma.installModel(
-    modelType: ModelType.gemmaIt,
+    modelType: ModelType.gemma4,
     fileType: ModelFileType.litertlm,
   ).fromNetwork(
     'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm',

--- a/packages/flutter_gemma/MIGRATION.md
+++ b/packages/flutter_gemma/MIGRATION.md
@@ -123,7 +123,7 @@ Native setup moved to the package that owns it:
   `<script>` for web — see the main README).
 - **The `.litertlm` native library + the `@litert-lm/core` web CDN** are in
   `flutter_gemma_litertlm`.
-- **wa-sqlite web loader** is in `flutter_gemma_rag_sqlite`.
+- **The custom `sqlite3.wasm` (with `sqlite-vec`/`vec0` linked in)** ships as a web asset in `flutter_gemma_rag_sqlite`.
 
 The iOS/Android entitlements and manifest entries from the main README still
 apply when you ship an inference engine. See the

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -29,25 +29,29 @@ There is an example of using:
 
 - **Local Execution:** Run Gemma and other LLMs (Qwen, DeepSeek, Phi, FastVLM, SmolLM, …) directly on user devices for enhanced privacy and offline functionality.
 - **Platform Support:** Compatible with iOS, Android, Web, macOS, Windows, and Linux platforms.
+- **🧩 Modular Packages:** A small `flutter_gemma` core plus opt-in packages — add only the engine (`.litertlm` / `.task`), embeddings, RAG, or agent code your app ships. Register them via one `FlutterGemma.initialize(...)` call. See [MIGRATION.md](MIGRATION.md).
 - **🖥️ Desktop Support:** Native desktop apps (macOS, Windows, Linux) with GPU acceleration via LiteRT-LM, called directly from Dart through `dart:ffi` — no JVM/JRE bundling. See [DESKTOP_SUPPORT.md](DESKTOP_SUPPORT.md) for details.
-- **🖼️ Multimodal Support:** Text + Image input with Gemma 4, Gemma3n, and FastVLM vision models
-- **🎙️ Audio Input:** Record and send audio messages with Gemma3n E2B/E4B models (Android, iOS device, Desktop)
+- **🖼️ Multimodal Support:** Text + Image input with Gemma 4, Gemma3n, and FastVLM vision models (all platforms incl. Web)
+- **🎙️ Audio Input:** Record and send audio messages with Gemma 4 and Gemma3n E2B/E4B models (Android, iOS device, macOS/Windows/Linux via LiteRT-LM — not on Web)
 - **🛠️ Function Calling:** Enable your models to call external functions and integrate with other services (supported by select models)
-- **🧠 Thinking Mode:** View the reasoning process of DeepSeek and Gemma 4 models with thinking blocks
+- **🤖 On-device Agent Skills:** Opt-in [`flutter_gemma_agent`](https://pub.dev/packages/flutter_gemma_agent) — give the model `SKILL.md` skills (text / JavaScript / native-intent / MCP) it invokes through the function-calling loop, fully offline. Gallery-compatible. Android, iOS, macOS, Windows (Web not supported yet).
+- **🧠 Thinking Mode:** View the reasoning process of Gemma 4, DeepSeek R1, and Qwen3 models with thinking blocks
 - **🛑 Stop Generation:** Cancel text generation mid-process on Android, iOS, Web, and Desktop
-- **⚙️ Backend Switching:** Choose between CPU and GPU backends for each model individually in the example app 
-- **🔍 Advanced Model Filtering:** Filter models by features (Multimodal, Function Calls, Thinking) with expandable UI
-- **📊 Model Sorting:** Sort models alphabetically, by size, or use default order in the example app 
+- **⚡ Backend Switching:** Choose between CPU, GPU, and NPU backends per model — CPU/GPU on Android/iOS/Desktop, GPU on Web
+- **⚙️ NPU Acceleration:** Hardware NPU inference for `.litertlm` models on Qualcomm Snapdragon (Android) and Intel LunarLake/PantherLake (Windows)
+- **🔍 Advanced Model Filtering:** Filter models by features (Multimodal, Function Calls, Thinking) with expandable UI (example app)
+- **📊 Model Sorting:** Sort models alphabetically, by size, or use default order (example app)
 - **LoRA Support:** Efficient fine-tuning and integration of LoRA (Low-Rank Adaptation) weights for tailored AI behavior.
 - **📥 Enhanced Downloads:** Smart retry logic with exponential backoff for reliable model downloads
 - **🔧 Download Reliability:** Automatic restart logic for interrupted downloads (resume not supported by HuggingFace CDN)
 - **📱 Android Foreground Service:** Large downloads (>500MB) automatically use foreground service to bypass 9-minute timeout
 - **🔧 Model Replace Policy:** Configurable model replacement system (keep/replace) with automatic model switching
-- **📊 Text Embeddings:** Generate vector embeddings from text using EmbeddingGemma and Gecko models
-- **🔎 On-device RAG:** qdrant-edge vector store on native, wa-sqlite on Web. Payload-aware `Filter` (must / should / mustNot) for semantic search.
+- **📊 Text Embeddings:** Generate 768-dim vector embeddings with EmbeddingGemma or Gecko (all native platforms + Web) via the unified LiteRT C API
+- **🔎 On-device RAG:** Two vector-store backends — `flutter_gemma_rag_qdrant` (qdrant-edge, native) and `flutter_gemma_rag_sqlite` (in-SQLite `sqlite-vec`/`vec0` KNN on all six platforms incl. Web). Payload-aware `Filter` (must / should / mustNot) for semantic search.
+- **🧩 Genkit Integration:** Use flutter_gemma through [Genkit](https://pub.dev/packages/genkit) via [`genkit_flutter_gemma`](https://pub.dev/packages/genkit_flutter_gemma), and route between on-device and cloud models with [`genkit_hybrid`](https://pub.dev/packages/genkit_hybrid).
 - **🔧 Unified Model Management:** Single system for managing both inference and embedding models with automatic validation
 - **🔐 Typed Download Errors:** Catch the public `DownloadException` sealed type (401/403/404/429/5xx) for gated HuggingFace models instead of substring-matching error strings
-- **💾 Web Persistent Caching:** Models persist across browser restarts using Cache API (Web only)
+- **💾 Web Persistent Caching:** Models persist across browser restarts — Cache API for models <2GB, OPFS streaming for large ones (>2GB, e.g. Gemma 4 E4B) — no re-download on reload (Web only)
 
 ## What's new in 1.0
 
@@ -59,7 +63,7 @@ There is an example of using:
 - 📦 **Modular package split** — the monolith is now a small **core** (`flutter_gemma`) plus **opt-in** packages, so your app ships only the native weight it uses: `flutter_gemma_litertlm` (.litertlm), `flutter_gemma_mediapipe` (.task/.bin), `flutter_gemma_embeddings`, `flutter_gemma_rag_qdrant`, `flutter_gemma_rag_sqlite`.
 - 🔧 **New `FlutterGemma.initialize(...)`** registration — pass `inferenceEngines`, `embeddingBackends`, `vectorStore` for the packages you added. See [Initialize Flutter Gemma](#initialize-flutter-gemma).
 - ✅ **Every model / session / chat / embedding / RAG API is unchanged** — migrating is just adding packages + the initialize call. See **[MIGRATION.md](MIGRATION.md)**.
-- 🧹 **Legacy sqlite+local_hnsw vector store removed** — native RAG runs on qdrant-edge (`flutter_gemma_rag_qdrant`); web on wa-sqlite (`flutter_gemma_rag_sqlite`).
+- 🧹 **Legacy sqlite+local_hnsw vector store removed** — native RAG runs on qdrant-edge (`flutter_gemma_rag_qdrant`); the portable store is in-SQLite `sqlite-vec`/`vec0` on all six platforms incl. Web (`flutter_gemma_rag_sqlite`).
 - 🧩 **Genkit integration** — use flutter_gemma through [Genkit](https://pub.dev/packages/genkit) via [`genkit_flutter_gemma`](https://pub.dev/packages/genkit_flutter_gemma), and route between on-device and cloud models with [`genkit_hybrid`](https://pub.dev/packages/genkit_hybrid). See [docs](https://fluttergemma.dev/docs/genkit).
 
 📖 Full docs & guides: **[fluttergemma.dev](https://fluttergemma.dev)**
@@ -172,7 +176,10 @@ model formats and features you need.
       # Optional — text embeddings + on-device RAG:
       flutter_gemma_embeddings: latest_version   # text embeddings (EmbeddingGemma / Gecko)
       flutter_gemma_rag_qdrant: latest_version   # RAG vector store (native: qdrant-edge)
-      flutter_gemma_rag_sqlite: latest_version   # RAG vector store (web: wa-sqlite; native: sqlite3)
+      flutter_gemma_rag_sqlite: latest_version   # RAG vector store (sqlite-vec/vec0; all six platforms incl. web)
+
+      # Optional — on-device agent skills:
+      flutter_gemma_agent: latest_version        # SKILL.md skills (text / JS / native-intent / MCP) via tool-calling
     ```
 
     **Pick by need:**
@@ -182,8 +189,9 @@ model formats and features you need.
     | Run `.litertlm` models (Gemma 4, Qwen3, FastVLM, + all desktop) | `flutter_gemma_litertlm` |
     | Run `.task` / `.bin` models (Gemma3n, Gemma 3, DeepSeek, Qwen 2.5, Phi-4) | `flutter_gemma_mediapipe` |
     | Generate text embeddings | `flutter_gemma_embeddings` |
-    | On-device RAG on native (Android/iOS/desktop) | `flutter_gemma_rag_qdrant` |
-    | On-device RAG on web | `flutter_gemma_rag_sqlite` |
+    | On-device RAG on native (fastest on Android/iOS/desktop) | `flutter_gemma_rag_qdrant` |
+    | On-device RAG on any platform incl. web (portable `sqlite-vec`) | `flutter_gemma_rag_sqlite` |
+    | On-device agent skills (SKILL.md + tool-calling loop) | `flutter_gemma_agent` |
 
     Core registers **no** engine by itself — you wire the packages you added in
     `FlutterGemma.initialize(...)` (see [Initialize Flutter Gemma](#initialize-flutter-gemma)).
@@ -354,8 +362,9 @@ script(s) for the **engine package(s) you use** to your `web/index.html`.
   </script>
 ```
 
-* **`flutter_gemma_rag_sqlite`** (web RAG) — add the wa-sqlite loader; see that
-  package's README for the exact `<script>` + Subresource-Integrity hash.
+* **`flutter_gemma_rag_sqlite`** (web RAG) — copy the package's custom
+  `sqlite3.wasm` (with `sqlite-vec`/`vec0` statically linked) into your app's web
+  root. No CDN `<script>` needed; see that package's README for the exact path.
 
 > **Model compatibility:** mobile `.task` models often don't work on web — use
 > the `-web.task` (MediaPipe) or `.litertlm` (LiteRT-LM) web variant. Check the
@@ -1515,7 +1524,7 @@ All embedding models generate **768-dimensional vectors**. The numbers in names 
 
 ## 🔎 On-device RAG / Vector Store
 
-Native platforms (Android, iOS, macOS, Linux, Windows) use qdrant-edge as the default vector store since 0.16. Web stays on wa-sqlite (qdrant-edge can't target WASM yet). Same Dart API on both — code is portable across platforms.
+Two vector-store packages implement the same Dart API: `flutter_gemma_rag_qdrant` (qdrant-edge, native — fastest on Android/iOS/desktop) and `flutter_gemma_rag_sqlite` (in-SQLite `sqlite-vec`/`vec0` KNN, portable across all six platforms incl. Web, since qdrant-edge can't target WASM). Code is the same on both.
 
 ```dart
 import 'package:flutter_gemma/flutter_gemma.dart';
@@ -1560,7 +1569,7 @@ for (var i = 0; i < docs.length; i++) {
   );
 }
 
-// 4. Semantic search, with optional payload-aware Filter (native only)
+// 4. Semantic search, with optional payload-aware Filter (all backends + platforms)
 final results = await FlutterGemmaPlugin.instance.searchSimilar(
   query: 'quantum entanglement',
   topK: 10,
@@ -1572,7 +1581,7 @@ final results = await FlutterGemmaPlugin.instance.searchSimilar(
 );
 ```
 
-`Filter` supports `must` / `should` / `mustNot` lists of `FieldEquals`, `FieldRange`, `FieldMatchAny` conditions. On Web the `filter` argument is silently ignored — wa-sqlite has no payload-filter support.
+`Filter` supports `must` / `should` / `mustNot` lists of `FieldEquals`, `FieldRange`, `FieldMatchAny` conditions. Both backends honor it: qdrant-edge natively, and the `sqlite-vec`/`vec0` store on all platforms incl. Web (one `Filter` → vec0 declared-column `WHERE`). Filterable fields must be declared as vec0 columns.
 
 **Benchmarks** comparing qdrant-edge to the legacy sqlite + local_hnsw backend across 5 platforms (5 000 documents, EmbeddingGemma 300M, 768-dim): see [example/integration_test/benchmarks/comparison.md](example/integration_test/benchmarks/comparison.md).
 
@@ -1617,7 +1626,7 @@ Function calling is currently supported by the following models:
 | **Streaming Responses** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Real-time generation |
 | **LoRA Support** | ✅ Full | ✅ Full | ✅ Full | ❌ Not supported | LiteRT-LM limitation |
 | **Text Embeddings** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | EmbeddingGemma, Gecko |
-| **VectorStore (RAG)** | ✅ qdrant-edge | ✅ qdrant-edge | ✅ wa-sqlite (WASM) | ✅ qdrant-edge | Semantic search + payload `Filter` (native) |
+| **VectorStore (RAG)** | ✅ qdrant-edge / vec0 | ✅ qdrant-edge / vec0 | ✅ vec0 (WASM) | ✅ qdrant-edge / vec0 | Semantic search + payload `Filter` (all platforms) |
 | **File Downloads** | ✅ Background | ✅ Background | ✅ In-memory | ✅ Background | Platform-specific |
 | **Asset Loading** | ✅ Full | ✅ Full | ✅ Full | ❌ Not supported | Flutter assets N/A |
 | **Bundled Resources** | ✅ Full | ✅ Full | ✅ Full | ❌ Not supported | Native bundles only |
@@ -1770,7 +1779,7 @@ The full and complete example you can find in `example` folder
 ## **🛟 Troubleshooting**
 
 **Multimodal Issues:**
-- Ensure you're using a multimodal model (Gemma3n E2B/E4B)
+- Ensure you're using a multimodal model (Gemma 4 E2B/E4B, Gemma3n E2B/E4B, or FastVLM)
 - Set `supportImage: true` when creating model and chat
 - Check device memory - multimodal models require more RAM
 

--- a/packages/flutter_gemma_agent/README.md
+++ b/packages/flutter_gemma_agent/README.md
@@ -68,7 +68,8 @@ WebView), verified on hardware. On web the skill runs in a sandboxed `<iframe>`.
 
 ## Bundled starter skills
 
-Seven starter skills ship as package assets and cover all four mechanisms:
+Eight starter skills ship as package assets, spanning the JS, native-intent, and
+text-only mechanisms (write your own `SKILL.md` for MCP):
 
 | Skill | Type | What it does |
 |---|---|---|
@@ -78,6 +79,7 @@ Seven starter skills ship as package assets and cover all four mechanisms:
 | `interactive-map` | JS (webview) | Show a location on an embedded map |
 | `send-email` | intent | Open the OS mail composer |
 | `create-calendar-event` | intent | Open the calendar event editor |
+| `get-current-time` | intent | Report the current local date and time |
 | `kitchen-adventure` | text-only | A text-adventure dungeon-master persona |
 
 Load them with `AssetSkillSource` and wire the JS executor to their bundled HTML:
@@ -196,8 +198,8 @@ Most skills need no platform setup. For the platform-specific bits:
 ## Third-party attribution
 
 The bundled starter skills (`calculate-hash`, `qr-code`, `query-wikipedia`,
-`interactive-map`, `send-email`, `create-calendar-event`, `kitchen-adventure`)
-and the `SKILL.md` format are derived from
+`interactive-map`, `send-email`, `create-calendar-event`, `get-current-time`,
+`kitchen-adventure`) and the `SKILL.md` format are derived from
 [google-ai-edge/gallery](https://github.com/google-ai-edge/gallery), licensed
 under the [Apache License 2.0](https://github.com/google-ai-edge/gallery/blob/main/LICENSE).
 

--- a/packages/flutter_gemma_agent/README.md
+++ b/packages/flutter_gemma_agent/README.md
@@ -16,16 +16,18 @@ unmodified, and their JavaScript skills run as-is (the
 
 | Skill type | Android | iOS | macOS | Windows | Web | Linux |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|
-| **text-only** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **MCP** (Streamable HTTP) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **native-intent** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **JS** (webview) | ✅ | ✅ | ✅ | ✅¹ | ✅ | ❌² |
+| **text-only** | ✅ | ✅ | ✅ | ✅ | ❌³ | ✅ |
+| **MCP** (Streamable HTTP) | ✅ | ✅ | ✅ | ✅ | ❌³ | ✅ |
+| **native-intent** | ✅ | ✅ | ✅ | ✅ | ❌³ | ✅ |
+| **JS** (webview) | ✅ | ✅ | ✅ | ✅¹ | ❌³ | ❌² |
 
 ¹ Windows JS skills need the [WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/)
 (pre-installed on Windows 11; on Windows 10 ship the bootstrapper). See
 [Setup](#setup).
 ² Linux has no embeddable webview, so JS skills return an `ErrorResult`
 (`isAvailable` is false). text / native-intent / MCP skills work on Linux.
+³ The agent is not supported on Web yet — the browser LLM runtimes don't
+reliably emit tool calls, so the agent loop is disabled there (see the note below).
 
 JS skills run in a headless, sandboxed webview. To grant a secure context (so
 skills using `crypto.subtle` and other secure-context Web APIs work), the

--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -27,15 +27,17 @@ execution mechanisms:
 
 | Skill type | What it does | Android | iOS | macOS | Windows | Web | Linux |
 |---|---|:-:|:-:|:-:|:-:|:-:|:-:|
-| **text-only** | A persona / instruction the model follows directly | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **MCP** | Calls remote MCP tools over Streamable HTTP | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **native-intent** | Opens an OS surface (mail, SMS, calendar, notification) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **JS** | Runs the skill's JavaScript in a sandboxed headless webview | ✅ | ✅ | ✅ | ✅¹ | ✅ | ❌² |
+| **text-only** | A persona / instruction the model follows directly | ✅ | ✅ | ✅ | ✅ | ❌³ | ✅ |
+| **MCP** | Calls remote MCP tools over Streamable HTTP | ✅ | ✅ | ✅ | ✅ | ❌³ | ✅ |
+| **native-intent** | Opens an OS surface (mail, SMS, calendar, notification) | ✅ | ✅ | ✅ | ✅ | ❌³ | ✅ |
+| **JS** | Runs the skill's JavaScript in a sandboxed headless webview | ✅ | ✅ | ✅ | ✅¹ | ❌³ | ❌² |
 
 ¹ Windows JS skills need the
 [WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/)
 (pre-installed on Windows 11). ² Linux has no embeddable webview, so JS skills
 return an `ErrorResult`; text / native-intent / MCP skills work on Linux.
+³ The agent is not supported on Web yet — the browser LLM runtimes don't reliably
+emit tool calls, so the agent loop is disabled there (see the note below).
 
 JS skills run in a headless, sandboxed webview. To grant a secure context (so
 skills using `crypto.subtle` and other secure-context Web APIs work), the package
@@ -96,7 +98,8 @@ The package also ships an adaptive UI: `AgentChatView`, `SkillManagerView`,
 
 ## Bundled starter skills
 
-Seven starter skills ship as package assets and cover all four mechanisms:
+Eight starter skills ship as package assets, spanning the JS, native-intent, and
+text-only mechanisms (write your own `SKILL.md` for MCP):
 
 | Skill | Type | What it does |
 |---|---|---|
@@ -106,6 +109,7 @@ Seven starter skills ship as package assets and cover all four mechanisms:
 | `interactive-map` | JS (webview) | Show a location on an embedded map |
 | `send-email` | intent | Open the OS mail composer |
 | `create-calendar-event` | intent | Open the calendar event editor |
+| `get-current-time` | intent | Report the current local date and time |
 | `kitchen-adventure` | text-only | A text-adventure dungeon-master persona |
 
 ## SKILL.md format

--- a/website/content/docs/desktop.md
+++ b/website/content/docs/desktop.md
@@ -21,7 +21,8 @@ Desktop is served exclusively by the **`flutter_gemma_litertlm`** package; see
 │   ┌──────────────────────────────────────────────┐ │
 │   │  FlutterGemmaDesktop (lib/desktop/)           │ │
 │   │           ↓                                    │ │
-│   │  LiteRtLmFfiClient (lib/core/ffi/)            │ │
+│   │  LiteRtLmFfiClient                            │ │
+│   │  (flutter_gemma_litertlm/lib/src/ffi/)        │ │
 │   │           ↓ dart:ffi                           │ │
 │   │  ───────────────────────────────────           │ │
 │   │  libLiteRtLm.{dylib,dll,so}                    │ │

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -140,7 +140,7 @@ flutter_gemma and works with **any** pair of Genkit models.
 ```
 dependencies:
   genkit_hybrid: ^0.1.0
-  genkit: ^0.14.0
+  genkit: ^0.14.1
 ```
 
 ### Basic usage

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -128,7 +128,7 @@ await FlutterGemma.installModel(modelType: ModelType.general)
 | [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT) | 0.5GB | ✅ | ✅ | ✅ |
 | [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it) | 0.3GB | ✅ | ✅ | ✅ |
 | [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ✅ |
-| [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ❌ |
+| [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ✅ |
 | [Qwen 2.5 1.5B](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct) | 1.6GB | ✅ | ✅ | ❌ |
 | [Qwen 2.5 0.5B](https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct) | 0.5GB | ❌ | ✅ | ❌ |
 | [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct) | 135MB | ❌ | ✅ | ❌ |

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -127,8 +127,8 @@ await FlutterGemma.installModel(modelType: ModelType.general)
 | [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B) | 0.5GB | ✅ | ❌ | ❌ |
 | [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT) | 0.5GB | ✅ | ✅ | ✅ |
 | [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it) | 0.3GB | ✅ | ✅ | ✅ |
-| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ❌ |
-| [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ✅ |
+| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ✅ |
+| [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ❌ |
 | [Qwen 2.5 1.5B](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct) | 1.6GB | ✅ | ✅ | ❌ |
 | [Qwen 2.5 0.5B](https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct) | 0.5GB | ❌ | ✅ | ❌ |
 | [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct) | 135MB | ❌ | ✅ | ❌ |

--- a/website/lib/landing/sections/features.dart
+++ b/website/lib/landing/sections/features.dart
@@ -32,7 +32,7 @@ const _features = [
   _FeatureData(
     icon: '💭',
     title: 'Thinking Mode',
-    desc: 'See the reasoning chains of DeepSeek R1 & Gemma 4',
+    desc: 'See the reasoning chains of Gemma 4, DeepSeek R1 & Qwen3',
     accent: Brand.blue,
   ),
   _FeatureData(
@@ -44,7 +44,7 @@ const _features = [
   _FeatureData(
     icon: '🔍',
     title: 'On-device RAG',
-    desc: 'qdrant-edge native vector store, wa-sqlite on web',
+    desc: 'qdrant-edge native vector store, sqlite-vec on all platforms incl. web',
     accent: Brand.green,
   ),
   _FeatureData(

--- a/website/lib/landing/sections/nav_bar.dart
+++ b/website/lib/landing/sections/nav_bar.dart
@@ -5,19 +5,14 @@ import '../../theme/brand.dart';
 
 /// Sticky top navigation bar.
 ///
-/// Client component because the mobile menu toggles open/closed. On wide
-/// screens the links render inline and the hamburger is hidden via CSS; on
-/// narrow screens the links collapse into a toggleable dropdown.
-@client
-class NavBar extends StatefulComponent {
+/// Pure CSS — NOT a `@client` component. The mobile menu toggles via a hidden
+/// checkbox + `:checked` sibling selector, so it works with **no JavaScript and
+/// no hydration**. This site is Jaspr static mode; the earlier `@client`
+/// version's `onClick` never hydrated on the deployed static build (the burger
+/// was dead, and the links only worked because they fell back to `href`
+/// navigation). The checkbox hack removes that dependency entirely.
+class NavBar extends StatelessComponent {
   const NavBar({super.key});
-
-  @override
-  State<NavBar> createState() => NavBarState();
-}
-
-class NavBarState extends State<NavBar> {
-  bool _open = false;
 
   static const _links = <({String text, String href, bool external, bool cta})>[
     (text: 'Docs', href: '/docs/getting-started', external: false, cta: false),
@@ -48,27 +43,33 @@ class NavBarState extends State<NavBar> {
           ),
           span(classes: 'navbar-wordmark', [Component.text('flutter_gemma')]),
         ]),
-        // Hamburger button (shown only on narrow screens via CSS).
-        button(
+        // Hidden checkbox drives the mobile menu open/closed state — pure CSS,
+        // no JS. The <label> below is the visible hamburger; clicking it toggles
+        // the checkbox, and `.navbar-toggle:checked ~ .navbar-links` reveals the
+        // dropdown. Hidden on wide screens via the desktop media query.
+        input(
+          type: InputType.checkbox,
+          id: 'navbar-toggle',
+          classes: 'navbar-toggle',
+          attributes: const {'aria-hidden': 'true'},
+        ),
+        // Hamburger label (shown only on narrow screens via CSS).
+        label(
           classes: 'navbar-burger',
           attributes: {
+            'for': 'navbar-toggle',
             'aria-label': 'Toggle navigation menu',
-            'aria-expanded': _open ? 'true' : 'false',
           },
-          onClick: () => setState(() => _open = !_open),
           [
             span(classes: 'navbar-burger-bar', []),
             span(classes: 'navbar-burger-bar', []),
             span(classes: 'navbar-burger-bar', []),
           ],
         ),
-        div(classes: _open ? 'navbar-links is-open' : 'navbar-links', [
+        div(classes: 'navbar-links', [
           for (final l in _links)
-            // NO onClick here: this is a static multi-page site, so each link is
-            // a full-page navigation via `href`. Attaching an onClick to a
-            // @client <a> intercepts and SUPPRESSES the native navigation
-            // (reported: clicking "Docs" did nothing). The mobile menu closes on
-            // its own because navigation reloads the page (resets _open=false).
+            // Full-page navigation via `href` (static multi-page site). The
+            // menu closes on its own because navigation reloads the page.
             a(
               href: l.href,
               classes: l.cta ? 'navbar-link navbar-link--cta' : 'navbar-link',
@@ -148,10 +149,20 @@ class NavBarState extends State<NavBar> {
       radius: BorderRadius.circular(2.px),
     ),
     // ---- MOBILE-FIRST BASE (narrow screens) ----
-    // Burger visible, links collapse into an absolutely-positioned dropdown
-    // that is hidden until `.is-open` is toggled. Desktop overrides below via a
-    // min-width media query, so source order can't accidentally re-hide the
-    // burger (the earlier ordering bug).
+    // Burger visible, links collapse into an absolutely-positioned dropdown that
+    // is hidden until the hidden checkbox is `:checked` (toggled by the burger
+    // <label>). Desktop overrides below via a min-width media query, so source
+    // order can't accidentally re-hide the burger (the earlier ordering bug).
+    // The checkbox itself is always visually hidden — it only carries state.
+    css('.navbar-toggle').styles(
+      position: Position.absolute(),
+      raw: {
+        'opacity': '0',
+        'width': '1px',
+        'height': '1px',
+        'pointer-events': 'none',
+      },
+    ),
     css('.navbar-burger').styles(
       display: Display.flex,
       flexDirection: FlexDirection.column,
@@ -177,7 +188,8 @@ class NavBarState extends State<NavBar> {
         bottom: BorderSide(color: Color('rgba(255,255,255,0.08)'), width: 1.px),
       ),
     ),
-    css('.navbar-links.is-open').styles(display: Display.flex),
+    // Checkbox checked → reveal the dropdown (pure-CSS toggle, no JS).
+    css('.navbar-toggle:checked ~ .navbar-links').styles(display: Display.flex),
     css('.navbar-links .navbar-link').styles(
       padding: Padding.symmetric(vertical: 0.85.rem, horizontal: 2.rem),
       fontSize: 1.rem,
@@ -187,6 +199,10 @@ class NavBarState extends State<NavBar> {
       query: MediaQuery.screen(minWidth: 769.px),
       styles: [
         css('.navbar-burger').styles(display: Display.none),
+        // On desktop the links are always inline regardless of checkbox state.
+        css('.navbar-toggle:checked ~ .navbar-links').styles(
+          flexDirection: FlexDirection.row,
+        ),
         css('.navbar-links').styles(
           position: Position.static,
           display: Display.flex,

--- a/website/lib/main.client.options.dart
+++ b/website/lib/main.client.options.dart
@@ -8,8 +8,6 @@ import 'package:jaspr/client.dart';
 
 import 'package:fluttergemma_website/components/clicker.dart'
     deferred as _clicker;
-import 'package:fluttergemma_website/landing/sections/nav_bar.dart'
-    deferred as _nav_bar;
 import 'package:jaspr_content/components/_internal/code_block_copy_button.dart'
     deferred as _code_block_copy_button;
 import 'package:jaspr_content/components/_internal/zoomable_image.dart'
@@ -42,10 +40,6 @@ ClientOptions get defaultClientOptions => ClientOptions(
     'clicker': ClientLoader(
       (p) => _clicker.Clicker(),
       loader: _clicker.loadLibrary,
-    ),
-    'nav_bar': ClientLoader(
-      (p) => _nav_bar.NavBar(),
-      loader: _nav_bar.loadLibrary,
     ),
     'jaspr_content:code_block_copy_button': ClientLoader(
       (p) => _code_block_copy_button.CodeBlockCopyButton(),

--- a/website/lib/main.server.options.dart
+++ b/website/lib/main.server.options.dart
@@ -60,7 +60,6 @@ ServerOptions get defaultServerOptions => ServerOptions(
   clientId: 'main.client.dart.js',
   clients: {
     _clicker.Clicker: ClientTarget<_clicker.Clicker>('clicker'),
-    _nav_bar.NavBar: ClientTarget<_nav_bar.NavBar>('nav_bar'),
     _code_block_copy_button.CodeBlockCopyButton:
         ClientTarget<_code_block_copy_button.CodeBlockCopyButton>(
           'jaspr_content:code_block_copy_button',
@@ -89,7 +88,7 @@ ServerOptions get defaultServerOptions => ServerOptions(
     ..._features.Features.styles,
     ..._hero.Hero.styles,
     ..._models_gallery.ModelsGallery.styles,
-    ..._nav_bar.NavBarState.styles,
+    ..._nav_bar.NavBar.styles,
     ..._platform_matrix.PlatformMatrix.styles,
     ..._quick_start.QuickStart.styles,
     ..._site_footer.SiteFooter.styles,


### PR DESCRIPTION
Two related cleanups after the 1.2.0 / agent release.

## Mobile hamburger menu (fix)
The mobile nav menu didn't open on fluttergemma.dev. `NavBar` was a Jaspr `@client` component whose `onClick` never hydrated on the static build — verified in the browser: the client bundle loads (200), the islands are marked, clicks reach the button, but no handler attaches. The links only worked because they fell back to `href` navigation; the burger has no such fallback.

Fix: rewrite `NavBar` as a `StatelessComponent` using the CSS checkbox hack (hidden `<input type=checkbox>` + `<label>` + `.navbar-toggle:checked ~ .navbar-links`). The menu toggles with pure CSS — no JS, no hydration. Verified on a local build: tapping the burger opens/closes the dropdown on mobile, and the desktop navbar is unaffected.

## Docs actualization
Swept the user-facing docs for stale facts (pre-vec0-migration, pre-OPFS, pre-agent), cross-checked against the code:
- `wa-sqlite` → `sqlite-vec`/`vec0` everywhere; rag_sqlite is the portable all-platform store, and payload `Filter` works on both backends + web (was wrongly 'native only').
- README feature list refreshed: web caching (Cache API + OPFS), Thinking (+ Qwen3), audio (+ Gemma 4); added Modular Packages / Agent Skills / Genkit / NPU entries; restored Gecko.
- `DESKTOP_SUPPORT.md`: native tag → `native-v0.13.1-a`, Flutter/Dart floors, Quick Start registers `LiteRtLmEngine` + `ModelType.gemma4`.
- agent docs: capability-table Web column ✅ → ❌ (agent loop disabled on web) to match the prose; 'Seven' → 'Eight' starter skills.
- website: landing cards, `genkit_hybrid` `^0.14.1`, `models.md` Web column for FunctionGemma / Qwen3.

Verified: `dart analyze` clean, `jaspr build` succeeds (14/14 routes).