### PR TITLE
fix(android): propagate #360 KGP guard to flutter_gemma_mediapipe + release 1.2.2 / mediapipe 1.0.4

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -52,6 +52,9 @@ Three independent dimensions — answer each:
 git diff <last-tag> -- lib/ hook/ pubspec.yaml ios/flutter_gemma.podspec android/ web/
 ```
 If yes → bump pub plugin version, publish to pub.dev. Always true for a release.
+Then **run 1f** for every satellite whose copy of the touched code is stale — a
+fix is not "done" until every duplicate across all 6 packages is patched or
+shown N/A.
 
 ### 1b. Native dylibs changed (any platform)?
 ```bash
@@ -70,6 +73,43 @@ Every release touches the site. At minimum the package versions hardcoded in its
 git diff <last-tag> -- packages/flutter_gemma/lib/flutter_gemma_interface.dart packages/flutter_gemma/lib/core
 ```
 If the public `InferenceModel` / `InferenceChat` / `EmbeddingModel` / `Message` / `ModelResponse` / enum surface changed, the Genkit integration packages (`genkit_flutter_gemma`, `genkit_hybrid`) likely no longer compile or are missing the new features. **Run the `upgrade-genkit` skill** before publishing — it realigns converters + the test fakes (which must match upstream signatures) and bumps those packages. They release in lockstep with the monorepo, so don't ship a core change that leaves them broken.
+
+### 1f. Did a fix touch shared code duplicated across satellites? → propagate it to ALL packages
+The monorepo split means the SAME logic is often copy-pasted into multiple
+packages' `android/build.gradle`, `hook/build.dart`, iOS podspecs, or FFI stubs.
+A core-only fix that leaves a copy stale ships a **HALF-fix** — and because each
+satellite publishes independently, the stale copy reaches users under its own
+version number.
+
+> **Regression #360 (what this rule prevents):** the AGP-9 Kotlin guard
+> `if (agpMajor < 9)` was fixed in `flutter_gemma/android/build.gradle`, but the
+> byte-identical guard in `flutter_gemma_mediapipe/android/build.gradle` was
+> missed. mediapipe `1.0.3` shipped to pub.dev still broken, so every `.task`
+> user on AGP 9 kept hitting the crash the core fix was supposed to close.
+
+**Before finalizing, grep the pattern you changed across ALL packages** and
+confirm every copy is patched (or provably N/A):
+```bash
+grep -rn "<the exact pattern you changed>" packages/
+# e.g. for the #360 guard:
+grep -rn "agpMajor < 9" packages/*/android/build.gradle
+```
+Shared-code hotspots to sweep, per fix type:
+- **Android Gradle** — `packages/*/android/build.gradle` (only `flutter_gemma` +
+  `flutter_gemma_mediapipe` have one): `kotlin-android` guard, `compileSdk`,
+  `minSdkVersion`, `kotlin_version`, AGP classpath.
+- **Native hook** — `packages/*/hook/build.dart`: `_nativeVersion`, `_checksums`,
+  `_cacheDir` cache-busting, `stage()` Apple-only guard.
+- **iOS podspecs** — `packages/*/ios/*.podspec`: `s.version`, min-iOS, dep pins,
+  `vtool` minos on any bundled dylib.
+- **FFI / web stubs** — `lib/**/*_stub.dart`: conditional-import signatures that
+  `analyze`/`test` can't catch (web stub drift).
+
+Every affected satellite gets its **own** version bump + CHANGELOG entry +
+publish. **This makes it a MULTI-package release** — before touching any
+version, list every package you will publish (e.g. "publishing `flutter_gemma`
+1.2.2 AND `flutter_gemma_mediapipe` 1.0.4"), and run the whole of Steps 2/8/9/10
+for each one.
 
 ## Step 2: Bump versions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Core has NO pigeon (dropped at the 1.0 cut; its value types are hand-written in 
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.13.1-a` GitHub Release. Android tarball bundles the Qualcomm QNN dispatch stack and Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` (Qualcomm Snapdragon / Intel LunarLake/PantherLake). MTP (speculative decoding) support for Gemma 4 (#318 MTP crash fixed). (native-v0.13.1-a restores the NPU dispatch libs accidentally omitted from native-v0.13.1 — #155.)
 - **large_file_handler**: `^0.5.0` (core dep; 0.5.0 declares all 6 platforms — needed for pana platform support + the dart2wasm-clean web graph)
-- **Current Version**: core `flutter_gemma` `1.2.1`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm`/`flutter_gemma_mediapipe` `1.0.2`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
+- **Current Version**: core `flutter_gemma` `1.2.2`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.2`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2
+- Fix AGP 9 build on `android.builtInKotlin=false` — apply KGP unless built-in Kotlin is on, so the plugin's Kotlin compiles (#360).
+
 ## 1.2.1
 - Fix SmartDownloader resume-loop hang — cap resume attempts + arm a watchdog timer (#355).
 - Fix foreground downloads on Android — configure a running notification so the service actually activates (#356).

--- a/packages/flutter_gemma/android/build.gradle
+++ b/packages/flutter_gemma/android/build.gradle
@@ -23,12 +23,16 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-// Built-in Kotlin migration (#323). AGP 9 ships Kotlin built-in and rejects an
-// explicit kotlin-android apply; AGP 8.x still needs it. Apply KGP only on
-// AGP < 9 so we build on both and stop tripping Flutter's "plugin applies KGP"
-// deprecation warning on AGP 9+.
+// Built-in Kotlin migration (#323), fixed for #360. AGP 9's built-in Kotlin is
+// opt-in (android.builtInKotlin=true); Flutter's AGP-9 tooling sets it to `false`
+// by default so KGP-based plugins keep building (flutter/flutter#183910). The old
+// check keyed on the AGP *version* alone, so on AGP 9 with the flag false/unset
+// NEITHER KGP nor built-in Kotlin compiled the plugin's .kt — FlutterGemmaPlugin
+// was never emitted and the app's GeneratedPluginRegistrant failed (#360). Apply
+// KGP when AGP < 9 OR built-in Kotlin is not explicitly enabled.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlinOn = project.findProperty('android.builtInKotlin') == 'true'
+if (agpMajor < 9 || !builtInKotlinOn) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.2.1'
+  s.version          = '1.2.2'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma

--- a/packages/flutter_gemma_mediapipe/CHANGELOG.md
+++ b/packages/flutter_gemma_mediapipe/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+- Fix AGP 9 build on `android.builtInKotlin=false` — apply KGP unless built-in Kotlin is on, so the plugin's Kotlin compiles (#360).
+
 ## 1.0.3
 - Migrate Android module to Built-in Kotlin — apply KGP only on AGP < 9, ready for AGP 9+ (#323).
 

--- a/packages/flutter_gemma_mediapipe/android/build.gradle
+++ b/packages/flutter_gemma_mediapipe/android/build.gradle
@@ -23,12 +23,16 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-// Built-in Kotlin migration (#323). AGP 9 ships Kotlin built-in and rejects an
-// explicit kotlin-android apply; AGP 8.x still needs it. Apply KGP only on
-// AGP < 9 so we build on both and stop tripping Flutter's "plugin applies KGP"
-// deprecation warning on AGP 9+.
+// Built-in Kotlin migration (#323), fixed for #360. AGP 9's built-in Kotlin is
+// opt-in (android.builtInKotlin=true); Flutter's AGP-9 tooling sets it to `false`
+// by default so KGP-based plugins keep building (flutter/flutter#183910). The old
+// check keyed on the AGP *version* alone, so on AGP 9 with the flag false/unset
+// NEITHER KGP nor built-in Kotlin compiled the plugin's .kt — the MediaPipe plugin
+// class was never emitted and the app's GeneratedPluginRegistrant failed (#360).
+// Apply KGP when AGP < 9 OR built-in Kotlin is not explicitly enabled.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlinOn = project.findProperty('android.builtInKotlin') == 'true'
+if (agpMajor < 9 || !builtInKotlinOn) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/flutter_gemma_mediapipe/ios/flutter_gemma_mediapipe.podspec
+++ b/packages/flutter_gemma_mediapipe/ios/flutter_gemma_mediapipe.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma_mediapipe'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'MediaPipe GenAI (.task) inference backend for flutter_gemma on iOS.'
   s.description      = <<-DESC
 MediaPipe GenAI (`.task`) inference backend for the flutter_gemma plugin.

--- a/packages/flutter_gemma_mediapipe/pubspec.yaml
+++ b/packages/flutter_gemma_mediapipe/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_mediapipe
 description: "MediaPipe (.task) on-device inference engine for flutter_gemma (Android/iOS/Web). Opt-in package; provides an InferenceEngineProvider. Bundles Google's MediaPipe Pod/Gradle deps."
-version: 1.0.3
+version: 1.0.4
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_mediapipe
 topics: [gemma, llm, mediapipe, on-device, ai]

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,10 +21,10 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.2.1
+  flutter_gemma: ^1.2.2
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)
-  flutter_gemma_mediapipe: ^1.0.3  # .task / .bin models (mobile + web)
+  flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
   flutter_gemma_embeddings: ^1.0.1
 ```

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,9 +29,9 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.2.1                 # core — always required
+  flutter_gemma: ^1.2.2                 # core — always required
   flutter_gemma_litertlm: ^1.0.2        # add if you run .litertlm models
