### PR TITLE
fix(android): apply KGP when built-in Kotlin is off, not just AGP<9 (#360)

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2
+- Fix AGP 9 build on `android.builtInKotlin=false` — apply KGP unless built-in Kotlin is on, so the plugin's Kotlin compiles (#360).
+
 ## 1.2.1
 - Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
 - Fix foreground downloads on Android — configure a running notification so the service actually activates (#356).

--- a/packages/flutter_gemma/android/build.gradle
+++ b/packages/flutter_gemma/android/build.gradle
@@ -23,12 +23,16 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-// Built-in Kotlin migration (#323). AGP 9 ships Kotlin built-in and rejects an
-// explicit kotlin-android apply; AGP 8.x still needs it. Apply KGP only on
-// AGP < 9 so we build on both and stop tripping Flutter's "plugin applies KGP"
-// deprecation warning on AGP 9+.
+// Built-in Kotlin migration (#323), fixed for #360. AGP 9's built-in Kotlin is
+// opt-in (android.builtInKotlin=true); Flutter's AGP-9 tooling sets it to `false`
+// by default so KGP-based plugins keep building (flutter/flutter#183910). The old
+// check keyed on the AGP *version* alone, so on AGP 9 with the flag false/unset
+// NEITHER KGP nor built-in Kotlin compiled the plugin's .kt — FlutterGemmaPlugin
+// was never emitted and the app's GeneratedPluginRegistrant failed (#360). Apply
+// KGP when AGP < 9 OR built-in Kotlin is not explicitly enabled.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlinOn = project.findProperty('android.builtInKotlin') == 'true'
+if (agpMajor < 9 || !builtInKotlinOn) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma


### PR DESCRIPTION
Fixes #360.

## Problem
Since #323 (Built-in Kotlin migration), the plugin applied the Kotlin Gradle Plugin only when `agpMajor < 9`. But AGP 9's built-in Kotlin is opt-in, and Flutter's AGP-9 tooling sets `android.builtInKotlin=false` by default (flutter/flutter#183910). So on AGP 9 with the flag false — the default for any app that has other KGP-based plugins — neither KGP nor built-in Kotlin compiled the plugin's `.kt`. `FlutterGemmaPlugin` was never emitted and the app's `GeneratedPluginRegistrant` failed with `cannot find symbol`.

## Fix
Apply KGP when `AGP < 9` **OR** built-in Kotlin is not explicitly enabled.

## Verification
Reproduced on a fresh Flutter app with AGP 9.0.1 + Gradle 9.1.0 + `builtInKotlin=false` + `newDsl=false` (the reporter's exact environment): the build failed with the reported `cannot find symbol FlutterGemmaPlugin`, and with this fix the debug APK builds cleanly.

Bump 1.2.1 → 1.2.2.