### PR TITLE
fix(macos): re-run companion staging when embed re-copies LiteRtLm (#368)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,3 +110,59 @@ jobs:
         working-directory: packages/flutter_gemma/example
         run: flutter build ios --release --no-codesign
         continue-on-error: true
+
+  build-example-macos:
+    runs-on: macos-latest
+    needs: analyze-and-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install plugin dependencies
+        working-directory: packages/flutter_gemma
+        run: flutter pub get
+
+      - name: Install example dependencies
+        working-directory: packages/flutter_gemma/example
+        run: flutter pub get
+
+      # Build twice: the macOS companion-dylib staging is patched by a
+      # CocoaPods build phase that the always-out-of-date Flutter embed phase
+      # clobbers. A single build masks the bug (the phase runs last on a clean
+      # build); the second incremental build is where a stale-stamped phase
+      # would ship an unpatched LiteRtLm (#368). Both must leave the embedded
+      # binary referencing the framework-form companion, not the raw dylib.
+      - name: Build example macOS (clean)
+        working-directory: packages/flutter_gemma/example
+        run: flutter build macos --debug
+
+      - name: Build example macOS (incremental)
+        working-directory: packages/flutter_gemma/example
+        run: flutter build macos --debug
+
+      - name: Assert LiteRtLm links the framework-form companion, not the raw dylib
+        working-directory: packages/flutter_gemma/example
+        run: |
+          LITERTLM="build/macos/Build/Products/Debug/flutter_gemma_example.app/Contents/Frameworks/LiteRtLm.framework/Versions/A/LiteRtLm"
+          if [ ! -f "$LITERTLM" ]; then
+            echo "::error::LiteRtLm binary not found at $LITERTLM"
+            exit 1
+          fi
+          DEPS="$(otool -L "$LITERTLM")"
+          echo "$DEPS" | grep -i GemmaModelConstraint || true
+          if echo "$DEPS" | grep -q "@rpath/libGemmaModelConstraintProvider.dylib"; then
+            echo "::error::#368 regression — LiteRtLm still references the raw dylib after the incremental build; the Setup phase did not re-apply the install_name patch."
+            exit 1
+          fi
+          if ! echo "$DEPS" | grep -q "GemmaModelConstraintProvider.framework"; then
+            echo "::error::LiteRtLm does not reference the framework-form companion; staging did not run."
+            exit 1
+          fi
+          echo "OK: LiteRtLm references the framework-form GemmaModelConstraintProvider."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,13 +139,24 @@ jobs:
       # build); the second incremental build is where a stale-stamped phase
       # would ship an unpatched LiteRtLm (#368). Both must leave the embedded
       # binary referencing the framework-form companion, not the raw dylib.
+      # CI has no signing identity; disable Xcode code-signing via the
+      # FLUTTER_XCODE_* passthrough. The staging phase re-signs the patched
+      # binary ad-hoc (`codesign --sign -`) itself, so this doesn't affect it.
       - name: Build example macOS (clean)
         working-directory: packages/flutter_gemma/example
         run: flutter build macos --debug
+        env:
+          FLUTTER_XCODE_CODE_SIGNING_ALLOWED: 'NO'
+          FLUTTER_XCODE_CODE_SIGNING_REQUIRED: 'NO'
+          FLUTTER_XCODE_CODE_SIGN_IDENTITY: ''
 
       - name: Build example macOS (incremental)
         working-directory: packages/flutter_gemma/example
         run: flutter build macos --debug
+        env:
+          FLUTTER_XCODE_CODE_SIGNING_ALLOWED: 'NO'
+          FLUTTER_XCODE_CODE_SIGNING_REQUIRED: 'NO'
+          FLUTTER_XCODE_CODE_SIGN_IDENTITY: ''
 
       - name: Assert LiteRtLm links the framework-form companion, not the raw dylib
         working-directory: packages/flutter_gemma/example

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.2.3
 - Cancel native `.litertlm` decoding before session teardown to avoid an ANR (#364, #373).
+- Re-run macOS companion staging on incremental builds so LiteRtLm stays patched (#368).
 - Fix FunctionGemma parser dropping array, number, boolean and object arguments (#366).
 - Fix FunctionGemma streaming truncating a tool call at the first `}` (#366).
 - Fix FunctionGemma tools prompt to match the model's `chat_template` (#367).

--- a/packages/flutter_gemma/example/macos/Podfile
+++ b/packages/flutter_gemma/example/macos/Podfile
@@ -81,6 +81,17 @@ post_install do |installer|
       # dependency graph instead of treating it as "runs every build" with
       # no outputs (the other half of the cycle warning). The script
       # `touch`es this file at the end.
+      #
+      # Declare the embedded LiteRtLm binary as an input so the stamp
+      # invalidates whenever the always-out-of-date Flutter `embed` phase
+      # re-copies the raw, unpatched binary over our patched one. Without an
+      # input the phase is cached after the first build and never re-applies
+      # its install_name patch, so the second incremental build ships an
+      # unpatched LiteRtLm that fails dlopen at runtime — #368, a regression
+      # the #300 cycle fix introduced when it added the output stamp.
+      phase.input_paths = [
+        '$(BUILT_PRODUCTS_DIR)/$(PRODUCT_NAME).app/Contents/Frameworks/LiteRtLm.framework/Versions/A/LiteRtLm',
+      ]
       phase.output_paths = ['$(DERIVED_FILE_DIR)/flutter_gemma_litertlm_macos.stamp']
       phase.shell_script = <<~SHELL
         set -e

--- a/packages/flutter_gemma/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/flutter_gemma/example/macos/Runner.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(PRODUCT_NAME).app/Contents/Frameworks/LiteRtLm.framework/Versions/A/LiteRtLm",
 			);
 			name = "[flutter_gemma] Setup LiteRT-LM macOS";
 			outputFileListPaths = (


### PR DESCRIPTION
Fixes #368 — the macOS example fails at runtime after an incremental build:

```
dlopen(LiteRtLm.framework/LiteRtLm) → Library not loaded: @rpath/libGemmaModelConstraintProvider.dylib
```

## Root cause

A regression from the **0.16.2 cycle fix** (#300, `eeacb725`). The macOS companion dylibs are staged by a CocoaPods `post_install` phase that wraps them into `.framework`s and `install_name_tool -change`s LiteRtLm to the framework form. #300 gave that phase an `output_paths` stamp but **no `input_paths`**, so Xcode caches it as up-to-date after the first build — while the always-out-of-date Flutter `embed` phase re-copies the raw, unpatched LiteRtLm into the bundle **every** build.

Result: the patch is applied once on a clean build and never re-applied. The **second** incremental build ships a raw binary whose companion dependency resolves to a non-existent Bazel `_solib` path.

`git bisect` of the symptom: works in 0.16.1 (phase had no output → ran every build), breaks in 0.16.2 (stamp added). Not the 1.0 split, not the 0.13.1 native bump — confirmed by diffing the Podfile phase and the install_name string across both.

## Fix

Declare the embedded LiteRtLm as an **input** to the phase, so the stamp invalidates whenever `embed` re-copies it. Restores the always-re-patch behaviour of 0.16.1 while keeping the output stamp #300 needs for deterministic ordering (and the cross-target cycle stays fixed — the phase is already Runner-only).

## Verification (on-device macOS)

Controlled experiment — identical clobber (embedded LiteRtLm → raw), rebuild:

| | after clobber + incremental build |
|---|---|
| without fix | embedded stays **raw** → #368 reproduced, Setup skipped |
| with `input_paths` | embedded becomes **framework-form** → re-patched |

Then full runtime through the fix:
- **Inference** (Gemma 3 1B `.litertlm`): dlopen ✓, engine ✓, generation **~65 chunks/sec**, both ffi_test cases pass.
- **Embeddings** (embeddinggemma-300M): dlopen ✓, **768-dim vector**, tests pass.

`otool` after a real `flutter test` rebuild confirms the framework form — not a simulation, an actual build cycle that clobbers and re-patches.

## CI guard

New `build-example-macos` job builds the example **twice** and asserts via `otool` that LiteRtLm references the framework-form companion, not the raw dylib. A single build masks this class of regression (which is why a one-off "Verified on macOS" note in a past bump didn't catch it).

## Scope

This fixes the **example** (the in-repo Podfile). pub.dev consumers get no staging phase at all — a separate, pre-existing gap tracked in **#255** (consumer report) and upstream in **google-ai-edge/LiteRT-LM#2151** (companion dylibs lack `-headerpad_max_install_names`, which is what forces the Podfile workaround instead of iOS-style in-binary resolution). Not in scope here.