-  flutter_gemma_mediapipe: ^1.0.3       # add if you run .task / .bin models
+  flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)
   flutter_gemma_rag_sqlite: ^1.1.0      # add for on-device RAG (sqlite-vec; all platforms incl. web)


### PR DESCRIPTION
Follow-up to #361. The squash-merge of #361 landed only the core `flutter_gemma` Gradle fix + 1.2.2 bump. This PR carries the rest of the #360 work that didn't make it into that squash:

## What

- **Propagate the #360 fix to `flutter_gemma_mediapipe`.** Its `android/build.gradle` had the byte-identical `if (agpMajor < 9)` guard, so `.task`/MediaPipe users on AGP 9 with `android.builtInKotlin=false` (Flutter's default) still hit the `GeneratedPluginRegistrant` crash — the published `1.0.3` shipped broken. Applies the same combo guard: `if (agpMajor < 9 || !builtInKotlinOn)`.
- **Release version bumps:**
  - `flutter_gemma` → 1.2.2 (podspec — pubspec/CHANGELOG landed in #361)
  - `flutter_gemma_mediapipe` → 1.0.4 (pubspec + podspec + CHANGELOG)
  - `CLAUDE.md` current-version line, `website/` docs (`^1.2.2`, `^1.0.4`)
- **Release skill hardening:** new **§1f — cross-package propagation check** in `.claude/skills/release/SKILL.md`. Requires grepping the changed pattern across all 6 packages so a core-only fix never leaves a satellite stale (exactly the gap that let mediapipe `1.0.3` ship with the #360 bug).

## Verification

- `flutter analyze` — 0 errors both packages
- `flutter test` — core 379/379
- `flutter build apk --release` — core ✓ (317 MB; exercises the changed Gradle)
- `dart pub publish --dry-run` — clean both packages
- 1f sweep: no bare `if (agpMajor < 9)` left in any `packages/*/android/build.gradle`

Fixes #360 (completes the mediapipe half).