### PR TITLE
fix(core): FunctionGemma ToolChoice.required warning + template-faithful tool responses (#367)

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Parse a bare `None` argument as null instead of the string `"None"` (#366).
 - Refuse a FunctionGemma call whose body cannot be parsed in full (#366).
 - Warn instead of silently ignoring `ToolChoice.required` on FunctionGemma (#367).
+- Send FunctionGemma tool results as the template does, not as `result:{json}` (#367).
+- Stop opening a second model turn after a FunctionGemma tool response (#367).
 
 ## 1.2.2
 - Fix AGP 9 build on `android.builtInKotlin=false` — apply KGP unless built-in Kotlin is on, so the plugin's Kotlin compiles (#360).

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Render numbers, booleans and `None` the way the template's Python does (#367).
 - Parse a bare `None` argument as null instead of the string `"None"` (#366).
 - Refuse a FunctionGemma call whose body cannot be parsed in full (#366).
+- Warn instead of silently ignoring `ToolChoice.required` on FunctionGemma (#367).
 
 ## 1.2.2
 - Fix AGP 9 build on `android.builtInKotlin=false` — apply KGP unless built-in Kotlin is on, so the plugin's Kotlin compiles (#360).

--- a/packages/flutter_gemma/lib/core/chat.dart
+++ b/packages/flutter_gemma/lib/core/chat.dart
@@ -808,87 +808,11 @@ class InferenceChat {
     'nullable',
   };
 
-  /// Python's `str.lower()`, which Jinja's `dictsort` folds keys with. Dart maps
-  /// `İ` (U+0130) to a plain `i`; Python appends a combining dot, which sorts
-  /// after it.
-  String _pythonFold(String key) => key.replaceAll('İ', 'i̇').toLowerCase();
-
-  /// Jinja's `dictsort`, which defaults to `case_sensitive=False`. A plain
-  /// `.sort()` would put `Beta` before `alpha`; the template does the reverse.
-  ///
-  /// Jinja's sort is stable, Dart's `List.sort` is not (it drops to an unstable
-  /// quicksort past 32 elements), so ties like `Foo`/`foo` are broken by
-  /// insertion order explicitly.
-  List<String> _dictsort(Iterable<String> keys) {
-    final indexed = keys.toList().indexed.toList();
-    indexed.sort((a, b) {
-      final byKey = _pythonFold(a.$2).compareTo(_pythonFold(b.$2));
-      return byKey != 0 ? byKey : a.$1.compareTo(b.$1);
-    });
-    return [for (final entry in indexed) entry.$2];
-  }
-
-  /// Jinja renders a bare `{{ value }}` through Python's `str()`, so booleans
-  /// capitalise, `null` becomes `None`, and floats follow Python's notation.
-  String _pythonScalar(dynamic value) {
-    if (value is bool) return value ? 'True' : 'False';
-    if (value is double) return _pythonDouble(value);
-    if (value == null) return 'None';
-    return '$value';
-  }
-
-  /// The template's `format_argument` macro: strings are escape-wrapped,
-  /// booleans and numbers stay bare, lists and maps recurse.
-  String _formatFunctionGemmaArgument(dynamic value, {bool escapeKeys = true}) {
-    if (value is String) {
-      return '$functionGemmaEscape$value$functionGemmaEscape';
-    }
-    if (value is bool) return value ? 'true' : 'false';
-    if (value is List) {
-      final items = value.map(
-        (v) => _formatFunctionGemmaArgument(v, escapeKeys: escapeKeys),
-      );
-      return '[${items.join(',')}]';
-    }
-    if (value is Map) {
-      final entries = _dictsort(value.keys.map((k) => '$k')).map((key) {
-        final renderedKey = escapeKeys
-            ? '$functionGemmaEscape$key$functionGemmaEscape'
-            : key;
-        final rendered = _formatFunctionGemmaArgument(
-          value[key],
-          escapeKeys: escapeKeys,
-        );
-        return '$renderedKey:$rendered';
-      });
-      return '{${entries.join(',')}}';
-    }
-    // Numbers and `None` fall through the macro's `{{ value }}` branch.
-    return _pythonScalar(value);
-  }
-
-  /// Python's `str(float)`. The template is Jinja, so every number in the prompt
-  /// was formatted by Python. Both languages print the shortest round-trip
-  /// digits, but they switch to exponent notation at different magnitudes:
-  /// Python below `1e-4` and from `1e16`, Dart below `1e-6` and from `1e21`.
-  String _pythonDouble(double value) {
-    if (value.isNaN) return 'nan';
-    if (value.isInfinite) return value.isNegative ? '-inf' : 'inf';
-
-    final magnitude = value.abs();
-    if (magnitude == 0 || (magnitude >= 1e-4 && magnitude < 1e16)) {
-      return value.toString();
-    }
-
-    // Dart writes `1e-5`, Python pads the exponent to two digits: `1e-05`.
-    final exponential = value.toStringAsExponential();
-    final parts = RegExp(r'^(.*)e([+-])(\d+)$').firstMatch(exponential);
-    if (parts == null) return exponential;
-    return '${parts.group(1)}e${parts.group(2)}${parts.group(3)!.padLeft(2, '0')}';
-  }
-
   String _formatFunctionGemmaRequired(List<dynamic> required) => required
-      .map((r) => '$functionGemmaEscape${_pythonScalar(r)}$functionGemmaEscape')
+      .map(
+        (r) =>
+            '$functionGemmaEscape${functionGemmaScalar(r)}$functionGemmaEscape',
+      )
       .join(',');
 
   /// The declaration must name one concrete type per property. `properties` and
@@ -915,13 +839,13 @@ class InferenceChat {
   ) {
     final entries = <String>[];
 
-    // NOT `_dictsort`: the template sorts, but a tool's properties reach the
-    // model in the order the app declared them, and every model fine-tuned
-    // before 1.2.3 — including via our own colab — learned that order. On the
-    // base model, sorting changed nothing measurable (device A/B on 12 prompts:
-    // same hits, same misses). Fidelity to the template is not worth breaking
-    // existing fine-tunes. `items` keys and map arguments still dictsort: they
-    // are new in 1.2.3 and no prompt ever depended on them.
+    // NOT `functionGemmaDictsort`: the template sorts, but a tool's properties
+    // reach the model in the order the app declared them, and every model
+    // fine-tuned before 1.2.3 — including via our own colab — learned that
+    // order. On the base model, sorting changed nothing measurable (device A/B
+    // on 12 prompts: same hits, same misses). Fidelity to the template is not
+    // worth breaking existing fine-tunes. `items` keys and map arguments still
+    // dictsort: they are new in 1.2.3 and no prompt ever depended on them.
     for (final name in properties.keys) {
       if (_functionGemmaStructuralKeys.contains(name)) continue;
       final schema = properties[name];
@@ -952,7 +876,7 @@ class InferenceChat {
       final property = StringBuffer(
         '$name:{description:$functionGemmaEscape'
         // An explicit null renders empty here, not as Python's `None`.
-        '${description == null ? '' : _pythonScalar(description)}'
+        '${description == null ? '' : functionGemmaScalar(description)}'
         '$functionGemmaEscape',
       );
 
@@ -966,7 +890,7 @@ class InferenceChat {
       switch (type) {
         case 'STRING':
           if (enumValues != null && enumValues.isNotEmpty) {
-            property.write(',enum:${_formatFunctionGemmaArgument(enumValues)}');
+            property.write(',enum:${functionGemmaArgument(enumValues)}');
           }
         case 'OBJECT':
           final nested = schema['properties'];
@@ -1003,7 +927,7 @@ class InferenceChat {
   ) {
     final parts = <String>[];
 
-    for (final key in _dictsort(items.keys)) {
+    for (final key in functionGemmaDictsort(items.keys)) {
       final value = items[key];
       if (value == null) continue;
 
@@ -1025,9 +949,9 @@ class InferenceChat {
           final upper = value is List
               ? value.map((v) => '$v'.toUpperCase()).toList()
               : '$value'.toUpperCase();
-          parts.add('type:${_formatFunctionGemmaArgument(upper)}');
+          parts.add('type:${functionGemmaArgument(upper)}');
         default:
-          parts.add('$key:${_formatFunctionGemmaArgument(value)}');
+          parts.add('$key:${functionGemmaArgument(value)}');
       }
     }
 

--- a/packages/flutter_gemma/lib/core/chat.dart
+++ b/packages/flutter_gemma/lib/core/chat.dart
@@ -736,6 +736,17 @@ class InferenceChat {
   }
 
   String _createFunctionGemmaToolsPrompt() {
+    if (toolChoice == ToolChoice.required) {
+      // The model's chat_template renders a developer turn of declarations plus
+      // an optional system text. Nothing in the format expresses "you must call
+      // a function", so honouring `required` would mean inventing tokens the
+      // model was never trained on. Say so rather than ignore it.
+      gemmaLog(
+        'WARNING: ToolChoice.required is not supported by FunctionGemma — its '
+        'prompt format cannot express it. Behaving as ToolChoice.auto.',
+      );
+    }
+
     final toolsPrompt = StringBuffer();
 
     // FunctionGemma requires developer turn for tools definition

--- a/packages/flutter_gemma/lib/core/extensions.dart
+++ b/packages/flutter_gemma/lib/core/extensions.dart
@@ -1,8 +1,14 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
-import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma/core/message.dart';
 import 'package:flutter_gemma/core/model.dart';
 import 'package:flutter_gemma/core/model_response.dart';
+import 'package:flutter_gemma/core/parsing/function_gemma_wire.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
+
+// The FunctionGemma tokens live with the wire format they belong to.
+export 'package:flutter_gemma/core/parsing/function_gemma_wire.dart';
 
 const userPrefix = "user";
 const modelPrefix = "model";
@@ -26,15 +32,6 @@ const llamaInstEnd = "[/INST]";
 // Hammer tokens (using general format for now - need more research)
 const hammerUser = "User:";
 const hammerAssistant = "Assistant:";
-
-// FunctionGemma special tokens
-const functionGemmaStartCall = '<start_function_call>';
-const functionGemmaEndCall = '<end_function_call>';
-const functionGemmaStartDecl = '<start_function_declaration>';
-const functionGemmaEndDecl = '<end_function_declaration>';
-const functionGemmaStartResp = '<start_function_response>';
-const functionGemmaEndResp = '<end_function_response>';
-const functionGemmaEscape = '<escape>';
 
 /// The three chat-prompt formatting modes the engine-dispatch decision selects.
 ///
@@ -203,11 +200,12 @@ extension MessageExtension on Message {
       return text;
     }
 
-    // Handle tool response - NO user turn, goes directly after function call
-    // Per FunctionGemma docs: <end_function_call><start_function_response>...
+    // A tool response continues the model's own turn: the template renders
+    // call -> response -> answer inside one `<start_of_turn>model`. Opening a
+    // second one nested a header the model never saw. Verified on device: the
+    // engine still generates without it.
     if (type == MessageType.toolResponse) {
-      final content = _formatFunctionGemmaContent();
-      return '$content\n$startTurn$modelPrefix\n';
+      return _formatFunctionGemmaContent();
     }
 
     if (isUser) {
@@ -218,10 +216,18 @@ extension MessageExtension on Message {
   }
 
   String _formatFunctionGemmaContent() {
-    // Format tool response in FunctionGemma format
     if (type == MessageType.toolResponse && toolName != null) {
+      // The template splays the response map into its own dictsorted
+      // `key:value` pairs. The old `result:<escape>{json}<escape>` wrapper was
+      // invented here: that key appears nowhere in the model's chat_template.
+      Object? response;
+      try {
+        response = jsonDecode(text);
+      } on FormatException {
+        response = text;
+      }
       return '$functionGemmaStartResp'
-          'response:$toolName{result:$functionGemmaEscape$text$functionGemmaEscape}'
+          'response:$toolName{${functionGemmaResponseBody(response)}}'
           '$functionGemmaEndResp';
     }
     return text;

--- a/packages/flutter_gemma/lib/core/parsing/function_gemma_wire.dart
+++ b/packages/flutter_gemma/lib/core/parsing/function_gemma_wire.dart
@@ -1,0 +1,113 @@
+/// FunctionGemma's wire format, in one place.
+///
+/// Both halves of the protocol live here: the tokens, and the `format_argument`
+/// macro of the model's own `chat_template.jinja`. Declarations (`chat.dart`)
+/// and tool responses (`extensions.dart`) both render through it, so the two
+/// cannot drift apart the way the encoder and decoder once did.
+library;
+
+// FunctionGemma special tokens
+const functionGemmaStartCall = '<start_function_call>';
+const functionGemmaEndCall = '<end_function_call>';
+const functionGemmaStartDecl = '<start_function_declaration>';
+const functionGemmaEndDecl = '<end_function_declaration>';
+const functionGemmaStartResp = '<start_function_response>';
+const functionGemmaEndResp = '<end_function_response>';
+const functionGemmaEscape = '<escape>';
+
+/// Python's `str.lower()`, which Jinja's `dictsort` folds keys with. Dart maps
+/// `İ` (U+0130) to a plain `i`; Python appends a combining dot, which sorts
+/// after it.
+String functionGemmaFold(String key) => key.replaceAll('İ', 'i̇').toLowerCase();
+
+/// Jinja's `dictsort`, which defaults to `case_sensitive=False`. A plain
+/// `.sort()` would put `Beta` before `alpha`; the template does the reverse.
+///
+/// Jinja's sort is stable, Dart's `List.sort` is not (it drops to an unstable
+/// quicksort past 32 elements), so ties like `Foo`/`foo` are broken by
+/// insertion order explicitly.
+List<String> functionGemmaDictsort(Iterable<String> keys) {
+  final indexed = keys.toList().indexed.toList();
+  indexed.sort((a, b) {
+    final byKey = functionGemmaFold(a.$2).compareTo(functionGemmaFold(b.$2));
+    return byKey != 0 ? byKey : a.$1.compareTo(b.$1);
+  });
+  return [for (final entry in indexed) entry.$2];
+}
+
+/// Python's `str(float)`. The template is Jinja, so every number in the prompt
+/// was formatted by Python. Both languages print the shortest round-trip
+/// digits, but they switch to exponent notation at different magnitudes:
+/// Python below `1e-4` and from `1e16`, Dart below `1e-6` and from `1e21`.
+String functionGemmaDouble(double value) {
+  if (value.isNaN) return 'nan';
+  if (value.isInfinite) return value.isNegative ? '-inf' : 'inf';
+
+  final magnitude = value.abs();
+  if (magnitude == 0 || (magnitude >= 1e-4 && magnitude < 1e16)) {
+    return value.toString();
+  }
+
+  // Dart writes `1e-5`, Python pads the exponent to two digits: `1e-05`.
+  final exponential = value.toStringAsExponential();
+  final parts = RegExp(r'^(.*)e([+-])(\d+)$').firstMatch(exponential);
+  if (parts == null) return exponential;
+  return '${parts.group(1)}e${parts.group(2)}${parts.group(3)!.padLeft(2, '0')}';
+}
+
+/// Jinja renders a bare `{{ value }}` through Python's `str()`, so booleans
+/// capitalise, `null` becomes `None`, and floats follow Python's notation.
+String functionGemmaScalar(dynamic value) {
+  if (value is bool) return value ? 'True' : 'False';
+  if (value is double) return functionGemmaDouble(value);
+  if (value == null) return 'None';
+  return '$value';
+}
+
+/// The template's `format_argument` macro: strings are escape-wrapped,
+/// booleans and numbers stay bare, lists and maps recurse.
+String functionGemmaArgument(dynamic value, {bool escapeKeys = true}) {
+  if (value is String) {
+    return '$functionGemmaEscape$value$functionGemmaEscape';
+  }
+  if (value is bool) return value ? 'true' : 'false';
+  if (value is List) {
+    final items = value.map(
+      (v) => functionGemmaArgument(v, escapeKeys: escapeKeys),
+    );
+    return '[${items.join(',')}]';
+  }
+  if (value is Map) {
+    final entries = functionGemmaDictsort(value.keys.map((k) => '$k')).map((
+      key,
+    ) {
+      final renderedKey = escapeKeys
+          ? '$functionGemmaEscape$key$functionGemmaEscape'
+          : key;
+      final rendered = functionGemmaArgument(
+        value[key],
+        escapeKeys: escapeKeys,
+      );
+      return '$renderedKey:$rendered';
+    });
+    return '{${entries.join(',')}}';
+  }
+  // Numbers and `None` fall through the macro's `{{ value }}` branch.
+  return functionGemmaScalar(value);
+}
+
+/// The body of `response:NAME{...}`.
+///
+/// The template splays a map response into its own dictsorted `key:value`
+/// pairs — bare keys, values through `format_argument` — and falls back to a
+/// single `value:` key for a scalar. It never wraps the result in a JSON blob.
+String functionGemmaResponseBody(Object? response) {
+  if (response is Map) {
+    final entries = functionGemmaDictsort(response.keys.map((k) => '$k')).map(
+      (key) =>
+          '$key:${functionGemmaArgument(response[key], escapeKeys: false)}',
+    );
+    return entries.join(',');
+  }
+  return 'value:${functionGemmaArgument(response, escapeKeys: false)}';
+}

--- a/packages/flutter_gemma/lib/core/tool.dart
+++ b/packages/flutter_gemma/lib/core/tool.dart
@@ -16,6 +16,9 @@ enum ToolChoice {
   auto,
 
   /// Model must respond with a function call.
+  ///
+  /// Not supported by [ModelType.functionGemma]: its prompt format has no way
+  /// to express the constraint, so it behaves as [auto] and logs a warning.
   required,
 
   /// Model must NOT call any tools, even if tools are provided.

--- a/packages/flutter_gemma/lib/core/tool.dart
+++ b/packages/flutter_gemma/lib/core/tool.dart
@@ -17,7 +17,7 @@ enum ToolChoice {
 
   /// Model must respond with a function call.
   ///
-  /// Not supported by [ModelType.functionGemma]: its prompt format has no way
+  /// Not supported by FunctionGemma: its prompt format has no way
   /// to express the constraint, so it behaves as [auto] and logs a warning.
   required,
 

--- a/packages/flutter_gemma/test/core/chat_prompt_test.dart
+++ b/packages/flutter_gemma/test/core/chat_prompt_test.dart
@@ -803,6 +803,36 @@ void main() {
       expect(prompt, isNot(contains('additionalProperties')));
     });
 
+    test('ToolChoice.required is a no-op, and stays one', () {
+      // The template's developer turn carries declarations and an optional
+      // system text — there is no slot for "you must call a function". The
+      // encoder logs this instead of pretending to honour it.
+      String promptFor(ToolChoice choice) => InferenceChat(
+        sessionCreator: null,
+        maxTokens: 1024,
+        modelType: ModelType.functionGemma,
+        supportsFunctionCalls: true,
+        toolChoice: choice,
+        tools: [
+          const Tool(
+            name: 't',
+            description: 'd',
+            parameters: {
+              'type': 'object',
+              'properties': {
+                'x': {'type': 'string', 'description': 'x'},
+              },
+            },
+          ),
+        ],
+      ).createToolsPrompt();
+
+      expect(
+        promptFor(ToolChoice.required),
+        equals(promptFor(ToolChoice.auto)),
+      );
+    });
+
     test('a non-map property schema is skipped, not rendered degenerate', () {
       final prompt = promptForParameters({
         'type': 'object',

--- a/packages/flutter_gemma/test/core/function_gemma_tool_response_test.dart
+++ b/packages/flutter_gemma/test/core/function_gemma_tool_response_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_gemma/core/extensions.dart';
+import 'package:flutter_gemma/core/message.dart';
+import 'package:flutter_gemma/core/model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The tool result is the only thing the model reads to answer. Golden strings
+/// below are rendered by FunctionGemma's own `chat_template.jinja`: it splays a
+/// dict response into dictsorted `key:value` pairs through `format_argument`,
+/// so numbers and booleans stay bare and only strings are escape-wrapped.
+///
+/// The template ships with the model; an ungated copy lives at
+/// huggingface.co/onnx-community/functiongemma-270m-it-ONNX.
+void main() {
+  String render(Map<String, dynamic> response) =>
+      Message.toolResponse(
+        toolName: 'get_weather',
+        response: response,
+      ).transformToChatPrompt(
+        type: ModelType.functionGemma,
+        fileType: ModelFileType.task,
+      );
+
+  group('FunctionGemma tool response', () {
+    test('splays a dict into bare keys, not a JSON blob under `result`', () {
+      expect(
+        render({'status': 'ok', 'count': 2}),
+        startsWith(
+          '<start_function_response>response:get_weather'
+          '{count:2,status:<escape>ok<escape>}<end_function_response>',
+        ),
+      );
+    });
+
+    test('keeps booleans, doubles and lists in their own types', () {
+      expect(
+        render({
+          'ok': true,
+          'ratio': 0.5,
+          'items': ['a', 'b'],
+        }),
+        contains(
+          '{items:[<escape>a<escape>,<escape>b<escape>],ok:true,ratio:0.5}',
+        ),
+      );
+    });
+
+    test('a single `value` key renders as the template\'s scalar form', () {
+      expect(
+        render({'value': 'sunny'}),
+        contains('{value:<escape>sunny<escape>}'),
+      );
+    });
+
+    test('never emits the invented `result` key', () {
+      expect(render({'status': 'ok'}), isNot(contains('result:')));
+    });
+
+    test('continues the model turn instead of opening a new one', () {
+      // The template renders call -> response -> answer inside one
+      // `<start_of_turn>model`. Appending another header nested a turn the model
+      // never saw. Verified on device: generation still fires without it.
+      expect(
+        render({'status': 'ok'}),
+        equals(
+          '<start_function_response>response:get_weather'
+          '{status:<escape>ok<escape>}<end_function_response>',
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Two FunctionGemma fixes found while reviewing #369, held back from it because they needed more than a byte-level check. Both verified on an Android emulator against the real 270M model.

### `ToolChoice.required` is a silent no-op

The model's developer turn is a list of declarations plus an optional system text. Nothing in the format says "you must call a function", so `required` has always behaved as `auto` — quietly. Honouring it would mean inventing tokens the model never saw. It now logs the downgrade, the enum documents it, and a test pins the no-op so it cannot regress into a fake instruction.

### Tool results were sent in a shape the model never saw

The tool result is the only thing the model reads to answer, and we fed it two things that appear nowhere in its `chat_template` — or in the fine-tuning colab, whose examples stop at the call:

- **Body.** We sent `result:<escape>{"status":"ok"}<escape>` — the `result` key was invented in `3bb2186d`. The template splays the response map into its own dictsorted `key:value` pairs, so numbers and booleans stay bare and only strings are escape-wrapped.
- **Turn.** The response opened a second `<start_of_turn>model`. The template renders call, response and answer inside one model turn.

**Device check:** on the 270M model both the old and new body produce the same output (it repeats the call — the colab never trains a continuation after a tool result), and generation still fires without the extra turn header. So this is byte-correctness with no behavioural regression, not a behaviour change.

Rendering the response needs `format_argument`, which lived privately in `chat.dart`. It moves, with the wire tokens, into `core/parsing/function_gemma_wire.dart`, so both halves of the protocol sit together — the split is what let the encoder and decoder drift in the first place. Re-verified against the template on 584 schemas: byte-identical, so the move changed nothing.

`1.2.3` is not published yet, so the CHANGELOG entries are added in place.
