### PR TITLE
fix(genkit): declare ModelFileType.litertlm for .litertlm models

### DIFF
--- a/packages/genkit_flutter_gemma/CHANGELOG.md
+++ b/packages/genkit_flutter_gemma/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+- Fix example: declare `ModelFileType.litertlm` for `.litertlm` models (desktop was declaring `.task`, routing them to MediaPipe). Adds a fileType-consistency test.
+
 ## 0.4.2
 
 - Bump `genkit` to `^0.14.1` and `schemantic` to `^0.2.0`. No API or behavioral changes; tests green against the new versions.

--- a/packages/genkit_flutter_gemma/example/integration_test/test_helpers.dart
+++ b/packages/genkit_flutter_gemma/example/integration_test/test_helpers.dart
@@ -78,16 +78,14 @@ class TestModelConfig {
   static const litertlmConfig = TestModelConfig(
     url: _litertlmUrl,
     filename: 'functiongemma-270M-it.litertlm',
-    fileType: ModelFileType.task,
+    fileType: ModelFileType.litertlm,
   );
 
   /// All engine configs to test on current platform.
   /// Android gets both engines, others get one.
   static List<({TestModelConfig config, String label})>
-      allForCurrentPlatform() {
-    final configs = [
-      (config: forCurrentPlatform(), label: 'default engine'),
-    ];
+  allForCurrentPlatform() {
+    final configs = [(config: forCurrentPlatform(), label: 'default engine')];
     if (!kIsWeb && Platform.isAndroid) {
       configs.add((config: litertlmConfig, label: 'LiteRT-LM'));
     }
@@ -109,16 +107,16 @@ Future<void> ensureModelInstalled([TestModelConfig? config]) async {
 
 /// Force install a specific model config (always installs, even if another model is active).
 Future<void> forceInstallModel(TestModelConfig config) async {
-  debugPrint(
-      '[Test] Installing model: ${config.filename} from ${config.url}');
+  debugPrint('[Test] Installing model: ${config.filename} from ${config.url}');
 
   await FlutterGemma.installModel(
-    modelType: ModelType.functionGemma,
-    fileType: config.fileType,
-  )
+        modelType: ModelType.functionGemma,
+        fileType: config.fileType,
+      )
       .fromNetwork(config.url)
       .withProgress(
-          (progress) => debugPrint('[Test] Download progress: $progress%'))
+        (progress) => debugPrint('[Test] Download progress: $progress%'),
+      )
       .install();
 
   debugPrint('[Test] Model installed successfully');
@@ -130,35 +128,39 @@ Future<void> forceInstallModel(TestModelConfig config) async {
 Genkit createTestGenkit([TestModelConfig? config]) {
   config ??= TestModelConfig.forCurrentPlatform();
 
-  return Genkit(plugins: [
-    GenkitFlutterGemmaPlugin(models: [
-      FlutterGemmaModelConfig(
-        name: kTestModelName,
-        modelType: ModelType.functionGemma,
-        fileType: config.fileType,
+  return Genkit(
+    plugins: [
+      GenkitFlutterGemmaPlugin(
+        models: [
+          FlutterGemmaModelConfig(
+            name: kTestModelName,
+            modelType: ModelType.functionGemma,
+            fileType: config.fileType,
+          ),
+        ],
       ),
-    ]),
-  ]);
+    ],
+  );
 }
 
 /// Creates a [Genkit] instance with both model and embedder configured.
 Genkit createTestGenkitWithEmbedder([TestModelConfig? config]) {
   config ??= TestModelConfig.forCurrentPlatform();
 
-  return Genkit(plugins: [
-    GenkitFlutterGemmaPlugin(
-      models: [
-        FlutterGemmaModelConfig(
-          name: kTestModelName,
-          modelType: ModelType.functionGemma,
-          fileType: config.fileType,
-        ),
-      ],
-      embedders: [
-        FlutterGemmaEmbedderConfig(name: 'embedding-gemma-300m'),
-      ],
-    ),
-  ]);
+  return Genkit(
+    plugins: [
+      GenkitFlutterGemmaPlugin(
+        models: [
+          FlutterGemmaModelConfig(
+            name: kTestModelName,
+            modelType: ModelType.functionGemma,
+            fileType: config.fileType,
+          ),
+        ],
+        embedders: [FlutterGemmaEmbedderConfig(name: 'embedding-gemma-300m')],
+      ),
+    ],
+  );
 }
 
 /// Convenience [ModelRef] for the test model.

--- a/packages/genkit_flutter_gemma/example/lib/app_state.dart
+++ b/packages/genkit_flutter_gemma/example/lib/app_state.dart
@@ -70,6 +70,7 @@ class AppState extends ChangeNotifier {
     _useStreaming = value;
     notifyListeners();
   }
+
   String currentStreamText = '';
 
   // Embeddings
@@ -118,11 +119,17 @@ class AppState extends ChangeNotifier {
     final embedders = <FlutterGemmaEmbedderConfig>[];
 
     if (inferenceInstalled) {
-      models.add(FlutterGemmaModelConfig(
-        name: _modelName,
-        modelType: gemma.ModelType.gemmaIt,
-        fileType: _isDesktop ? ModelFileType.task : ModelFileType.task,
-      ));
+      models.add(
+        FlutterGemmaModelConfig(
+          name: _modelName,
+          modelType: gemma.ModelType.gemmaIt,
+          // Desktop downloads the .litertlm model (see inferenceUrl above) and so
+          // MUST declare ModelFileType.litertlm — otherwise the engine registry
+          // routes the .litertlm file to the MediaPipe (.task) engine, which
+          // can't load it. Mobile/web download the .task model → MediaPipe.
+          fileType: _isDesktop ? ModelFileType.litertlm : ModelFileType.task,
+        ),
+      );
     }
     if (embedderInstalled) {
       embedders.add(FlutterGemmaEmbedderConfig(name: _embedderName));
@@ -130,12 +137,9 @@ class AppState extends ChangeNotifier {
 
     if (models.isEmpty && embedders.isEmpty) return;
 
-    _ai = Genkit(plugins: [
-      GenkitFlutterGemmaPlugin(
-        models: models,
-        embedders: embedders,
-      ),
-    ]);
+    _ai = Genkit(
+      plugins: [GenkitFlutterGemmaPlugin(models: models, embedders: embedders)],
+    );
   }
 
   void reinitializeGenkit() {
@@ -152,15 +156,13 @@ class AppState extends ChangeNotifier {
     notifyListeners();
 
     try {
-      await FlutterGemma.installModel(
-        modelType: gemma.ModelType.gemmaIt,
-      )
-          .fromNetwork(inferenceUrl,
-              token: hfToken.isNotEmpty ? hfToken : null)
+      await FlutterGemma.installModel(modelType: gemma.ModelType.gemmaIt)
+          .fromNetwork(inferenceUrl, token: hfToken.isNotEmpty ? hfToken : null)
           .withProgress((progress) {
-        inferenceProgress = progress;
-        notifyListeners();
-      }).install();
+            inferenceProgress = progress;
+            notifyListeners();
+          })
+          .install();
 
       inferenceInstalled = true;
       _createGenkit();
@@ -238,10 +240,7 @@ class AppState extends ChangeNotifier {
           }
         }
 
-        chatMessages.add(ChatMessage(
-          text: currentStreamText,
-          isUser: false,
-        ));
+        chatMessages.add(ChatMessage(text: currentStreamText, isUser: false));
       } else {
         final response = await _ai!.generate(
           model: modelRef,
@@ -249,17 +248,11 @@ class AppState extends ChangeNotifier {
           config: FlutterGemmaModelOptions(maxTokens: maxTokens),
         );
 
-        chatMessages.add(ChatMessage(
-          text: response.text,
-          isUser: false,
-        ));
+        chatMessages.add(ChatMessage(text: response.text, isUser: false));
       }
     } catch (e, stack) {
       _logError('AppState.sendMessage', e, stack);
-      chatMessages.add(ChatMessage(
-        text: 'Error: $e',
-        isUser: false,
-      ));
+      chatMessages.add(ChatMessage(text: 'Error: $e', isUser: false));
     } finally {
       isGenerating = false;
       currentStreamText = '';
@@ -282,8 +275,9 @@ class AppState extends ChangeNotifier {
     try {
       final embeddings = await _ai!.embed(
         embedder: embedderRef,
-        documents:
-            texts.map((t) => DocumentData(content: [TextPart(text: t)])).toList(),
+        documents: texts
+            .map((t) => DocumentData(content: [TextPart(text: t)]))
+            .toList(),
       );
 
       final queryEmb = embeddings[0].embedding;
@@ -345,7 +339,8 @@ class AppState extends ChangeNotifier {
           buffer.writeln(part.text);
         } else if (part.isToolRequest) {
           buffer.writeln(
-              'Tool call: ${part.toolRequest!.name}(${part.toolRequest!.input})');
+            'Tool call: ${part.toolRequest!.name}(${part.toolRequest!.input})',
+          );
         }
       }
       lastToolResult = buffer.toString().trim();

--- a/packages/genkit_flutter_gemma/example/test/model_config_consistency_test.dart
+++ b/packages/genkit_flutter_gemma/example/test/model_config_consistency_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/test_helpers.dart';
+
+/// Guards against the class of bug Google flagged: a model whose URL/filename
+/// is `.litertlm` but whose declared `ModelFileType` is `.task` (or vice
+/// versa). Engine routing is driven by the declared `fileType` (`.task` →
+/// MediaPipe, `.litertlm` → LiteRT-LM), so a fileType that disagrees with the
+/// actual file extension routes the model to the wrong engine — a `.litertlm`
+/// file sent to MediaPipe won't load.
+///
+/// This is a PURE test (no network, no device) — it validates the static
+/// `TestModelConfig` values, so it runs under `flutter test` without a target.
+void main() {
+  /// The fileType every model file with [extension] must declare, per
+  /// flutter_gemma's `ModelFileType` doc comments (core/model.dart):
+  ///   .task            → ModelFileType.task     (MediaPipe)
+  ///   .bin / .tflite   → ModelFileType.binary   (manual templates)
+  ///   .litertlm        → ModelFileType.litertlm (LiteRT-LM)
+  ModelFileType expectedFileType(String path) {
+    final lower = path.toLowerCase();
+    if (lower.endsWith('.litertlm')) return ModelFileType.litertlm;
+    if (lower.endsWith('.task')) return ModelFileType.task;
+    if (lower.endsWith('.bin') || lower.endsWith('.tflite')) {
+      return ModelFileType.binary;
+    }
+    fail('Unrecognised model extension in "$path" — extend expectedFileType.');
+  }
+
+  void checkConsistent(String label, TestModelConfig config) {
+    // The URL extension and the filename extension must agree with each other…
+    expect(
+      expectedFileType(config.url),
+      expectedFileType(config.filename),
+      reason:
+          '$label: url "${config.url}" and filename "${config.filename}" '
+          'have mismatched extensions',
+    );
+    // …and the declared fileType must match that extension, so the engine
+    // registry routes the file to the engine that can actually load it.
+    expect(
+      config.fileType,
+      expectedFileType(config.url),
+      reason:
+          '$label: declares fileType ${config.fileType} but the model file '
+          '"${config.url}" is a ${expectedFileType(config.url)} file — this '
+          'routes to the wrong inference engine (the bug Google reported).',
+    );
+  }
+
+  test('mediapipeConfig fileType matches its .task file', () {
+    checkConsistent('mediapipeConfig', TestModelConfig.mediapipeConfig);
+    expect(TestModelConfig.mediapipeConfig.fileType, ModelFileType.task);
+  });
+
+  test('litertlmConfig fileType matches its .litertlm file', () {
+    checkConsistent('litertlmConfig', TestModelConfig.litertlmConfig);
+    // The regression: this was ModelFileType.task, routing the .litertlm model
+    // to MediaPipe. It must be ModelFileType.litertlm.
+    expect(TestModelConfig.litertlmConfig.fileType, ModelFileType.litertlm);
+  });
+
+  test('every allForCurrentPlatform() config is fileType-consistent', () {
+    final configs = TestModelConfig.allForCurrentPlatform();
+    expect(configs, isNotEmpty);
+    for (final entry in configs) {
+      checkConsistent(entry.label, entry.config);
+    }
+  });
+
+  test('forCurrentPlatform() is fileType-consistent', () {
+    checkConsistent('forCurrentPlatform', TestModelConfig.forCurrentPlatform());
+  });
+}

--- a/packages/genkit_flutter_gemma/pubspec.yaml
+++ b/packages/genkit_flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 issue_tracker: https://github.com/DenisovAV/flutter_gemma/issues

--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -110,7 +110,7 @@ Seven starter skills ship as package assets and cover all four mechanisms:
 
 ## SKILL.md format
 
-```yaml
+```
 ---
 name: kebab-case-id
 description: One-line summary the model uses to pick the skill.
@@ -153,13 +153,13 @@ Most skills need no platform setup. For the platform-specific bits:
   (pre-installed on Windows 11; bundle the bootstrapper for Windows 10).
 - **iOS** — the `create-calendar-event` intent needs a usage description in
   `ios/Runner/Info.plist`:
-  ```xml
+  ```
   <key>NSCalendarsUsageDescription</key>
   <string>Create calendar events from the agent.</string>
   ```
 - **Android** — `schedule_notification` requires core-library desugaring in
   `android/app/build.gradle(.kts)`:
-  ```kotlin
+  ```
   android { compileOptions { isCoreLibraryDesugaringEnabled = true } }
   dependencies { coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4") }
   ```

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -20,7 +20,7 @@ with the on-device model exactly as it would with any cloud provider.
 
 ```
 dependencies:
-  genkit_flutter_gemma: ^0.4.2
+  genkit_flutter_gemma: ^0.4.3
   flutter_gemma: ^1.2.1
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)


### PR DESCRIPTION
Fixes a model-routing bug in the `genkit_flutter_gemma` example that Google reported: a `.litertlm` model (LiteRT-LM engine) was declared with `ModelFileType.task`, so the engine registry — which routes by declared fileType (`.task`→MediaPipe, `.litertlm`→LiteRT-LM) — sent the LiteRT-LM model to the MediaPipe engine, which can't load it.

## Two mismatches fixed (both in `example/`)

- **`example/lib/app_state.dart`** — desktop downloads the `.litertlm` model, but the fileType ternary was `_isDesktop ? ModelFileType.task : ModelFileType.task` (both branches `.task`). Desktop now declares `ModelFileType.litertlm`; mobile/web stay `.task` (their URL is `.task`).
- **`example/integration_test/test_helpers.dart`** — `litertlmConfig` (a `.litertlm` url/filename) declared `fileType: ModelFileType.task`; now `ModelFileType.litertlm`.

## Regression guard

Adds `example/test/model_config_consistency_test.dart` — a pure unit test (no network/device) asserting every `TestModelConfig`'s declared `fileType` matches its url/filename extension (`.litertlm`→litertlm, `.task`→task, `.bin`/`.tflite`→binary). Verified red-then-green: it fails with the old `.task` declaration and passes after the fix, so this class of url×fileType desync can't silently regress.

## Notes

- The published `lib/` is unchanged — this is a patch fixing the demo/example. Version bumped `0.4.2` → `0.4.3`.
- `genkit_hybrid` was checked and is unaffected (provider-agnostic router, never touches `ModelFileType`).