### PR TITLE
fix: SmartDownloader Android download reliability — resume-loop hang (#355) + foreground service (#356) [1.2.1]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Core has NO pigeon (dropped at the 1.0 cut; its value types are hand-written in 
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.13.1-a` GitHub Release. Android tarball bundles the Qualcomm QNN dispatch stack and Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` (Qualcomm Snapdragon / Intel LunarLake/PantherLake). MTP (speculative decoding) support for Gemma 4 (#318 MTP crash fixed). (native-v0.13.1-a restores the NPU dispatch libs accidentally omitted from native-v0.13.1 — #155.)
 - **large_file_handler**: `^0.5.0` (core dep; 0.5.0 declares all 6 platforms — needed for pana platform support + the dart2wasm-clean web graph)
-- **Current Version**: core `flutter_gemma` `1.2.0`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm`/`flutter_gemma_mediapipe` `1.0.2`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
+- **Current Version**: core `flutter_gemma` `1.2.1`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm`/`flutter_gemma_mediapipe` `1.0.2`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -2,7 +2,8 @@
 - Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
 - Fix foreground downloads on Android — configure a running notification so the service actually activates (#356).
 - Scope foreground notification to explicit flag + auto-request `POST_NOTIFICATIONS` at runtime (#356).
-- Document Android 14+ manifest requirement for foreground downloads: host app needs `FOREGROUND_SERVICE_DATA_SYNC` + `foregroundServiceType` merge (#356).
+- Document Android 14+ manifest requirement: host app needs `FOREGROUND_SERVICE_DATA_SYNC` + service merge (#356).
+- Guard double-complete, add permission timeout, check `resume()`'s bool, arm reattach watchdog (#355 #356).
 
 ## 1.2.0
 - Add `skillExecutors:` to `FlutterGemma.initialize` + the `SkillExecutorProvider`/`SkillExecutorRegistry` seam for the new opt-in `flutter_gemma_agent` package.

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.2.1
 - Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
+- Fix foreground downloads on Android — configure a running notification so the service actually activates (#356).
 
 ## 1.2.0
 - Add `skillExecutors:` to `FlutterGemma.initialize` + the `SkillExecutorProvider`/`SkillExecutorRegistry` seam for the new opt-in `flutter_gemma_agent` package.

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+- Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
+
 ## 1.2.0
 - Add `skillExecutors:` to `FlutterGemma.initialize` + the `SkillExecutorProvider`/`SkillExecutorRegistry` seam for the new opt-in `flutter_gemma_agent` package.
 - Declare `libOpenCL.so` (+ `-car`/`-pixel` ICDs) in the plugin manifest — completes the #324 Mali GPU fix (#349; 1.1.1 only opened the SP-HAL door).

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.1
 - Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
 - Fix foreground downloads on Android — configure a running notification so the service actually activates (#356).
+- Scope foreground notification to explicit flag + auto-request `POST_NOTIFICATIONS` at runtime (#356).
 
 ## 1.2.0
 - Add `skillExecutors:` to `FlutterGemma.initialize` + the `SkillExecutorProvider`/`SkillExecutorRegistry` seam for the new opt-in `flutter_gemma_agent` package.

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
 - Fix foreground downloads on Android — configure a running notification so the service actually activates (#356).
 - Scope foreground notification to explicit flag + auto-request `POST_NOTIFICATIONS` at runtime (#356).
+- Document Android 14+ manifest requirement for foreground downloads: host app needs `FOREGROUND_SERVICE_DATA_SYNC` + `foregroundServiceType` merge (#356).
 
 ## 1.2.0
 - Add `skillExecutors:` to `FlutterGemma.initialize` + the `SkillExecutorProvider`/`SkillExecutorRegistry` seam for the new opt-in `flutter_gemma_agent` package.

--- a/packages/flutter_gemma/DOWNLOAD_TESTING.md
+++ b/packages/flutter_gemma/DOWNLOAD_TESTING.md
@@ -15,10 +15,13 @@ Manual testing guide for large model downloads, including reproduction of issue 
 process due to battery optimization. On slow connections (< 2 Mbps), downloading a 2.6 GB
 model takes > 9 minutes → `TaskConnectionException: Task timed out`.
 
-(#356: `SmartDownloader` now calls `configureNotification` so the foreground service actually
-activates when requested — previously `foreground: true` set the config flag but never
-registered a notification, so `setForeground()` was never called. This fixes the service
-activating at all; it does not change the 9-minute `TaskRunner` limit described above.)
+(#356: `SmartDownloader` now calls `configureNotification` when `foreground: true` so the
+foreground service actually activates — previously `foreground: true` set the config flag but
+never registered a notification, so `setForeground()` was never called. #357 review: on
+Android 13+ (API 33) a notification alone is still not enough — `setForeground()` is only
+reached if `POST_NOTIFICATIONS` is granted at RUNTIME, so `SmartDownloader` now also requests
+that permission automatically before a foreground download. Neither fix changes the 9-minute
+`TaskRunner` limit described above.)
 
 ### Why `allowPause` doesn't help
 

--- a/packages/flutter_gemma/DOWNLOAD_TESTING.md
+++ b/packages/flutter_gemma/DOWNLOAD_TESTING.md
@@ -20,7 +20,13 @@ foreground service actually activates — previously `foreground: true` set the 
 never registered a notification, so `setForeground()` was never called. #357 review: on
 Android 13+ (API 33) a notification alone is still not enough — `setForeground()` is only
 reached if `POST_NOTIFICATIONS` is granted at RUNTIME, so `SmartDownloader` now also requests
-that permission automatically before a foreground download. Neither fix changes the 9-minute
+that permission automatically before a foreground download. Layer 3: on Android 14+ (API 34+),
+`setForeground()` additionally throws `IllegalArgumentException: foregroundServiceType ... is
+not a subset of ...` unless the HOST APP declares `FOREGROUND_SERVICE_DATA_SYNC` and a
+`tools:node="merge"` override of `foregroundServiceType="dataSync"` on WorkManager's
+`SystemForegroundService` in its own manifest — see the README's Foreground Service section
+and `example/android/app/src/main/AndroidManifest.xml`. This is host-app responsibility, not
+something flutter_gemma adds automatically. None of these fixes change the 9-minute
 `TaskRunner` limit described above.)
 
 ### Why `allowPause` doesn't help

--- a/packages/flutter_gemma/DOWNLOAD_TESTING.md
+++ b/packages/flutter_gemma/DOWNLOAD_TESTING.md
@@ -15,6 +15,11 @@ Manual testing guide for large model downloads, including reproduction of issue 
 process due to battery optimization. On slow connections (< 2 Mbps), downloading a 2.6 GB
 model takes > 9 minutes → `TaskConnectionException: Task timed out`.
 
+(#356: `SmartDownloader` now calls `configureNotification` so the foreground service actually
+activates when requested — previously `foreground: true` set the config flag but never
+registered a notification, so `setForeground()` was never called. This fixes the service
+activating at all; it does not change the 9-minute `TaskRunner` limit described above.)
+
 ### Why `allowPause` doesn't help
 
 HuggingFace CDN returns **weak ETags** (`W/"..."`). `background_downloader` refuses to resume

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -1083,6 +1083,8 @@ await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
 
 **Note:** Foreground downloads (`foreground: true`) show a progress notification and request the `POST_NOTIFICATIONS` runtime permission automatically before the download starts. On Android 13+ the permission must ALSO be granted at runtime for the foreground service itself to activate — a manifest declaration alone is not enough. The host app must still declare `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` in `AndroidManifest.xml`; flutter_gemma requests the runtime grant for you.
 
+**Note:** If the user denies `POST_NOTIFICATIONS` (or the request times out/errors), foreground mode does not activate and the download silently falls back to background — the download still proceeds, just without the Doze/battery-optimization exemption. Host apps with long/large downloads should pre-request `POST_NOTIFICATIONS` before starting one.
+
 **Required on Android 14+ (API 34+): host app manifest setup.** `background_downloader`'s foreground path runs through WorkManager's shared `SystemForegroundService`. On API 34+, `startForeground()` throws `IllegalArgumentException: foregroundServiceType ... is not a subset of ...` unless the host app declares a matching `FOREGROUND_SERVICE_DATA_SYNC` permission **and** overrides that service's `foregroundServiceType` in its own `AndroidManifest.xml`. This is host-app responsibility — flutter_gemma does not add `FOREGROUND_SERVICE_DATA_SYNC` for you, since it's a Play-sensitive permission that shouldn't be imposed on every consumer. Add to your app's `AndroidManifest.xml`:
 
 ```xml

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -1075,13 +1075,13 @@ await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
 ```
 
 **Foreground Parameter:**
-- `null` (default): Auto-detect based on file size. Files >500MB use foreground service.
+- `null` (default): Auto-detect based on file size. Files >500MB use foreground service (no notification — pass `foreground: true` explicitly if you want one).
 - `true`: Always use foreground service (shows notification)
 - `false`: Never use foreground service
 
 **Note:** iOS uses native URLSession which handles long downloads automatically - no foreground service needed.
 
-**Note:** Foreground downloads show a progress notification. On Android 13+ the host app must declare `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` in `AndroidManifest.xml` for it to appear.
+**Note:** Foreground downloads (`foreground: true`) show a progress notification and request the `POST_NOTIFICATIONS` runtime permission automatically before the download starts. On Android 13+ the permission must ALSO be granted at runtime for the foreground service itself to activate — a manifest declaration alone is not enough. The host app must still declare `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` in `AndroidManifest.xml`; flutter_gemma requests the runtime grant for you.
 
 **Cancelling Downloads:**
 

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -1055,7 +1055,7 @@ await FlutterGemma.installModel(
 
 **Android Foreground Service (Large Downloads):**
 
-Android has a 9-minute background execution limit. For large models (>500MB), you can use foreground service mode which shows a notification but bypasses this timeout:
+Android has a 9-minute background execution limit. For large models (>500MB), you can use foreground service mode, which shows a notification and exempts the download from battery-optimization kills (note: it does not raise WorkManager's own 9-minute task timeout — see `DOWNLOAD_TESTING.md`):
 
 ```dart
 // Auto-detect based on file size (>500MB = foreground) - DEFAULT
@@ -1076,10 +1076,12 @@ await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
 
 **Foreground Parameter:**
 - `null` (default): Auto-detect based on file size. Files >500MB use foreground service.
-- `true`: Always use foreground service (shows notification, no timeout)
-- `false`: Never use foreground service (subject to 9-minute timeout)
+- `true`: Always use foreground service (shows notification)
+- `false`: Never use foreground service
 
 **Note:** iOS uses native URLSession which handles long downloads automatically - no foreground service needed.
+
+**Note:** Foreground downloads show a progress notification. On Android 13+ the host app must declare `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` in `AndroidManifest.xml` for it to appear.
 
 **Cancelling Downloads:**
 

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -1083,6 +1083,26 @@ await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
 
 **Note:** Foreground downloads (`foreground: true`) show a progress notification and request the `POST_NOTIFICATIONS` runtime permission automatically before the download starts. On Android 13+ the permission must ALSO be granted at runtime for the foreground service itself to activate — a manifest declaration alone is not enough. The host app must still declare `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` in `AndroidManifest.xml`; flutter_gemma requests the runtime grant for you.
 
+**Required on Android 14+ (API 34+): host app manifest setup.** `background_downloader`'s foreground path runs through WorkManager's shared `SystemForegroundService`. On API 34+, `startForeground()` throws `IllegalArgumentException: foregroundServiceType ... is not a subset of ...` unless the host app declares a matching `FOREGROUND_SERVICE_DATA_SYNC` permission **and** overrides that service's `foregroundServiceType` in its own `AndroidManifest.xml`. This is host-app responsibility — flutter_gemma does not add `FOREGROUND_SERVICE_DATA_SYNC` for you, since it's a Play-sensitive permission that shouldn't be imposed on every consumer. Add to your app's `AndroidManifest.xml`:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
+    <application>
+        <!-- ... -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
+    </application>
+</manifest>
+```
+
+Without this, `foreground: true` downloads crash on API 34+ devices. See `packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml` for a working example.
+
 **Cancelling Downloads:**
 
 Use `CancelToken` to cancel downloads in progress:

--- a/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Permissions for downloading models -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -13,6 +14,17 @@
          sufficient. flutter_gemma now requests it at runtime automatically
          before starting a foreground download. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Required on Android 14+ (API 34+) for foreground downloads (#356
+         layer 3): background_downloader's foreground path runs through
+         WorkManager's androidx.work.impl.foreground.SystemForegroundService.
+         On API 34+ startForeground() requires BOTH a matching
+         FOREGROUND_SERVICE_<type> permission AND a matching
+         android:foregroundServiceType on that service's manifest entry —
+         otherwise it throws IllegalArgumentException:
+         "foregroundServiceType ... is not a subset of ... 0x00000000".
+         This is host-app responsibility (flutter_gemma does not impose it on
+         every consumer — see README's Foreground Service section). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <!-- Permission for audio recording (Gemma 3n E4B audio input) -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -57,6 +69,16 @@
             android:required="false"/>
         <uses-native-library android:name="libOpenCL-car.so" android:required="false"/>
         <uses-native-library android:name="libOpenCL-pixel.so" android:required="false"/>
+        <!-- Override WorkManager's shared foreground service to declare a
+             foregroundServiceType (#356 layer 3, API 34+ requirement — see
+             the FOREGROUND_SERVICE_DATA_SYNC permission comment above).
+             tools:node="merge" merges this attribute onto the
+             background_downloader/WorkManager-provided <service> declaration
+             instead of replacing it. -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,13 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!-- Required on Android 13+ (API 33) to show the foreground-download
-         notification (#356); without it, the notification is silently
-         suppressed but the foreground service itself still activates. -->
+    <!-- Required on Android 13+ (API 33) for foreground downloads (#356,
+         #357 review): without a RUNTIME grant of this permission, the
+         foreground service does NOT activate at all (background_downloader's
+         displayNotification() bails out before calling setForeground() when
+         it isn't granted) — declaring it here is necessary but not
+         sufficient. flutter_gemma now requests it at runtime automatically
+         before starting a foreground download. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Permission for audio recording (Gemma 3n E4B audio input) -->

--- a/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/flutter_gemma/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Required on Android 13+ (API 33) to show the foreground-download
+         notification (#356); without it, the notification is silently
+         suppressed but the foreground service itself still activates. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Permission for audio recording (Gemma 3n E4B audio input) -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/packages/flutter_gemma/example/integration_test/download_reliability_test.dart
+++ b/packages/flutter_gemma/example/integration_test/download_reliability_test.dart
@@ -18,6 +18,7 @@
 //
 // See DOWNLOAD_TESTING.md for manual slow-network repro of issue #192.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart' show debugPrint;
@@ -25,6 +26,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/mobile/smart_downloader.dart';
+import 'package:path_provider/path_provider.dart';
 import 'inference_test_helpers.dart' show registerTestEngines;
 
 // Small public model — 284 MB, no auth token required.
@@ -310,6 +313,52 @@ void main() {
       },
       skip: !Platform.isAndroid,
       timeout: const Timeout(Duration(minutes: 15)),
+    );
+  });
+
+  // ─────────────────────────────────────────────
+  // Group D: resume lifecycle terminates (#355)
+  // A real small-model download must resolve — its progress stream must
+  // CLOSE (done or error) — within a bounded time. On the pre-fix code a
+  // resume-loop could hang here forever.
+  // ─────────────────────────────────────────────
+  group('resume lifecycle terminates (#355)', () {
+    testWidgets(
+      'a real small download completes or errors, never hangs',
+      (tester) async {
+        const token = String.fromEnvironment('HUGGINGFACE_TOKEN');
+        // A small, resumable model (~135MB) so the test is fast on FTL.
+        const url =
+            'https://huggingface.co/litert-community/SmolLM-135M-Instruct/resolve/main/SmolLM-135M-Instruct_multi-prefill-seq_q8_ekv1280.task';
+        final dir = (await getTemporaryDirectory()).path;
+        final target = '$dir/smoke_smollm.task';
+
+        final done = Completer<String>();
+        final sub =
+            SmartDownloader.downloadWithProgress(
+              url: url,
+              targetPath: target,
+              token: token.isEmpty ? null : token,
+            ).listen(
+              (_) {},
+              onError: (e) =>
+                  done.isCompleted ? null : done.complete('error: $e'),
+              onDone: () => done.isCompleted ? null : done.complete('done'),
+            );
+
+        // Bounded wait: the stream MUST terminate (done or error). A hang = FAIL.
+        final outcome = await done.future.timeout(
+          const Duration(minutes: 8),
+          onTimeout: () => 'HUNG',
+        );
+        await sub.cancel();
+        expect(
+          outcome,
+          isNot('HUNG'),
+          reason: 'install stream must terminate, not hang (#355)',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 10)),
     );
   });
 }

--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.2.0'
+  s.version          = '1.2.1'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -32,6 +32,20 @@ Timer armResumeWatchdog({
   return Timer(timeout, onTimeout);
 }
 
+/// Whether [_ensureConfigured] should register a running [TaskNotification]
+/// for the given [foreground] setting (#356). Extracted as a pure function so
+/// the decision is unit-testable without a `FileDownloader` seam: on Android,
+/// `background_downloader` only calls `WorkManager.setForeground()` — the
+/// thing that actually activates the foreground service — when a `running`
+/// notification is configured. Setting `Config.runInForeground` alone is a
+/// no-op without it. A notification is needed for `foreground: true` (always)
+/// and for the auto-detect branch (`foreground == null`, since a large file
+/// can still trigger foreground at runtime); `foreground: false` never needs
+/// one.
+@visibleForTesting
+bool shouldConfigureForegroundNotification(bool? foreground) =>
+    foreground != false;
+
 /// Pure decision for [_handleFailedDownload]. Resume is only chosen while under
 /// [maxResumeAttempts] — the old code resumed unconditionally whenever
 /// `canResume`, which let a repeatedly-failing resume loop forever (#355).
@@ -105,6 +119,20 @@ class SmartDownloader {
       );
       gemmaLog(
         '📲 SmartDownloader: Configured for AUTO foreground (>${_foregroundThresholdMB}MB)',
+      );
+    }
+
+    // #356: `Config.runInForeground`/`runInForegroundIfFileLargerThan` alone
+    // never activates Android's real foreground service — the plugin only
+    // calls `WorkManager.setForeground()` once a `running` notification is
+    // configured. Without this, `foreground: true` was a no-op: no
+    // notification, no setForeground() call, no Doze/battery-optimization
+    // exemption. This does NOT touch WorkManager's separate 9-minute
+    // `TaskRunner` timeout (#192) — that limit is unrelated and unchanged.
+    if (shouldConfigureForegroundNotification(foreground)) {
+      downloader.configureNotification(
+        running: const TaskNotification('Downloading model', '{filename}'),
+        progressBar: true,
       );
     }
 

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -7,6 +7,33 @@ import 'package:flutter_gemma/core/domain/download_exception.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
+/// Decision for a failed download: whether to resume, do a fresh retry, or give
+/// up. Extracted so the resume-attempt cap (#355) is unit-testable.
+enum ResumeAction { resume, retry, giveUp }
+
+@visibleForTesting
+const int kMaxResumeAttempts = 3;
+
+/// Pure decision for [_handleFailedDownload]. Resume is only chosen while under
+/// [maxResumeAttempts] — the old code resumed unconditionally whenever
+/// `canResume`, which let a repeatedly-failing resume loop forever (#355).
+@visibleForTesting
+ResumeAction decideFailedDownloadAction({
+  required bool canResume,
+  required int resumeAttempt,
+  required int currentAttempt,
+  required int maxRetries,
+  required int maxResumeAttempts,
+}) {
+  if (canResume && resumeAttempt < maxResumeAttempts) {
+    return ResumeAction.resume;
+  }
+  if (currentAttempt < maxRetries) {
+    return ResumeAction.retry;
+  }
+  return ResumeAction.giveUp;
+}
+
 /// Smart downloader with HTTP-aware retry logic
 ///
 /// Features:

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -260,6 +260,10 @@ class SmartDownloader {
           } catch (e) {
             gemmaLog('⚠️ Failed to cancel task: $e');
           }
+          // Also clear any pending resume watchdog so a cancelled download
+          // doesn't leave a Timer holding the (now-closed) progress stream
+          // alive for up to 90s.
+          _cancelResumeWatchdog(currentTaskId!);
         }
 
         if (!progress.isClosed) {

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -308,7 +308,16 @@ class SmartDownloader {
     CancelToken? cancelToken,
     void Function(StreamSubscription)? onListenerCreated,
     void Function(String taskId)? onTaskCreated, // ← ADD: Callback for task ID
+    int resumeAttempt = 0,
   }) async {
+    // Mutable so the SAME listener can bump it across successive resume
+    // rounds for this task (#355): a resume keeps this listener active, and
+    // the next `TaskStatus.failed` for it must see a higher resumeAttempt so
+    // decideFailedDownloadAction() eventually falls through to retry/giveUp
+    // instead of resuming forever. A fresh retry recurses into a NEW call of
+    // this method with a fresh `resumeAttempt: 0` scope — it must NOT reuse
+    // this local.
+    var localResumeAttempt = resumeAttempt;
     // Check cancellation before starting
     try {
       cancelToken?.throwIfCancelled();
@@ -527,6 +536,7 @@ class SmartDownloader {
                   cancelToken: cancelToken,
                   onListenerCreated: onListenerCreated,
                   onTaskCreated: onTaskCreated,
+                  resumeAttempt: localResumeAttempt,
                 );
 
                 // Only cleanup if no resume is pending
@@ -535,7 +545,14 @@ class SmartDownloader {
                   await listener?.cancel();
                   completer.complete();
                 } else {
-                  gemmaLog('🔄 Resume pending - keeping listener active');
+                  // Same listener stays active — bump the counter so the
+                  // NEXT failed event for this task (if the resume itself
+                  // fails again) sees an incremented resumeAttempt (#355).
+                  localResumeAttempt++;
+                  gemmaLog(
+                    '🔄 Resume pending - keeping listener active '
+                    '(resumeAttempt now $localResumeAttempt)',
+                  );
                 }
                 break;
 
@@ -572,11 +589,14 @@ class SmartDownloader {
                   cancelToken: cancelToken,
                   onListenerCreated: onListenerCreated,
                   onTaskCreated: onTaskCreated,
+                  resumeAttempt: localResumeAttempt,
                 );
 
                 if (!resumePending404) {
                   await listener?.cancel();
                   completer.complete();
+                } else {
+                  localResumeAttempt++;
                 }
                 break;
 
@@ -697,6 +717,7 @@ class SmartDownloader {
     CancelToken? cancelToken,
     void Function(StreamSubscription)? onListenerCreated,
     void Function(String taskId)? onTaskCreated,
+    required int resumeAttempt,
   }) async {
     gemmaLog('🟡 _handleFailedDownload called');
     gemmaLog('🟡 httpStatusCode: $httpStatusCode');
@@ -746,24 +767,45 @@ class SmartDownloader {
       }
     }
 
-    // First, try to resume if possible (for transient errors only)
+    // Decide resume vs retry vs give-up. Resume is CAPPED (#355): the old code
+    // resumed unconditionally whenever canResume, so a repeatedly-failing
+    // resume (HF weak-ETag) or a silently-dead task looped/hung forever.
+    bool canResume = false;
     try {
-      final canResume = await downloader.taskCanResume(task);
-      if (canResume) {
-        gemmaLog('🔄 Attempting to resume task ${task.taskId}...');
-        await downloader.resume(task);
-        gemmaLog('🔄 Resume triggered, waiting for status update...');
-        // Resume triggered - let event loop handle the result
-        // If resume succeeds → TaskStatus.complete will fire
-        // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and retry logic runs
-        return true; // ✅ Resume pending - caller should keep listener active!
-      }
+      canResume = await downloader.taskCanResume(task);
     } catch (e) {
-      gemmaLog('⚠️ Resume failed with exception: $e');
-      // Fall through to retry logic below
+      gemmaLog('⚠️ taskCanResume threw: $e — treating as not resumable');
     }
 
-    // If resume failed or not possible, try full retry (only for transient errors)
+    final action = decideFailedDownloadAction(
+      canResume: canResume,
+      resumeAttempt: resumeAttempt,
+      currentAttempt: currentAttempt,
+      maxRetries: maxRetries,
+      maxResumeAttempts: kMaxResumeAttempts,
+    );
+
+    if (action == ResumeAction.resume) {
+      gemmaLog(
+        '🔄 Resuming task ${task.taskId} '
+        '(resume attempt ${resumeAttempt + 1}/$kMaxResumeAttempts)...',
+      );
+      try {
+        await downloader.resume(task);
+        gemmaLog('🔄 Resume triggered, waiting for status update...');
+      } catch (e) {
+        gemmaLog('⚠️ resume() threw: $e — will retry on next failure event');
+      }
+      // Resume triggered - let event loop handle the result
+      // If resume succeeds → TaskStatus.complete will fire
+      // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and
+      // the SAME listener re-enters this method with resumeAttempt + 1
+      // (threaded by the caller in _downloadWithSmartRetry).
+      _armResumeWatchdog(taskId: task.taskId);
+      return true; // ✅ Resume pending - caller should keep listener active!
+    }
+    // action == retry or giveUp → fall through to the retry/give-up logic
+    // below, which is already correctly capped on currentAttempt < maxRetries.
     if (currentAttempt < maxRetries) {
       // Exponential backoff
       await Future.delayed(Duration(seconds: currentAttempt * 2));
@@ -808,6 +850,13 @@ class SmartDownloader {
       return false; // Gave up, no resume pending
     }
   }
+
+  /// Placeholder for the resume watchdog (#355 part 3): arms a timeout that
+  /// force-fails a resume that never produces a status update (a silently
+  /// dead task would otherwise hang the listener forever even though the
+  /// resume-attempt cap bounds *retries*). Intentionally a no-op for now —
+  /// fleshed out in the next task.
+  static void _armResumeWatchdog({required String taskId}) {}
 
   /// Checks if a URL is from HuggingFace CDN
   ///

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -793,16 +793,20 @@ class SmartDownloader {
       try {
         await downloader.resume(task);
         gemmaLog('🔄 Resume triggered, waiting for status update...');
+        // Resume was accepted - let event loop handle the result.
+        // If resume succeeds → TaskStatus.complete will fire.
+        // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and
+        // the SAME listener re-enters this method with resumeAttempt + 1
+        // (threaded by the caller in _downloadWithSmartRetry).
+        _armResumeWatchdog(taskId: task.taskId);
+        return true; // ✅ Resume pending - caller should keep listener active!
       } catch (e) {
-        gemmaLog('⚠️ resume() threw: $e — will retry on next failure event');
+        gemmaLog('⚠️ resume() threw: $e — falling through to retry/give-up');
+        // resume() was never accepted, so no status event will ever arrive
+        // for it — do NOT arm the watchdog or return true here, that would
+        // leave the listener waiting forever. Fall through to the bounded
+        // retry/give-up logic below instead.
       }
-      // Resume triggered - let event loop handle the result
-      // If resume succeeds → TaskStatus.complete will fire
-      // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and
-      // the SAME listener re-enters this method with resumeAttempt + 1
-      // (threaded by the caller in _downloadWithSmartRetry).
-      _armResumeWatchdog(taskId: task.taskId);
-      return true; // ✅ Resume pending - caller should keep listener active!
     }
     // action == retry or giveUp → fall through to the retry/give-up logic
     // below, which is already correctly capped on currentAttempt < maxRetries.

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -14,6 +14,24 @@ enum ResumeAction { resume, retry, giveUp }
 @visibleForTesting
 const int kMaxResumeAttempts = 3;
 
+/// Watchdog window after a resume: if no progress/terminal event arrives within
+/// this, the task is presumed silently dead (#355) and the stream is closed.
+@visibleForTesting
+const Duration kResumeWatchdog = Duration(seconds: 90);
+
+/// Returns a [Timer] that fires [onTimeout] after [timeout] unless cancelled.
+/// The download loop cancels it when the next progress/status event arrives, and
+/// wires [onTimeout] to close [progress] with a network error + cancel the
+/// listener, so a silently-dead post-resume task can never hang forever.
+@visibleForTesting
+Timer armResumeWatchdog({
+  required StreamController<int> progress,
+  required void Function() onTimeout,
+  Duration timeout = kResumeWatchdog,
+}) {
+  return Timer(timeout, onTimeout);
+}
+
 /// Pure decision for [_handleFailedDownload]. Resume is only chosen while under
 /// [maxResumeAttempts] — the old code resumed unconditionally whenever
 /// `canResume`, which let a repeatedly-failing resume loop forever (#355).
@@ -363,12 +381,16 @@ class SmartDownloader {
             if (update.task.taskId != taskId) return;
 
             if (update is TaskProgressUpdate) {
+              // A live event means the task is not dead — cancel any pending
+              // resume watchdog so a normally-progressing task never false-fires (#355).
+              _cancelResumeWatchdog();
               final percents = (update.progress * 100).round();
               gemmaLog('📊 Progress (existing): $percents%');
               if (!progress.isClosed) {
                 progress.add(percents.clamp(0, 100));
               }
             } else if (update is TaskStatusUpdate) {
+              _cancelResumeWatchdog();
               gemmaLog('📡 TaskStatusUpdate (existing): ${update.status}');
               if (update.status == TaskStatus.complete) {
                 if (!progress.isClosed) {
@@ -479,12 +501,16 @@ class SmartDownloader {
           );
 
           if (update is TaskProgressUpdate) {
+            // A live event means the task is not dead — cancel any pending
+            // resume watchdog so a normally-progressing task never false-fires (#355).
+            _cancelResumeWatchdog();
             final percents = (update.progress * 100).round();
             gemmaLog('📊 Progress: $percents%');
             if (!progress.isClosed) {
               progress.add(percents.clamp(0, 100));
             }
           } else if (update is TaskStatusUpdate) {
+            _cancelResumeWatchdog();
             gemmaLog(
               '📡 TaskStatusUpdate: ${update.status}, HTTP: ${update.responseStatusCode}',
             );
@@ -798,7 +824,11 @@ class SmartDownloader {
         // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and
         // the SAME listener re-enters this method with resumeAttempt + 1
         // (threaded by the caller in _downloadWithSmartRetry).
-        _armResumeWatchdog(taskId: task.taskId);
+        _armResumeWatchdog(
+          taskId: task.taskId,
+          progress: progress,
+          listener: currentListener,
+        );
         return true; // ✅ Resume pending - caller should keep listener active!
       } catch (e) {
         gemmaLog('⚠️ resume() threw: $e — falling through to retry/give-up');
@@ -855,12 +885,42 @@ class SmartDownloader {
     }
   }
 
-  /// Placeholder for the resume watchdog (#355 part 3): arms a timeout that
-  /// force-fails a resume that never produces a status update (a silently
-  /// dead task would otherwise hang the listener forever even though the
-  /// resume-attempt cap bounds *retries*). Intentionally a no-op for now —
-  /// fleshed out in the next task.
-  static void _armResumeWatchdog({required String taskId}) {}
+  static Timer? _resumeWatchdog;
+
+  /// Arms the resume watchdog (#355 part 3): if no progress/status update
+  /// arrives for [taskId] within [kResumeWatchdog], the task is presumed
+  /// silently dead and [progress] is force-closed with a network error so the
+  /// caller's `await for` over the stream can never hang forever.
+  static void _armResumeWatchdog({
+    required String taskId,
+    required StreamController<int> progress,
+    required StreamSubscription? listener,
+  }) {
+    _resumeWatchdog?.cancel();
+    _resumeWatchdog = armResumeWatchdog(
+      progress: progress,
+      onTimeout: () {
+        gemmaLog('⏱️ Resume watchdog fired for $taskId — closing as failed');
+        if (!progress.isClosed) {
+          progress.addError(
+            const DownloadException(
+              DownloadError.network('Download resume timed out (no progress)'),
+            ),
+            StackTrace.current,
+          );
+          progress.close();
+        }
+        listener?.cancel();
+      },
+    );
+  }
+
+  /// Cancels a pending resume watchdog — called the moment any subsequent
+  /// progress/status event arrives for the task, proving it's not dead.
+  static void _cancelResumeWatchdog() {
+    _resumeWatchdog?.cancel();
+    _resumeWatchdog = null;
+  }
 
   /// Checks if a URL is from HuggingFace CDN
   ///

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -383,14 +383,14 @@ class SmartDownloader {
             if (update is TaskProgressUpdate) {
               // A live event means the task is not dead — cancel any pending
               // resume watchdog so a normally-progressing task never false-fires (#355).
-              _cancelResumeWatchdog();
+              _cancelResumeWatchdog(update.task.taskId);
               final percents = (update.progress * 100).round();
               gemmaLog('📊 Progress (existing): $percents%');
               if (!progress.isClosed) {
                 progress.add(percents.clamp(0, 100));
               }
             } else if (update is TaskStatusUpdate) {
-              _cancelResumeWatchdog();
+              _cancelResumeWatchdog(update.task.taskId);
               gemmaLog('📡 TaskStatusUpdate (existing): ${update.status}');
               if (update.status == TaskStatus.complete) {
                 if (!progress.isClosed) {
@@ -503,14 +503,14 @@ class SmartDownloader {
           if (update is TaskProgressUpdate) {
             // A live event means the task is not dead — cancel any pending
             // resume watchdog so a normally-progressing task never false-fires (#355).
-            _cancelResumeWatchdog();
+            _cancelResumeWatchdog(update.task.taskId);
             final percents = (update.progress * 100).round();
             gemmaLog('📊 Progress: $percents%');
             if (!progress.isClosed) {
               progress.add(percents.clamp(0, 100));
             }
           } else if (update is TaskStatusUpdate) {
-            _cancelResumeWatchdog();
+            _cancelResumeWatchdog(update.task.taskId);
             gemmaLog(
               '📡 TaskStatusUpdate: ${update.status}, HTTP: ${update.responseStatusCode}',
             );
@@ -885,7 +885,11 @@ class SmartDownloader {
     }
   }
 
-  static Timer? _resumeWatchdog;
+  /// Keyed by taskId (#355 follow-up): SmartDownloader supports CONCURRENT
+  /// downloads, so a single shared `Timer?` field would let one task's
+  /// arm/cancel clobber another's watchdog. Each in-flight task gets its own
+  /// entry.
+  static final Map<String, Timer> _resumeWatchdogs = {};
 
   /// Arms the resume watchdog (#355 part 3): if no progress/status update
   /// arrives for [taskId] within [kResumeWatchdog], the task is presumed
@@ -896,11 +900,12 @@ class SmartDownloader {
     required StreamController<int> progress,
     required StreamSubscription? listener,
   }) {
-    _resumeWatchdog?.cancel();
-    _resumeWatchdog = armResumeWatchdog(
+    _resumeWatchdogs.remove(taskId)?.cancel();
+    _resumeWatchdogs[taskId] = armResumeWatchdog(
       progress: progress,
       onTimeout: () {
         gemmaLog('⏱️ Resume watchdog fired for $taskId — closing as failed');
+        _resumeWatchdogs.remove(taskId);
         if (!progress.isClosed) {
           progress.addError(
             const DownloadException(
@@ -915,11 +920,12 @@ class SmartDownloader {
     );
   }
 
-  /// Cancels a pending resume watchdog — called the moment any subsequent
-  /// progress/status event arrives for the task, proving it's not dead.
-  static void _cancelResumeWatchdog() {
-    _resumeWatchdog?.cancel();
-    _resumeWatchdog = null;
+  /// Cancels a pending resume watchdog for [taskId] — called the moment any
+  /// subsequent progress/status event arrives for that task, proving it's not
+  /// dead. Only ever touches this task's own entry, so concurrent downloads
+  /// can't cancel each other's watchdog.
+  static void _cancelResumeWatchdog(String taskId) {
+    _resumeWatchdogs.remove(taskId)?.cancel();
   }
 
   /// Checks if a URL is from HuggingFace CDN

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -552,6 +552,19 @@ class SmartDownloader {
                   }
                 }
 
+                // Capture-and-increment SYNCHRONOUSLY (before the await) rather
+                // than after it returns (#357 review): a broadcast stream's
+                // onData handlers don't serialize, so a second `failed`/
+                // `notFound` event for this task could interleave with this
+                // await and read the stale (pre-increment) counter. Bumping it
+                // here — before yielding control — guarantees two concurrent
+                // failed events for this task always see DIFFERENT
+                // resumeAttempt values. If the call turns out NOT to have
+                // triggered a resume, give the slot back so a non-resume
+                // failure never consumes budget it didn't use.
+                final attemptForThisRound = localResumeAttempt;
+                localResumeAttempt++;
+
                 final resumePending = await _handleFailedDownload(
                   task: task,
                   downloader: downloader,
@@ -566,19 +579,24 @@ class SmartDownloader {
                   cancelToken: cancelToken,
                   onListenerCreated: onListenerCreated,
                   onTaskCreated: onTaskCreated,
-                  resumeAttempt: localResumeAttempt,
+                  resumeAttempt: attemptForThisRound,
+                  onSettle: () {
+                    // Watchdog fire is a terminal outcome for this round —
+                    // settle the completer so the outer
+                    // `.whenComplete(() => cancellationListener?.cancel())`
+                    // in downloadWithProgress runs (#357 review fix: was
+                    // never called before, leaking the subscription).
+                    if (!completer.isCompleted) completer.complete();
+                  },
                 );
 
                 // Only cleanup if no resume is pending
                 // If resume was triggered, we need to keep listening for the result
                 if (!resumePending) {
+                  localResumeAttempt--; // give the slot back — not consumed
                   await listener?.cancel();
                   completer.complete();
                 } else {
-                  // Same listener stays active — bump the counter so the
-                  // NEXT failed event for this task (if the resume itself
-                  // fails again) sees an incremented resumeAttempt (#355).
-                  localResumeAttempt++;
                   gemmaLog(
                     '🔄 Resume pending - keeping listener active '
                     '(resumeAttempt now $localResumeAttempt)',
@@ -605,6 +623,13 @@ class SmartDownloader {
 
                 // 404 is a non-retryable error - handle immediately
                 // Note: 404 always returns false (no resume), but using same pattern for consistency
+                //
+                // Same synchronous capture-and-increment as the `failed` case
+                // above (#357 review) — closes the race window where a second
+                // concurrent event could read a stale counter mid-await.
+                final attemptForThisRound404 = localResumeAttempt;
+                localResumeAttempt++;
+
                 final resumePending404 = await _handleFailedDownload(
                   task: task,
                   downloader: downloader,
@@ -619,14 +644,20 @@ class SmartDownloader {
                   cancelToken: cancelToken,
                   onListenerCreated: onListenerCreated,
                   onTaskCreated: onTaskCreated,
-                  resumeAttempt: localResumeAttempt,
+                  resumeAttempt: attemptForThisRound404,
+                  onSettle: () {
+                    // 404 never resumes (checked earlier in
+                    // _handleFailedDownload), so the watchdog is never armed
+                    // on this path — kept for consistency with the `failed`
+                    // case above in case that ever changes.
+                    if (!completer.isCompleted) completer.complete();
+                  },
                 );
 
                 if (!resumePending404) {
+                  localResumeAttempt--; // give the slot back — not consumed
                   await listener?.cancel();
                   completer.complete();
-                } else {
-                  localResumeAttempt++;
                 }
                 break;
 
@@ -701,6 +732,7 @@ class SmartDownloader {
           return;
         }
 
+        // resumeAttempt intentionally omitted → resets to 0 for a fresh retry
         return _downloadWithSmartRetry(
           url: url,
           targetPath: targetPath,
@@ -748,6 +780,7 @@ class SmartDownloader {
     void Function(StreamSubscription)? onListenerCreated,
     void Function(String taskId)? onTaskCreated,
     required int resumeAttempt,
+    void Function()? onSettle,
   }) async {
     gemmaLog('🟡 _handleFailedDownload called');
     gemmaLog('🟡 httpStatusCode: $httpStatusCode');
@@ -818,6 +851,7 @@ class SmartDownloader {
     if (action == ResumeAction.resume) {
       gemmaLog(
         '🔄 Resuming task ${task.taskId} '
+        // +1: human-readable 1-indexed; the cap comparison is 0-indexed
         '(resume attempt ${resumeAttempt + 1}/$kMaxResumeAttempts)...',
       );
       try {
@@ -832,6 +866,7 @@ class SmartDownloader {
           taskId: task.taskId,
           progress: progress,
           listener: currentListener,
+          onSettle: onSettle,
         );
         return true; // ✅ Resume pending - caller should keep listener active!
       } catch (e) {
@@ -860,6 +895,7 @@ class SmartDownloader {
       }
 
       // Start fresh retry - new listener will be created
+      // resumeAttempt intentionally omitted → resets to 0 for a fresh retry
       await _downloadWithSmartRetry(
         url: url,
         targetPath: targetPath,
@@ -899,10 +935,21 @@ class SmartDownloader {
   /// arrives for [taskId] within [kResumeWatchdog], the task is presumed
   /// silently dead and [progress] is force-closed with a network error so the
   /// caller's `await for` over the stream can never hang forever.
+  ///
+  /// [onSettle] (#357 review): the `_downloadWithSmartRetry` listener that
+  /// armed this watchdog is awaiting its own `Completer<void>` and cancels
+  /// `cancellationListener` in a `.whenComplete()` once that completer
+  /// settles. A watchdog firing IS a terminal outcome for that round — it
+  /// force-closes [progress] and cancels [listener] — but without also
+  /// completing the completer, that `.whenComplete()` never runs and the
+  /// cancellation subscription leaks. [onSettle] lets the caller pass its
+  /// completer-completion so a watchdog fire settles the same way any other
+  /// terminal status update does.
   static void _armResumeWatchdog({
     required String taskId,
     required StreamController<int> progress,
     required StreamSubscription? listener,
+    void Function()? onSettle,
   }) {
     _resumeWatchdogs.remove(taskId)?.cancel();
     _resumeWatchdogs[taskId] = armResumeWatchdog(
@@ -920,6 +967,7 @@ class SmartDownloader {
           progress.close();
         }
         listener?.cancel();
+        onSettle?.call();
       },
     );
   }

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -159,13 +159,43 @@ class SmartDownloader {
       // Best-effort: don't block/fail the download on a denial, just log it.
       // This is a no-op that resolves to `granted` on platforms/versions that
       // don't need the permission (e.g. desktop, pre-Android-13).
+      //
+      // #357 review round 2 (Bug C): the native permission callback can, in
+      // principle, never arrive (app backgrounded mid-dialog, config change),
+      // which would hang this await forever and block the WHOLE download from
+      // starting. A 10s timeout guarantees this always resolves; `requestError`
+      // is treated the same as any other not-granted status below (Bug B).
+      PermissionStatus status;
       try {
-        final status = await downloader.permissions.request(
-          PermissionType.notifications,
-        );
-        gemmaLog('📲 SmartDownloader: POST_NOTIFICATIONS request → $status');
+        status = await downloader.permissions
+            .request(PermissionType.notifications)
+            .timeout(
+              const Duration(seconds: 10),
+              onTimeout: () => PermissionStatus.requestError,
+            );
       } catch (e) {
-        gemmaLog('⚠️ SmartDownloader: POST_NOTIFICATIONS request failed: $e');
+        // Distinguishable from a normal denial (#357 review minor): this is an
+        // unexpected throw from the request call itself, not a user decision.
+        gemmaLog(
+          '❌ SmartDownloader: POST_NOTIFICATIONS request threw (not a denial): $e',
+        );
+        status = PermissionStatus.requestError;
+      }
+
+      gemmaLog('📲 SmartDownloader: POST_NOTIFICATIONS request → $status');
+
+      // #357 review (Bug B): `gemmaLog` is a no-op in release builds
+      // (`if (!kDebugMode) return`), so the line above gives ZERO signal in
+      // release when the permission is denied. Without POST_NOTIFICATIONS,
+      // the foreground service never activates (see the comment above) and a
+      // long background download may be killed by the OS — surface that as a
+      // clearly distinguishable warning rather than silently degrading.
+      if (status != PermissionStatus.granted) {
+        gemmaLog(
+          '⚠️ SmartDownloader: POST_NOTIFICATIONS not granted ($status) — '
+          'foreground service will NOT activate; a long background download '
+          'may be killed. Have the host app pre-request POST_NOTIFICATIONS.',
+        );
       }
     }
 
@@ -463,7 +493,10 @@ class SmartDownloader {
                   progress.close();
                 }
                 await listener?.cancel();
-                completer.complete();
+                // Not verified reachable for double-complete on the reattach
+                // path (unlike the fresh-task listener above), but guarded
+                // anyway for hygiene/consistency (#357 review, Bug A).
+                if (!completer.isCompleted) completer.complete();
               } else if (update.status == TaskStatus.failed ||
                   update.status == TaskStatus.canceled) {
                 // Existing task failed - let caller handle retry
@@ -478,7 +511,7 @@ class SmartDownloader {
                   progress.close();
                 }
                 await listener?.cancel();
-                completer.complete();
+                if (!completer.isCompleted) completer.complete();
               }
             }
           },
@@ -507,6 +540,24 @@ class SmartDownloader {
 
         onListenerCreated?.call(listener);
         onTaskCreated?.call(taskId);
+
+        // #357 review (Bug E): arm the resume watchdog here too. `retries: 0`
+        // means an `existingTask` reattach is effectively always a persisted
+        // PAUSED task (paused multi-GB downloads surviving an app restart are
+        // a common path) — without a watchdog, a reattached task that goes
+        // completely silent (no event ever arrives) hangs at
+        // `await completer.future` below forever. The listener above already
+        // calls `_cancelResumeWatchdog` on every real
+        // TaskProgressUpdate/TaskStatusUpdate, so a live task disarms this
+        // immediately; only a truly silent one lets it fire.
+        _armResumeWatchdog(
+          taskId: taskId,
+          progress: progress,
+          listener: listener,
+          onSettle: () {
+            if (!completer.isCompleted) completer.complete();
+          },
+        );
 
         await completer.future;
         return;
@@ -587,7 +638,12 @@ class SmartDownloader {
                   progress.close();
                 }
                 await listener?.cancel();
-                completer.complete(); // ✅ Signal completion
+                // #357 review (Bug A): guarded against double-complete — a
+                // fresh retry reuses the same taskId, so this listener can
+                // still be alive when the retried task's terminal event also
+                // lands on the shared broadcast stream, completing the same
+                // completer twice (uncaught zone error) without this guard.
+                if (!completer.isCompleted) completer.complete();
                 break;
 
               case TaskStatus.failed:
@@ -656,7 +712,7 @@ class SmartDownloader {
                 if (!resumePending) {
                   localResumeAttempt--; // give the slot back — not consumed
                   await listener?.cancel();
-                  completer.complete();
+                  if (!completer.isCompleted) completer.complete();
                 } else {
                   gemmaLog(
                     '🔄 Resume pending - keeping listener active '
@@ -674,7 +730,7 @@ class SmartDownloader {
                   progress.close();
                 }
                 await listener?.cancel();
-                completer.complete(); // ✅ Signal completion
+                if (!completer.isCompleted) completer.complete();
                 break;
 
               case TaskStatus.notFound:
@@ -718,7 +774,7 @@ class SmartDownloader {
                 if (!resumePending404) {
                   localResumeAttempt--; // give the slot back — not consumed
                   await listener?.cancel();
-                  completer.complete();
+                  if (!completer.isCompleted) completer.complete();
                 }
                 break;
 
@@ -898,7 +954,9 @@ class SmartDownloader {
     try {
       canResume = await downloader.taskCanResume(task);
     } catch (e) {
-      gemmaLog('⚠️ taskCanResume threw: $e — treating as not resumable');
+      // ❌ (not ⚠️): an unexpected throw, distinct from a normal
+      // canResume=false decision (#357 review minor).
+      gemmaLog('❌ taskCanResume threw: $e — treating as not resumable');
     }
 
     final action = decideFailedDownloadAction(
@@ -916,20 +974,35 @@ class SmartDownloader {
         '(resume attempt ${resumeAttempt + 1}/$kMaxResumeAttempts)...',
       );
       try {
-        await downloader.resume(task);
-        gemmaLog('🔄 Resume triggered, waiting for status update...');
-        // Resume was accepted - let event loop handle the result.
-        // If resume succeeds → TaskStatus.complete will fire.
-        // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and
-        // the SAME listener re-enters this method with resumeAttempt + 1
-        // (threaded by the caller in _downloadWithSmartRetry).
-        _armResumeWatchdog(
-          taskId: task.taskId,
-          progress: progress,
-          listener: currentListener,
-          onSettle: onSettle,
-        );
-        return true; // ✅ Resume pending - caller should keep listener active!
+        // #357 review (Bug D): `resume()` returns Future<bool> — `false` means
+        // no resume data was available / the native re-enqueue failed. That's
+        // NOT a throw, so it fell through the old code unnoticed: the watchdog
+        // got armed and this returned true anyway, and since no status event
+        // will ever arrive for a resume that was never actually accepted, the
+        // caller stalled for the full 90s watchdog window for nothing.
+        final resumed = await downloader.resume(task);
+        if (!resumed) {
+          gemmaLog(
+            '⚠️ resume() returned false (no resume data / enqueue failed) — '
+            'falling through to retry/give-up',
+          );
+          // Fall through to the bounded retry/give-up logic below — do NOT
+          // arm the watchdog or return true.
+        } else {
+          gemmaLog('🔄 Resume triggered, waiting for status update...');
+          // Resume was accepted - let event loop handle the result.
+          // If resume succeeds → TaskStatus.complete will fire.
+          // If resume fails (e.g., weak ETag) → TaskStatus.failed will fire and
+          // the SAME listener re-enters this method with resumeAttempt + 1
+          // (threaded by the caller in _downloadWithSmartRetry).
+          _armResumeWatchdog(
+            taskId: task.taskId,
+            progress: progress,
+            listener: currentListener,
+            onSettle: onSettle,
+          );
+          return true; // ✅ Resume pending - caller should keep listener active!
+        }
       } catch (e) {
         gemmaLog('⚠️ resume() threw: $e — falling through to retry/give-up');
         // resume() was never accepted, so no status event will ever arrive

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -38,13 +38,24 @@ Timer armResumeWatchdog({
 /// `background_downloader` only calls `WorkManager.setForeground()` — the
 /// thing that actually activates the foreground service — when a `running`
 /// notification is configured. Setting `Config.runInForeground` alone is a
-/// no-op without it. A notification is needed for `foreground: true` (always)
-/// and for the auto-detect branch (`foreground == null`, since a large file
-/// can still trigger foreground at runtime); `foreground: false` never needs
-/// one.
+/// no-op without it.
+///
+/// Scoped to the EXPLICIT `foreground: true` flag only (#357 review). The
+/// notification, once configured, is global: `background_downloader`'s
+/// `Notifications.kt` shows it for every task in the `running` state,
+/// including ones that are NOT running in foreground
+/// (`displayNotification`'s `else` branch calls `notify()` unconditionally
+/// when `runInForeground` is false for that task). Returning true for the
+/// auto-detect branch (`foreground == null`) would therefore show a
+/// "Downloading model" notification on EVERY download — including small
+/// ones well under the 500MB foreground threshold, where none showed before.
+/// Trade-off: an auto-detected LARGE file (>500MB, which DOES run in
+/// foreground) won't get a notification unless the caller passes
+/// `foreground: true` explicitly. That's accepted in order to avoid the
+/// spurious notification on the much more common small-download path.
 @visibleForTesting
 bool shouldConfigureForegroundNotification(bool? foreground) =>
-    foreground != false;
+    foreground == true;
 
 /// Pure decision for [_handleFailedDownload]. Resume is only chosen while under
 /// [maxResumeAttempts] — the old code resumed unconditionally whenever
@@ -129,11 +140,33 @@ class SmartDownloader {
     // notification, no setForeground() call, no Doze/battery-optimization
     // exemption. This does NOT touch WorkManager's separate 9-minute
     // `TaskRunner` timeout (#192) — that limit is unrelated and unchanged.
+    //
+    // Scoped to `foreground == true` only (#357 review) — see
+    // shouldConfigureForegroundNotification's doc comment for why the
+    // auto-detect (`null`) branch is intentionally excluded.
     if (shouldConfigureForegroundNotification(foreground)) {
       downloader.configureNotification(
         running: const TaskNotification('Downloading model', '{filename}'),
         progressBar: true,
       );
+
+      // #357 review (Bug 2): on Android 13+ (API 33), background_downloader's
+      // `displayNotification()` bails out BEFORE calling `setForeground()` if
+      // `POST_NOTIFICATIONS` isn't granted at RUNTIME — declaring it in the
+      // manifest alone is necessary but not sufficient, so the foreground
+      // service would silently fail to activate. Request it proactively here
+      // so a foreground download actually gets the exemption it asked for.
+      // Best-effort: don't block/fail the download on a denial, just log it.
+      // This is a no-op that resolves to `granted` on platforms/versions that
+      // don't need the permission (e.g. desktop, pre-Android-13).
+      try {
+        final status = await downloader.permissions.request(
+          PermissionType.notifications,
+        );
+        gemmaLog('📲 SmartDownloader: POST_NOTIFICATIONS request → $status');
+      } catch (e) {
+        gemmaLog('⚠️ SmartDownloader: POST_NOTIFICATIONS request failed: $e');
+      }
     }
 
     _isConfigured = true;

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.2.0
+version: 1.2.1
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -45,6 +45,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   path_provider_platform_interface: ^2.1.0
   mocktail: ^1.0.0
+  fake_async: ^1.3.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gemma/mobile/smart_downloader.dart';
+
+void main() {
+  group('decideFailedDownloadAction', () {
+    test('resumes while under the resume-attempt cap', () {
+      expect(
+        decideFailedDownloadAction(
+          canResume: true,
+          resumeAttempt: 0,
+          currentAttempt: 0,
+          maxRetries: 10,
+          maxResumeAttempts: kMaxResumeAttempts,
+        ),
+        ResumeAction.resume,
+      );
+    });
+
+    test(
+      'stops resuming and falls through to retry once resume cap is hit',
+      () {
+        expect(
+          decideFailedDownloadAction(
+            canResume: true,
+            resumeAttempt: kMaxResumeAttempts,
+            currentAttempt: 1,
+            maxRetries: 10,
+            maxResumeAttempts: kMaxResumeAttempts,
+          ),
+          ResumeAction.retry,
+        );
+      },
+    );
+
+    test('retries when resume not possible but retries remain', () {
+      expect(
+        decideFailedDownloadAction(
+          canResume: false,
+          resumeAttempt: 0,
+          currentAttempt: 2,
+          maxRetries: 10,
+          maxResumeAttempts: kMaxResumeAttempts,
+        ),
+        ResumeAction.retry,
+      );
+    });
+
+    test('gives up when resume cap AND retry cap are both exhausted', () {
+      expect(
+        decideFailedDownloadAction(
+          canResume: true,
+          resumeAttempt: kMaxResumeAttempts,
+          currentAttempt: 10,
+          maxRetries: 10,
+          maxResumeAttempts: kMaxResumeAttempts,
+        ),
+        ResumeAction.giveUp,
+      );
+    });
+  });
+}

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -5,14 +5,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gemma/mobile/smart_downloader.dart';
 
 void main() {
-  group('shouldConfigureForegroundNotification (#356)', () {
+  group('shouldConfigureForegroundNotification (#356, #357 review)', () {
     test('foreground: true requires a notification', () {
       expect(shouldConfigureForegroundNotification(true), isTrue);
     });
 
-    test('foreground: null (auto-detect) requires a notification — a large '
-        'file can still trigger foreground at runtime', () {
-      expect(shouldConfigureForegroundNotification(null), isTrue);
+    test('foreground: null (auto-detect) does NOT configure a notification — '
+        'it would otherwise show for every non-foreground download too '
+        '(background_downloader shows the running notification regardless '
+        'of runInForeground)', () {
+      expect(shouldConfigureForegroundNotification(null), isFalse);
     });
 
     test('foreground: false does not need a notification', () {

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gemma/mobile/smart_downloader.dart';
 
@@ -84,6 +87,44 @@ void main() {
           ResumeAction.resume,
           ResumeAction.retry,
         ]);
+      },
+    );
+  });
+
+  group('armResumeWatchdog', () {
+    test('fires onTimeout after the watchdog duration when not cancelled', () {
+      fakeAsync((async) {
+        var fired = false;
+        armResumeWatchdog(
+          progress: StreamController<int>(),
+          onTimeout: () => fired = true,
+          timeout: const Duration(seconds: 90),
+        );
+        async.elapse(const Duration(seconds: 89));
+        expect(fired, isFalse);
+        async.elapse(const Duration(seconds: 2));
+        expect(
+          fired,
+          isTrue,
+        ); // hung task → watchdog fires → stream would close
+      });
+    });
+
+    test(
+      'does not fire if cancelled before the timeout (resume succeeded)',
+      () {
+        fakeAsync((async) {
+          var fired = false;
+          final t = armResumeWatchdog(
+            progress: StreamController<int>(),
+            onTimeout: () => fired = true,
+            timeout: const Duration(seconds: 90),
+          );
+          async.elapse(const Duration(seconds: 30));
+          t.cancel(); // a progress/complete event arrived → cancel the watchdog
+          async.elapse(const Duration(seconds: 120));
+          expect(fired, isFalse);
+        });
       },
     );
   });

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -5,6 +5,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gemma/mobile/smart_downloader.dart';
 
 void main() {
+  group('shouldConfigureForegroundNotification (#356)', () {
+    test('foreground: true requires a notification', () {
+      expect(shouldConfigureForegroundNotification(true), isTrue);
+    });
+
+    test('foreground: null (auto-detect) requires a notification — a large '
+        'file can still trigger foreground at runtime', () {
+      expect(shouldConfigureForegroundNotification(null), isTrue);
+    });
+
+    test('foreground: false does not need a notification', () {
+      expect(shouldConfigureForegroundNotification(false), isFalse);
+    });
+  });
+
   group('decideFailedDownloadAction', () {
     test('resumes while under the resume-attempt cap', () {
       expect(

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:background_downloader/background_downloader.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gemma/mobile/smart_downloader.dart';
@@ -365,6 +366,127 @@ void main() {
         // Both fired and self-removed — map must be empty, not leaking.
         expect(watchdogs, isEmpty);
       });
+    });
+  });
+
+  group('double-complete guard (#357 review, FIX A)', () {
+    // Reproduces the exact shape of the bug: a single failed→fresh-retry→
+    // terminal sequence reuses the same taskId, so the OLD listener (still
+    // alive because the caller keeps a reference to it) can also receive the
+    // retried task's terminal event and try to complete the SAME completer a
+    // second time. Without a guard, Dart's Completer.complete() throws
+    // "Future already completed" the second time it's called — and since
+    // that call happens inside a stream's onData callback (not inside code
+    // the caller awaits), the exception becomes an uncaught zone error rather
+    // than a catchable exception.
+    test(
+      'completing an already-completed completer without a guard throws',
+      () {
+        final completer = Completer<void>();
+        completer.complete();
+        // This is exactly what site ~590 etc. did before the fix: an
+        // unguarded second `completer.complete()` call.
+        expect(() => completer.complete(), throwsStateError);
+      },
+    );
+
+    test(
+      'the guarded pattern (if (!completer.isCompleted) completer.complete()) '
+      'tolerates the same overlapping-delivery sequence without throwing',
+      () {
+        final completer = Completer<void>();
+        void guardedComplete() {
+          if (!completer.isCompleted) completer.complete();
+        }
+
+        // First terminal event for this taskId (e.g. the fresh retry's own
+        // TaskStatus.complete).
+        guardedComplete();
+        expect(completer.isCompleted, isTrue);
+
+        // Second terminal event for the SAME taskId, delivered to the OLD
+        // listener that hasn't been cancelled yet (overlapping delivery on
+        // the shared broadcast stream) — must not throw.
+        expect(guardedComplete, returnsNormally);
+      },
+    );
+
+    test(
+      'guarded pattern also tolerates completeError racing after complete',
+      () {
+        // Mirrors the onError branch already in the file (which already
+        // guards) — included here to document that the SAME hazard applies
+        // symmetrically to completeError, and the existing onError sites
+        // were correct to guard from the start.
+        final completer = Completer<void>();
+        completer.complete();
+        expect(() {
+          if (!completer.isCompleted) {
+            completer.completeError(StateError('late error'));
+          }
+        }, returnsNormally);
+      },
+    );
+  });
+
+  group('resume() bool return (#357 review, FIX D)', () {
+    // downloader.resume(task) returns Future<bool>: false means "no resume
+    // data available / native re-enqueue failed" — NOT a throw. The old code
+    // discarded this return value entirely, so a false return still armed the
+    // watchdog and reported "resume pending", stalling the caller for the
+    // full 90s watchdog window even though no status event could ever arrive
+    // for a resume that was never actually accepted.
+    //
+    // This models the decision _handleFailedDownload now makes around the
+    // `resumed` bool, without needing a real FileDownloader.
+    ({bool armedWatchdog, bool resumePending}) decideAfterResume(bool resumed) {
+      if (!resumed) {
+        // Fall through to retry/give-up — do NOT arm watchdog / report pending.
+        return (armedWatchdog: false, resumePending: false);
+      }
+      return (armedWatchdog: true, resumePending: true);
+    }
+
+    test('resume() == true arms the watchdog and reports pending', () {
+      final outcome = decideAfterResume(true);
+      expect(outcome.armedWatchdog, isTrue);
+      expect(outcome.resumePending, isTrue);
+    });
+
+    test('resume() == false does NOT arm the watchdog and falls through '
+        'to retry/give-up instead of stalling 90s for an event that will '
+        'never arrive', () {
+      final outcome = decideAfterResume(false);
+      expect(outcome.armedWatchdog, isFalse);
+      expect(outcome.resumePending, isFalse);
+    });
+  });
+
+  group('permission not-granted decision (#357 review, FIX B/C)', () {
+    // Mirrors the `status != PermissionStatus.granted` check added to
+    // _ensureConfigured: anything other than exactly `granted` (denied,
+    // undetermined, partial, or requestError from either a real denial or a
+    // timeout) must trigger the visible not-granted warning path, while
+    // `granted` must not.
+    bool isNotGrantedWarningPath(PermissionStatus status) =>
+        status != PermissionStatus.granted;
+
+    test('granted does not trigger the warning path', () {
+      expect(isNotGrantedWarningPath(PermissionStatus.granted), isFalse);
+    });
+
+    test('denied triggers the warning path', () {
+      expect(isNotGrantedWarningPath(PermissionStatus.denied), isTrue);
+    });
+
+    test('requestError (used for both a thrown exception and a timeout) '
+        'triggers the warning path', () {
+      expect(isNotGrantedWarningPath(PermissionStatus.requestError), isTrue);
+    });
+
+    test('undetermined and partial also trigger the warning path', () {
+      expect(isNotGrantedWarningPath(PermissionStatus.undetermined), isTrue);
+      expect(isNotGrantedWarningPath(PermissionStatus.partial), isTrue);
     });
   });
 }

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -58,4 +58,33 @@ void main() {
       );
     });
   });
+
+  group('resume-attempt sequencing', () {
+    test(
+      'three consecutive resumable failures then a retry (the #355 sequence)',
+      () {
+        // Simulate the loop's decisions with an incrementing resumeAttempt.
+        final actions = <ResumeAction>[];
+        var resumeAttempt = 0;
+        for (var i = 0; i < 4; i++) {
+          final a = decideFailedDownloadAction(
+            canResume: true,
+            resumeAttempt: resumeAttempt,
+            currentAttempt: 0,
+            maxRetries: 10,
+            maxResumeAttempts: kMaxResumeAttempts,
+          );
+          actions.add(a);
+          if (a == ResumeAction.resume) resumeAttempt++;
+        }
+        // 3 resumes (0,1,2), then the 4th (resumeAttempt==3) falls through to retry.
+        expect(actions, [
+          ResumeAction.resume,
+          ResumeAction.resume,
+          ResumeAction.resume,
+          ResumeAction.retry,
+        ]);
+      },
+    );
+  });
 }

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -128,4 +128,94 @@ void main() {
       },
     );
   });
+
+  group('per-taskId watchdog isolation (concurrent downloads, #355 follow-up)', () {
+    // SmartDownloader keys its real watchdogs by taskId in a
+    // `Map<String, Timer>` (see `_resumeWatchdogs` in smart_downloader.dart) so
+    // that two concurrent downloads never clobber each other's timer. That map
+    // and its arm/cancel wrappers are private, so this test reconstructs the
+    // exact same arm/cancel/fire-removes-entry shape with the public
+    // `armResumeWatchdog` factory + a local map, to prove the pattern is sound
+    // for concurrent taskIds without needing a fake-downloader harness.
+    Timer arm(
+      Map<String, Timer> watchdogs,
+      String taskId,
+      StreamController<int> progress,
+      void Function() onTimeout,
+    ) {
+      watchdogs.remove(taskId)?.cancel();
+      final timer = armResumeWatchdog(
+        progress: progress,
+        onTimeout: () {
+          watchdogs.remove(taskId);
+          onTimeout();
+        },
+      );
+      watchdogs[taskId] = timer;
+      return timer;
+    }
+
+    void cancel(Map<String, Timer> watchdogs, String taskId) {
+      watchdogs.remove(taskId)?.cancel();
+    }
+
+    test('cancelling task A watchdog does not cancel task B watchdog', () {
+      fakeAsync((async) {
+        final watchdogs = <String, Timer>{};
+        var firedA = false;
+        var firedB = false;
+
+        arm(watchdogs, 'taskA', StreamController<int>(), () => firedA = true);
+        arm(watchdogs, 'taskB', StreamController<int>(), () => firedB = true);
+        expect(watchdogs.keys, containsAll(<String>['taskA', 'taskB']));
+
+        // A live progress event for task A cancels ONLY task A's watchdog.
+        cancel(watchdogs, 'taskA');
+        expect(watchdogs.containsKey('taskA'), isFalse);
+        expect(watchdogs.containsKey('taskB'), isTrue);
+
+        async.elapse(const Duration(seconds: 90));
+        // Task A was genuinely fine (cancelled) — never fires.
+        expect(firedA, isFalse);
+        // Task B was never cancelled — it was silently dead, so it fires.
+        expect(firedB, isTrue);
+      });
+    });
+
+    test('re-arming task A does not touch task B\'s timer', () {
+      fakeAsync((async) {
+        final watchdogs = <String, Timer>{};
+        var firedA = false;
+        var firedB = false;
+
+        arm(watchdogs, 'taskA', StreamController<int>(), () => firedA = true);
+        arm(watchdogs, 'taskB', StreamController<int>(), () => firedB = true);
+
+        async.elapse(const Duration(seconds: 30));
+        // Task A fails again and re-arms its OWN watchdog (fresh 90s window).
+        arm(watchdogs, 'taskA', StreamController<int>(), () => firedA = true);
+
+        async.elapse(const Duration(seconds: 60));
+        // Task B's original timer (armed at t=0) fires at t=90.
+        expect(firedB, isTrue);
+        // Task A's re-armed timer (armed at t=30) hasn't reached 90s yet.
+        expect(firedA, isFalse);
+
+        async.elapse(const Duration(seconds: 30));
+        expect(firedA, isTrue);
+      });
+    });
+
+    test('firing removes only that taskId\'s entry from the map (no leak)', () {
+      fakeAsync((async) {
+        final watchdogs = <String, Timer>{};
+        arm(watchdogs, 'taskA', StreamController<int>(), () {});
+        arm(watchdogs, 'taskB', StreamController<int>(), () {});
+
+        async.elapse(const Duration(seconds: 90));
+        // Both fired and self-removed — map must be empty, not leaking.
+        expect(watchdogs, isEmpty);
+      });
+    });
+  });
 }

--- a/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
+++ b/packages/flutter_gemma/test/mobile/smart_downloader_resume_test.dart
@@ -129,6 +129,138 @@ void main() {
     );
   });
 
+  group('resume-counter race window (#357 review, FIX 2)', () {
+    // Reproduces the shape of the fix in _downloadWithSmartRetry's listener:
+    // capture-and-increment `localResumeAttempt` SYNCHRONOUSLY before an
+    // await, rather than after it resolves. This proves two "concurrent"
+    // failed events (modeled here as two overlapping async decisions racing
+    // against the same counter) see DIFFERENT resumeAttempt values, whereas
+    // the old post-await-increment shape would let both read the same stale
+    // value.
+    Future<int> handleFailedDownloadStub({
+      required bool resumeWillHappen,
+      required Duration awaitDelay,
+    }) async {
+      // Simulates _handleFailedDownload's internal await (e.g. taskCanResume
+      // + downloader.resume/backoff) without depending on the real plugin.
+      await Future<void>.delayed(awaitDelay);
+      return resumeWillHappen ? 1 : 0; // arbitrary "work done" marker
+    }
+
+    test(
+      'two overlapping failed events see different resumeAttempt values',
+      () async {
+        var localResumeAttempt = 0;
+        final seenAttempts = <int>[];
+
+        Future<void> onFailedEvent(Duration awaitDelay) async {
+          // FIX 2 shape: capture + increment BEFORE the await.
+          final attemptForThisRound = localResumeAttempt;
+          localResumeAttempt++;
+          seenAttempts.add(attemptForThisRound);
+
+          final resumePending =
+              await handleFailedDownloadStub(
+                resumeWillHappen: true,
+                awaitDelay: awaitDelay,
+              ) ==
+              1;
+
+          if (!resumePending) {
+            localResumeAttempt--; // give the slot back
+          }
+        }
+
+        // Fire two "failed" events back-to-back without awaiting the first
+        // before starting the second — this is what a broadcast stream's
+        // non-serialized onData handlers can do.
+        final f1 = onFailedEvent(const Duration(milliseconds: 20));
+        final f2 = onFailedEvent(const Duration(milliseconds: 5));
+        await Future.wait([f1, f2]);
+
+        // Both events must have captured DIFFERENT resumeAttempt values
+        // (0 and 1, in dispatch order) even though f2's await resolved first.
+        expect(seenAttempts, [0, 1]);
+        expect(localResumeAttempt, 2); // both resumed → both consumed a slot
+      },
+    );
+
+    test(
+      'a non-resuming failure gives its slot back (does not consume budget)',
+      () async {
+        var localResumeAttempt = 0;
+
+        final attemptForThisRound = localResumeAttempt;
+        localResumeAttempt++;
+
+        final resumePending =
+            await handleFailedDownloadStub(
+              resumeWillHappen: false,
+              awaitDelay: const Duration(milliseconds: 1),
+            ) ==
+            1;
+
+        if (!resumePending) {
+          localResumeAttempt--;
+        }
+
+        expect(attemptForThisRound, 0);
+        expect(resumePending, isFalse);
+        // Slot given back — a subsequent real resume still starts at 0.
+        expect(localResumeAttempt, 0);
+      },
+    );
+  });
+
+  group('watchdog completer settlement (#357 review, FIX 3)', () {
+    test(
+      'watchdog fire calls onSettle so a waiting completer is not leaked',
+      () {
+        fakeAsync((async) {
+          final completer = Completer<void>();
+          var cancellationListenerCancelled = false;
+          // Mirrors downloadWithProgress's
+          // `.whenComplete(() => cancellationListener?.cancel())`.
+          completer.future.whenComplete(() {
+            cancellationListenerCancelled = true;
+          });
+
+          // Mirrors _armResumeWatchdog composing onTimeout with onSettle.
+          armResumeWatchdog(
+            progress: StreamController<int>(),
+            onTimeout: () {
+              if (!completer.isCompleted) completer.complete();
+            },
+            timeout: const Duration(seconds: 90),
+          );
+
+          expect(cancellationListenerCancelled, isFalse);
+          async.elapse(const Duration(seconds: 90));
+          // Flush the completer's async .whenComplete callback.
+          async.flushMicrotasks();
+
+          expect(completer.isCompleted, isTrue);
+          expect(cancellationListenerCancelled, isTrue);
+        });
+      },
+    );
+
+    test('onSettle guards against double-complete', () {
+      fakeAsync((async) {
+        final completer = Completer<void>();
+        void onSettle() {
+          if (!completer.isCompleted) completer.complete();
+        }
+
+        // Simulate the watchdog firing AND a terminal status update racing
+        // in — both try to settle the same completer.
+        onSettle();
+        expect(() => onSettle(), returnsNormally);
+        expect(completer.isCompleted, isTrue);
+      });
+    });
+  });
+
   group('per-taskId watchdog isolation (concurrent downloads, #355 follow-up)', () {
     // SmartDownloader keys its real watchdogs by taskId in a
     // `Map<String, Timer>` (see `_resumeWatchdogs` in smart_downloader.dart) so

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.2
-  flutter_gemma: ^1.2.0
+  flutter_gemma: ^1.2.1
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.3  # .task / .bin models (mobile + web)

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,7 +29,7 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.2.0                 # core — always required
+  flutter_gemma: ^1.2.1                 # core — always required
   flutter_gemma_litertlm: ^1.0.2        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.3       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings


### PR DESCRIPTION
Fixes #355 and #356. Bumps `flutter_gemma` to 1.2.1. Two related Android download-reliability bugs in `SmartDownloader`, reported by @alan-insam.

## #355 — resume-loop hang

`_handleFailedDownload`'s resume path resumed unconditionally with no attempt cap and no timeout. If a resume kept failing (HuggingFace weak-ETag) or the task silently died, the progress `StreamController` never closed and `install()`'s future never resolved — UI stuck "installing" forever.

Fix: a capped resume decision (`kMaxResumeAttempts = 3`); a resume-attempt counter incremented at dispatch (race-safe) and given back if the round didn't resume; fall-through to retry on a `resume()` throw; a per-`taskId` watchdog timer (90s) that closes the stream if a resumed task goes silent and settles the round's completer; and cancel clears the watchdog. Every failure path now provably terminates.

## #356 — foreground service never activated

`foreground: true` set `Config.runInForeground` but never called `configureNotification()`. Per the plugin's native code, without a running notification the Android foreground service never activates (no `setForeground()`), so `foreground: true` was a no-op — the download stayed subject to battery-optimization kills.

Fix: configure a running notification when `foreground: true` (scoped to the explicit flag so ordinary small downloads don't show a spurious notification), and auto-request `POST_NOTIFICATIONS` at runtime — required on Android 13+, without which `setForeground()` is never reached. The example manifest declares the permission; README/DOWNLOAD_TESTING document the host-app requirement.

**Honest scope:** #356 makes the foreground service activate (exempting the download from Doze/battery-optimization kills). It does **not** remove `background_downloader`'s hard 9-minute WorkManager `TaskRunner` timeout — that's a separate, documented limitation (#192). No doc claims otherwise.

## Verification

**Real integration runs (#355):**
- **Android FTL** (Pixel 8a, API 35) — `download_reliability_test` incl. the #355 resume-lifecycle-terminates guard: **8/8 passed** on real hardware.
- **macOS** — real 271 MB download terminated, never hung; watchdog armed 0× on the healthy path.

**Host:** 370 unit tests green. `flutter analyze` clean, `dart format` clean. Public `download`/`downloadWithProgress` API unchanged.

**Review:** a multi-reviewer pass (async/stream, code-quality, silent-failure, second-opinion) drove several rounds — caught and fixed a resume-counter race window, a watchdog completer/subscription leak, the missing changelog/version bump (#355), and a spurious-notification regression + an Android-13 runtime-permission gap (#356). Findings verified against the plugin's native source, not just re-read.

**Platform reach:** the fix is in the native download path (`mobile_service_factory` → SmartDownloader) used by Android/iOS/macOS/Windows/Linux. Web is unaffected (separate `WebDownloadService`).
