### PR TITLE
fix(litertlm): create conversation off the main isolate to avoid ANRs

### DIFF
--- a/packages/flutter_gemma/example/integration_test/gemma4_raw_output_capture.dart
+++ b/packages/flutter_gemma/example/integration_test/gemma4_raw_output_capture.dart
@@ -68,7 +68,7 @@ void main() {
         },
       ]);
 
-      ffi.createConversation(
+      await ffi.createConversation(
         toolsJson: tools,
         temperature: 0.6,
         topK: 40,
@@ -139,7 +139,7 @@ void main() {
         maxTokens: 2048,
         cacheDir: cacheDir.path,
       );
-      ffi.createConversation(temperature: 0.6, topK: 40, seed: 42);
+      await ffi.createConversation(temperature: 0.6, topK: 40, seed: 42);
 
       final messageJson = LiteRtLmFfiClient.buildMessageJson(
         'What is the capital of France?',

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/backend_preference.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/backend_preference.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter_gemma/core/domain/platform_types.dart';
@@ -76,7 +77,11 @@ Future<({T client, PreferredBackend activeBackend})> initializeFfiRuntime<T>({
   required T Function() createClient,
   required Future<void> Function(T client, PreferredBackend backend)
   initializeClient,
-  required void Function(T client) shutdownClient,
+  // FutureOr: LiteRtLmFfiClient.shutdown() is async (it waits for in-flight
+  // conversation creates before engine_delete); test fakes tear down
+  // synchronously. Awaiting covers both, so a failed backend is fully released
+  // before the next one allocates an engine.
+  required FutureOr<void> Function(T client) shutdownClient,
 }) async {
   final attempts = <BackendInitAttemptFailure>[];
   final backends = ffiBackendFallbackOrder(preferredBackend);
@@ -98,7 +103,7 @@ Future<({T client, PreferredBackend activeBackend})> initializeFfiRuntime<T>({
           stackTrace: stackTrace,
         ),
       );
-      shutdownClient(client);
+      await shutdownClient(client);
       developer.log(
         '$logTag ${ffiBackendWireName(backend)} backend failed: $error',
         name: 'flutter_gemma',

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
@@ -122,7 +122,7 @@ class FfiInferenceModel extends InferenceModel with CloseNotifier {
           : null;
 
       final beforeConv = sessionSw.elapsedMilliseconds;
-      final handle = ffiClient.createConversationHandle(
+      final handle = await ffiClient.createConversationHandle(
         systemMessage: systemInstruction,
         toolsJson: toolsJson,
         temperature: temperature,

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
@@ -135,6 +135,14 @@ class FfiInferenceModel extends InferenceModel with CloseNotifier {
         '[FfiInferenceModel/perf] createConversation (FFI): ${sessionSw.elapsedMilliseconds - beforeConv}ms',
       );
 
+      // createConversationHandle now suspends across an isolate round trip, so
+      // close() can have run while we were away. Without this the caller gets a
+      // working-looking session whose conversation belongs to a dead engine.
+      if (_isClosed) {
+        handle.close();
+        throw StateError('Model was closed while creating a session');
+      }
+
       late final FfiInferenceModelSession session;
       session = FfiInferenceModelSession(
         handle: handle,
@@ -309,7 +317,9 @@ class FfiInferenceModel extends InferenceModel with CloseNotifier {
       }
       _openSessions.clear();
     } finally {
-      ffiClient.shutdown();
+      // Awaited: shutdown() defers engine_delete until any conversation create
+      // suspended on its spawned isolate has finished.
+      await ffiClient.shutdown();
       onClose(); // legacy hook (engine passes a no-op)
       fireCloseListeners(); // core's singleton-reset, registered via addCloseListener
     }

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -173,6 +173,55 @@ class LiteRtLmConversationHandle implements ConversationHandle {
   }
 }
 
+/// Opens the LiteRT-LM shared library for the current platform.
+///
+/// Top-level so it can be called from a spawned isolate, which cannot capture
+/// `this` or any other non-const closure state.
+DynamicLibrary _openLiteRtLmLibrary() {
+  if (Platform.isIOS) {
+    return DynamicLibrary.open(
+      '@executable_path/Frameworks/LiteRtLm.framework/LiteRtLm',
+    );
+  }
+  if (Platform.isMacOS) {
+    return DynamicLibrary.open('LiteRtLm.framework/LiteRtLm');
+  }
+  if (Platform.isLinux || Platform.isAndroid) {
+    return DynamicLibrary.open('libLiteRtLm.so');
+  }
+  return DynamicLibrary.open('LiteRtLm.dll');
+}
+
+/// Calls native `litert_lm_conversation_create` on a spawned isolate.
+///
+/// For multimodal models this compiles the vision encoder's OpenCL kernels
+/// (`clBuildProgram`), which costs ~8s on a mid-range mobile GPU. Recent
+/// Flutter runs the Dart UI thread on Android's platform thread, so calling
+/// this inline blocks input dispatch and the OS raises an
+/// "Input dispatching timed out" ANR.
+///
+/// Native pointers are process-wide, so the conversation can be built on any
+/// isolate and used from this one. This mirrors what `litert_lm_engine_create`
+/// already does.
+Future<int> _createConversationOffMainIsolate({
+  required int engineAddr,
+  required int configAddr,
+}) {
+  final isolateLogLevel = gemmaLogLevel;
+  return Isolate.run(() {
+    gemmaLogLevel = isolateLogLevel;
+    final create = _openLiteRtLmLibrary()
+        .lookupFunction<
+          Pointer Function(Pointer, Pointer),
+          Pointer Function(Pointer, Pointer)
+        >('litert_lm_conversation_create');
+    return create(
+      Pointer.fromAddress(engineAddr),
+      Pointer.fromAddress(configAddr),
+    ).address;
+  });
+}
+
 /// High-level Dart wrapper around the LiteRT-LM C API.
 ///
 /// Provides a clean async interface over the native C functions,
@@ -686,7 +735,7 @@ class LiteRtLmFfiClient {
   /// session multiplexer to replay a session's history into a fresh
   /// conversation. When null the conversation starts empty (legacy
   /// behaviour).
-  LiteRtLmConversationHandle createConversationHandle({
+  Future<LiteRtLmConversationHandle> createConversationHandle({
     String? systemMessage,
     String? toolsJson,
     String? messagesJson,
@@ -695,8 +744,8 @@ class LiteRtLmFfiClient {
     double? topP,
     int seed = 1,
     int? maxOutputTokens,
-  }) {
-    final conv = _createRawConversation(
+  }) async {
+    final conv = await _createRawConversation(
       systemMessage: systemMessage,
       toolsJson: toolsJson,
       messagesJson: messagesJson,
@@ -719,7 +768,7 @@ class LiteRtLmFfiClient {
   /// ([startVirtualTurn]) which owns the pointer's lifecycle directly and
   /// does not register a handle. Lock-free — callers that need
   /// serialization (the multiplexer) hold [_nativeMutex] around it.
-  Pointer<LiteRtLmConversation> _createRawConversation({
+  Future<Pointer<LiteRtLmConversation>> _createRawConversation({
     String? systemMessage,
     String? toolsJson,
     String? messagesJson,
@@ -728,7 +777,7 @@ class LiteRtLmFfiClient {
     double? topP,
     int seed = 1,
     int? maxOutputTokens,
-  }) {
+  }) async {
     _assertInitialized();
     final b = _bindings!;
 
@@ -820,7 +869,12 @@ class LiteRtLmFfiClient {
       );
     }
 
-    final conv = b.litert_lm_conversation_create(_engine!, convConfig);
+    final conv = Pointer<LiteRtLmConversation>.fromAddress(
+      await _createConversationOffMainIsolate(
+        engineAddr: _engine!.address,
+        configAddr: convConfig.address,
+      ),
+    );
 
     b.litert_lm_conversation_config_delete(convConfig);
 
@@ -836,16 +890,16 @@ class LiteRtLmFfiClient {
   /// conversation (if any) and opens a fresh one stored in [_legacyHandle].
   /// Kept for backward compat — new code should use
   /// [createConversationHandle] and own the handle directly.
-  void createConversation({
+  Future<void> createConversation({
     String? systemMessage,
     String? toolsJson,
     double temperature = 0.8,
     int topK = 40,
     double? topP,
     int seed = 1,
-  }) {
+  }) async {
     _legacyHandle?.close();
-    _legacyHandle = createConversationHandle(
+    _legacyHandle = await createConversationHandle(
       systemMessage: systemMessage,
       toolsJson: toolsJson,
       temperature: temperature,
@@ -1093,7 +1147,7 @@ class LiteRtLmFfiClient {
           final historyJson = history.isEmpty
               ? null
               : buildHistoryJson(history);
-          _virtualConv = _createRawConversation(
+          _virtualConv = await _createRawConversation(
             systemMessage: systemMessage,
             toolsJson: toolsJson,
             messagesJson: historyJson,

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -245,6 +245,41 @@ class LiteRtLmFfiClient {
   String? _nativeLogPath;
   String? _backend;
 
+  /// Conversation creates currently suspended across an `await`.
+  ///
+  /// `litert_lm_conversation_create` runs on a spawned isolate, so the calling
+  /// isolate's event loop is free for the duration — long enough for [shutdown]
+  /// to run `litert_lm_engine_delete` while native code is still dereferencing
+  /// the engine pointer. [shutdown] waits for this to reach zero, and creates
+  /// re-check [_isShuttingDown] before publishing anything.
+  int _createsInFlight = 0;
+  Completer<void>? _createsQuiescent;
+  bool _isShuttingDown = false;
+
+  void _enterCreate() => _createsInFlight++;
+
+  void _exitCreate() {
+    if (--_createsInFlight == 0) {
+      _createsQuiescent?.complete();
+      _createsQuiescent = null;
+    }
+  }
+
+  /// Runs [body] while [shutdown] is held off. Everything the create publishes
+  /// (the conversation pointer, its handle) must happen inside [body];
+  /// [shutdown] may proceed the moment it returns.
+  Future<T> _guardCreate<T>(Future<T> Function() body) async {
+    if (_isShuttingDown) {
+      throw StateError('Client is shutting down; cannot create a conversation');
+    }
+    _enterCreate();
+    try {
+      return await body();
+    } finally {
+      _exitCreate();
+    }
+  }
+
   /// All live conversation handles created on this client. Closed in bulk
   /// by [shutdown]. Each handle removes itself on its own [close].
   final Set<LiteRtLmConversationHandle> _handles = {};
@@ -654,15 +689,7 @@ class LiteRtLmFfiClient {
       final engineAddr = await Isolate.run(() {
         gemmaLogLevel = isolateLogLevel;
         final isolateSw = Stopwatch()..start();
-        final lib = Platform.isIOS
-            ? DynamicLibrary.open(
-                '@executable_path/Frameworks/LiteRtLm.framework/LiteRtLm',
-              )
-            : Platform.isMacOS
-            ? DynamicLibrary.open('LiteRtLm.framework/LiteRtLm')
-            : (Platform.isLinux || Platform.isAndroid)
-            ? DynamicLibrary.open('libLiteRtLm.so')
-            : DynamicLibrary.open('LiteRtLm.dll');
+        final lib = _openLiteRtLmLibrary();
         gemmaLog(
           '[LiteRtLmFfi/perf]   isolate: DynamicLibrary.open: ${isolateSw.elapsedMilliseconds}ms',
           level: GemmaLogLevel.verbose,
@@ -744,21 +771,26 @@ class LiteRtLmFfiClient {
     double? topP,
     int seed = 1,
     int? maxOutputTokens,
-  }) async {
-    final conv = await _createRawConversation(
-      systemMessage: systemMessage,
-      toolsJson: toolsJson,
-      messagesJson: messagesJson,
-      temperature: temperature,
-      topK: topK,
-      topP: topP,
-      seed: seed,
-      maxOutputTokens: maxOutputTokens,
-    );
-    gemmaLog('[LiteRtLmFfi] Conversation created');
-    final handle = LiteRtLmConversationHandle._(this, conv);
-    _handles.add(handle);
-    return handle;
+  }) {
+    // The handle must be registered before the guard lifts: otherwise shutdown()
+    // can clear _handles between the create and the add, leaving a live
+    // conversation on a deleted engine that nothing will ever close.
+    return _guardCreate(() async {
+      final conv = await _createRawConversation(
+        systemMessage: systemMessage,
+        toolsJson: toolsJson,
+        messagesJson: messagesJson,
+        temperature: temperature,
+        topK: topK,
+        topP: topP,
+        seed: seed,
+        maxOutputTokens: maxOutputTokens,
+      );
+      gemmaLog('[LiteRtLmFfi] Conversation created');
+      final handle = LiteRtLmConversationHandle._(this, conv);
+      _handles.add(handle);
+      return handle;
+    });
   }
 
   /// Create a raw native conversation pointer with the given config.
@@ -869,14 +901,29 @@ class LiteRtLmFfiClient {
       );
     }
 
-    final conv = Pointer<LiteRtLmConversation>.fromAddress(
-      await _createConversationOffMainIsolate(
-        engineAddr: _engine!.address,
-        configAddr: convConfig.address,
-      ),
-    );
+    final Pointer<LiteRtLmConversation> conv;
+    try {
+      conv = Pointer<LiteRtLmConversation>.fromAddress(
+        await _createConversationOffMainIsolate(
+          engineAddr: _engine!.address,
+          configAddr: convConfig.address,
+        ),
+      );
 
-    b.litert_lm_conversation_config_delete(convConfig);
+      // The await above yielded the event loop for the whole native round trip.
+      // _guardCreate keeps shutdown() from deleting the engine meanwhile, but a
+      // shutdown may now be queued behind us — in which case this conversation
+      // must not escape. The engine is still alive here, so deleting is safe.
+      if (_isShuttingDown || _engine == null) {
+        if (conv != nullptr) _deleteConversation(conv);
+        throw StateError('Client shut down while creating a conversation');
+      }
+    } finally {
+      // Isolate.run can throw (isolate spawn failure under memory pressure,
+      // dlopen/lookupFunction failure in the fresh isolate). Without this the
+      // config leaks on that path.
+      b.litert_lm_conversation_config_delete(convConfig);
+    }
 
     if (conv == nullptr) {
       _dumpNativeLog();
@@ -899,7 +946,7 @@ class LiteRtLmFfiClient {
     int seed = 1,
   }) async {
     _legacyHandle?.close();
-    _legacyHandle = await createConversationHandle(
+    final handle = await createConversationHandle(
       systemMessage: systemMessage,
       toolsJson: toolsJson,
       temperature: temperature,
@@ -907,6 +954,13 @@ class LiteRtLmFfiClient {
       topP: topP,
       seed: seed,
     );
+    // A shutdown that landed while we were suspended already closed this handle
+    // (it was registered in _handles inside the guard). Publishing it would
+    // leave a closed conversation reachable on a torn-down client.
+    if (handle.isClosed) {
+      throw StateError('Client shut down while creating a conversation');
+    }
+    _legacyHandle = handle;
   }
 
   /// Build the JSON message for the Conversation API.
@@ -1147,17 +1201,24 @@ class LiteRtLmFfiClient {
           final historyJson = history.isEmpty
               ? null
               : buildHistoryJson(history);
-          _virtualConv = await _createRawConversation(
-            systemMessage: systemMessage,
-            toolsJson: toolsJson,
-            messagesJson: historyJson,
-            temperature: temperature,
-            topK: topK,
-            topP: topP,
-            seed: seed,
-            maxOutputTokens: maxOutputTokens,
-          );
-          _virtualActiveToken = conversationToken;
+          // Both fields are published inside the guard body: assigning them in
+          // the await's continuation would let shutdown() delete the engine
+          // first, leaving _virtualConv pointing at a conversation whose engine
+          // is gone — which releaseAndCleanup() would then try to delete.
+          await _guardCreate(() async {
+            final conv = await _createRawConversation(
+              systemMessage: systemMessage,
+              toolsJson: toolsJson,
+              messagesJson: historyJson,
+              temperature: temperature,
+              topK: topK,
+              topP: topP,
+              seed: seed,
+              maxOutputTokens: maxOutputTokens,
+            );
+            _virtualConv = conv;
+            _virtualActiveToken = conversationToken;
+          });
         }
         inner =
             _doSendMessageStreamRawOn(
@@ -1456,7 +1517,23 @@ class LiteRtLmFfiClient {
 
   /// Shutdown the engine and release all resources. Closes every live
   /// conversation handle first (legacy + any opened directly).
-  void shutdown() {
+  ///
+  /// Waits for any conversation create suspended inside [_guardCreate]. Since
+  /// `litert_lm_conversation_create` runs on a spawned isolate, deleting the
+  /// engine while one is in flight frees the engine out from under native code
+  /// that is still dereferencing it.
+  ///
+  /// Consequently this never completes if the native create itself hangs. That
+  /// is deliberate — the alternative is tearing down the engine underneath it —
+  /// but it means [FfiInferenceModel.close] inherits the hang. There is no
+  /// timeout escape hatch.
+  Future<void> shutdown() async {
+    _isShuttingDown = true;
+    if (_createsInFlight > 0) {
+      _createsQuiescent ??= Completer<void>();
+      await _createsQuiescent!.future;
+    }
+
     // Copy because close() mutates _handles.
     for (final h in _handles.toList()) {
       h.close();
@@ -1480,6 +1557,7 @@ class LiteRtLmFfiClient {
 
     _isInitialized = false;
     _backend = null;
+    _isShuttingDown = false;
   }
 
   /// Get session metrics from the given conversation including token usage.


### PR DESCRIPTION
## Problem

`LiteRtLmFfiClient._createRawConversation` calls `litert_lm_conversation_create` synchronously on the calling isolate. For multimodal models this compiles the vision encoder's OpenCL kernels via `clBuildProgram`, which takes **~8.7s** on a Redmi Note 13 (Mali GPU, Gemma 4 E2B).

Recent Flutter runs the Dart UI thread on Android's platform thread, so this blocks input dispatch and the OS raises an ANR:

```
ANR ... Input dispatching timed out
(Waited 5000ms for MotionEvent(action=DOWN))
```

Main thread at ANR time, from `dumpsys dropbox --print data_app_anr`. Note `sysTid` equals the pid — this is the Android main thread:

```
"main" prio=5 tid=1 Native  sysTid=30008
  clBuildProgram                                            libOpenCL.so
  tflite::Subgraph::AddNodeWithParameters
  tflite::Subgraph::ReplaceNodeSubsetsWithDelegateKernels
  tflite::Subgraph::ModifyGraphWithDelegate
  LiteRtCompiledModelT::Create
  LiteRtCreateCompiledModel
```

The window sits exactly where an app shows its "loading model" spinner, so users tap into it. Two ANRs were recorded organically on my device before I started investigating.

## Fix

Move the native call onto a spawned isolate, mirroring what `litert_lm_engine_create` already does a few lines up. Native pointers are process-wide, so the conversation can be built on any isolate and used from the caller — same `Isolate.run` + `Pointer.fromAddress` pattern.

Only the expensive native call moves. Config setup, the `calloc` allocations, and the frees all stay on the calling isolate.

The platform library-open logic is lifted into a top-level `_openLiteRtLmLibrary()` so both the engine and conversation paths share it (a spawned isolate can't capture `this`).

There's precedent in this repo: `0.16.4` fixed *"embedding freezing the UI thread (#299): forward pass runs on a background isolate."* Same bug class.

## API change

`_createRawConversation`, `createConversationHandle` and the legacy `createConversation` become async. Both internal call sites were already in async contexts (`FfiInferenceModel.createSession`, and the virtual-turn multiplexer's `controller.onListen = () async`), so the ripple is contained.

`createConversationHandle` and `createConversation` are public, so this is technically breaking for direct FFI-client users. Happy to reshape as additive `…Async` variants if you'd prefer to keep the sync signatures.

## What I verified, and what I didn't

Verified:
- `dart analyze lib` — no new issues (5 pre-existing infos untouched)
- `flutter test` — 31/31 pass
- The ANR reproduces on a Redmi Note 13 (Android 15, Gemma 4 E2B, GPU backend) by tapping during conversation create. Confirmed via `dumpsys activity exit-info` (`reason=6 (ANR)`) and the main-thread trace above.

**Not verified:** that this patch removes the ANR on-device. My test phone rejects `adb shell input` with `SecurityException: requires INJECT_EVENTS` unless MIUI's "USB debugging (Security settings)" is enabled, which that ROM won't grant. `sendevent` is blocked by SELinux and `monkey` uses the same injection path, so I could not script taps into the ~8.7s window under both builds. I'm flagging this rather than leaving an untested claim in the PR body — an earlier revision of this description asserted a device-level verification that had not actually happened.

The reasoning is straightforward (the blocking call leaves the platform thread, and `createSession` wall time is unchanged at ~8.7s), but if you have a device where input injection works, that's the check worth running.

Also note this moves the work off the main thread; it does not make it faster. The shader program cache doesn't help either — a warm-cache relaunch still took 8056ms.