### PR TITLE
fix(litertlm): serialize native conversation create on the engine mutex (follow-up to #365)

### DIFF
--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -776,15 +776,25 @@ class LiteRtLmFfiClient {
     // can clear _handles between the create and the add, leaving a live
     // conversation on a deleted engine that nothing will ever close.
     return _guardCreate(() async {
-      final conv = await _createRawConversation(
-        systemMessage: systemMessage,
-        toolsJson: toolsJson,
-        messagesJson: messagesJson,
-        temperature: temperature,
-        topK: topK,
-        topP: topP,
-        seed: seed,
-        maxOutputTokens: maxOutputTokens,
+      // Serialize the native create against generation and any other create on
+      // this engine. The engine is non-reentrant and holds one live
+      // conversation at a time (#966); the virtual path and generation already
+      // hold _nativeMutex, but this path did not — and once the create runs on
+      // a spawned isolate it can race them on the shared engine pointer.
+      // `protect` releases on every path (_createRawConversation can throw).
+      // Only the native create is guarded; handle registration below is
+      // pure-Dart bookkeeping and must stay inside _guardCreate, not the mutex.
+      final conv = await _nativeMutex.protect(
+        () => _createRawConversation(
+          systemMessage: systemMessage,
+          toolsJson: toolsJson,
+          messagesJson: messagesJson,
+          temperature: temperature,
+          topK: topK,
+          topP: topP,
+          seed: seed,
+          maxOutputTokens: maxOutputTokens,
+        ),
       );
       gemmaLog('[LiteRtLmFfi] Conversation created');
       final handle = LiteRtLmConversationHandle._(this, conv);
@@ -1219,6 +1229,12 @@ class LiteRtLmFfiClient {
             _virtualConv = conv;
             _virtualActiveToken = conversationToken;
           });
+        }
+        // _guardCreate above yields the event loop, so a shutdown() queued
+        // behind us can delete _virtualConv before we get here. Surface it as a
+        // clean "closed" error instead of a Null-check-operator crash.
+        if (_isShuttingDown || _virtualConv == null) {
+          throw StateError('Client is shutting down; conversation was closed');
         }
         inner =
             _doSendMessageStreamRawOn(


### PR DESCRIPTION
Follow-up to #365. Reviewing that PR surfaced two defects it introduced by moving conversation create onto a spawned isolate — held back so #365 could land on its own.

### 1. Two native `conversation_create` can run on one engine at once (medium)

`createConversationHandle` → `_createRawConversation` now runs the native create on a spawned isolate, but does **not** hold `_nativeMutex`. The virtual-session path and generation both do. The engine is non-reentrant and holds one live conversation (#966), so a create racing a generation — or another create — on the shared engine pointer can corrupt the heap.

Wrap only the native create in `_nativeMutex.protect()` inside `createConversationHandle` (the same lock generation and the virtual path already use). Handle registration stays inside `_guardCreate`, outside the mutex.

The mutex is deliberately **not** moved into `_createRawConversation`: the virtual path already holds `_nativeMutex` and calls that method directly, so re-acquiring the non-reentrant `package:mutex` there would self-deadlock. Only the one unguarded caller (`createConversationHandle`, and the legacy `createConversation` that goes through it) is changed; the virtual path is untouched.

### 2. Null-check crash in `startVirtualTurn` on a racing shutdown (minor)

`startVirtualTurn` read `_virtualConv!` after an awaited `_guardCreate`. A `shutdown()` queued in that window deletes `_virtualConv`, so the `!` crashed with a Null-check-operator error (memory-safe — it was caught and cleaned up, but the message was wrong). Re-check `_isShuttingDown`/null after the guard and throw a clean `StateError`.

### Verification

- 31 package unit tests + analyze green.
- **Firebase Test Lab**, Pixel 8a / Android 34, `litertlm_ffi_test` (the LiteRT-LM FFI smoke, incl. the `Multi-session` group with two `openSession` dialogues on one engine) against gemma-4-E2B — **23/23 test cases passed**. The mutex and the null-recheck do not regress real inference, multi-session or generation on device.
- Deadlock-freedom of the mutex placement independently reviewed: `_guardCreate` is a counter, not a mutual-exclusion lock, so the guard/mutex ordering difference between the two create paths cannot form a cycle; the only self-deadlock risk (mutex inside `_createRawConversation`) is avoided.
