### PR TITLE
fix(litertlm): cancel native decode before tearing a conversation down (#364, #373)

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.2.3
-- Cancel native `.litertlm` decoding before tearing a session down — avoids a multi-second platform-thread stall / ANR while `conversation_delete` drains an abandoned generation (#364, #373).
+- Cancel native `.litertlm` decoding before session teardown to avoid an ANR (#364, #373).
 - Fix FunctionGemma parser dropping array, number, boolean and object arguments (#366).
 - Fix FunctionGemma streaming truncating a tool call at the first `}` (#366).
 - Fix FunctionGemma tools prompt to match the model's `chat_template` (#367).

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.2.3
+- Cancel native `.litertlm` decoding before tearing a session down — avoids a multi-second platform-thread stall / ANR while `conversation_delete` drains an abandoned generation (#364, #373).
 - Fix FunctionGemma parser dropping array, number, boolean and object arguments (#366).
 - Fix FunctionGemma streaming truncating a tool call at the first `}` (#366).
 - Fix FunctionGemma tools prompt to match the model's `chat_template` (#367).

--- a/packages/flutter_gemma/lib/flutter_gemma_interface.dart
+++ b/packages/flutter_gemma/lib/flutter_gemma_interface.dart
@@ -442,12 +442,16 @@ abstract class InferenceModelSession {
 
   /// Streams generated tokens.
   ///
-  /// To stop generating early, either `cancel()` the [StreamSubscription] or
-  /// call [stopGeneration]. On the `.litertlm` FFI path both reach the native
-  /// engine and stop it decoding. Silently *abandoning* the stream (dropping
-  /// the subscription without cancelling, so it is only GC'd) cannot be
-  /// intercepted — the accelerator keeps decoding the whole turn for output no
-  /// one consumes, wasting compute and delaying the next turn's teardown.
+  /// To stop generating early, prefer [stopGeneration] — it reaches the native
+  /// engine and stops it decoding on every engine. `cancel()`ing the
+  /// [StreamSubscription] also stops native decoding on the `.litertlm` FFI
+  /// engine, but on other engines it only detaches the Dart side while native
+  /// keeps decoding, so [stopGeneration] is the portable choice.
+  ///
+  /// Silently *abandoning* the stream (dropping the subscription without
+  /// cancelling, so it is only GC'd) cannot be intercepted on any engine — the
+  /// accelerator keeps decoding the whole turn for output no one consumes,
+  /// wasting compute and delaying the next turn's teardown.
   Stream<String> getResponseAsync();
 
   Future<int> sizeInTokens(String text);

--- a/packages/flutter_gemma/lib/flutter_gemma_interface.dart
+++ b/packages/flutter_gemma/lib/flutter_gemma_interface.dart
@@ -440,12 +440,23 @@ class SessionMetrics {
 abstract class InferenceModelSession {
   Future<String> getResponse();
 
+  /// Streams generated tokens.
+  ///
+  /// To stop generating early, either `cancel()` the [StreamSubscription] or
+  /// call [stopGeneration]. On the `.litertlm` FFI path both reach the native
+  /// engine and stop it decoding. Silently *abandoning* the stream (dropping
+  /// the subscription without cancelling, so it is only GC'd) cannot be
+  /// intercepted — the accelerator keeps decoding the whole turn for output no
+  /// one consumes, wasting compute and delaying the next turn's teardown.
   Stream<String> getResponseAsync();
 
   Future<int> sizeInTokens(String text);
 
   Future<void> addQueryChunk(Message message);
 
+  /// Stops the current generation, cancelling native decoding on the
+  /// `.litertlm` FFI path. Call this (or `cancel()` the response subscription)
+  /// whenever a streamed response is superseded or no longer needed.
   Future<void> stopGeneration();
 
   /// Get session metrics including token usage and performance stats.

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -167,6 +167,14 @@ class LiteRtLmConversationHandle implements ConversationHandle {
   @override
   void close() {
     if (_conversation == null) return;
+    // Cancel any in-flight native decode before deleting: conversation_delete
+    // blocks in ~SessionBasic → ThreadPool::WaitUntilDone until the generation
+    // drains naturally, which under GPU throttle is tens of seconds and ANRs
+    // the platform thread (#364). Cancelling first collapses the drain to
+    // milliseconds. `_cancelOn` is lock-free so it can interrupt a generation
+    // that holds `_nativeMutex`. The virtual-session path already does this in
+    // `releaseVirtualConversation`; this brings the single-session path in line.
+    _client._cancelOn(_conversation!);
     _client._deleteConversation(_conversation!);
     _conversation = null;
     _client._handles.remove(this);
@@ -1173,6 +1181,11 @@ class LiteRtLmFfiClient {
     final controller = StreamController<String>();
     var mutexHeld = false;
     StreamSubscription<String>? inner;
+    // Set by onCancel. If the consumer cancels while onListen is still awaiting
+    // the mutex or the conversation create, `inner` is null so the cancel can't
+    // reach it — and onListen would otherwise resume and start a generation
+    // nobody is listening to. onListen checks this before starting the turn.
+    var cancelledByConsumer = false;
 
     Future<void> releaseAndCleanup() async {
       _virtualTurnInFlight = false;
@@ -1236,6 +1249,14 @@ class LiteRtLmFfiClient {
         if (_isShuttingDown || _virtualConv == null) {
           throw StateError('Client is shutting down; conversation was closed');
         }
+        // A cancel that landed during the mutex wait or the create above left
+        // `inner` null, so it never reached native. Don't start an orphan turn
+        // for a consumer that is already gone — release and close instead.
+        if (cancelledByConsumer) {
+          await releaseAndCleanup();
+          if (!controller.isClosed) await controller.close();
+          return;
+        }
         inner =
             _doSendMessageStreamRawOn(
               _virtualConv!,
@@ -1260,6 +1281,14 @@ class LiteRtLmFfiClient {
     // Fires when the consumer cancels / abandons the stream — guarantees the
     // mutex is released even if generation never completed.
     controller.onCancel = () async {
+      cancelledByConsumer = true;
+      // Cancel the live native turn explicitly. `inner?.cancel()` alone only
+      // reaches native transitively, and only once `inner` exists; a cancel
+      // that arrives during the mutex wait or create would otherwise never stop
+      // the native decode. `cancelVirtualTurn` is lock-free and a no-op unless
+      // this token owns the currently-live conversation, so it is safe here and
+      // safe to double-cancel with `inner.cancel()` (idempotent natively).
+      cancelVirtualTurn(conversationToken);
       await inner?.cancel();
       await releaseAndCleanup();
     };

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -1286,9 +1286,16 @@ class LiteRtLmFfiClient {
       // reaches native transitively, and only once `inner` exists; a cancel
       // that arrives during the mutex wait or create would otherwise never stop
       // the native decode. `cancelVirtualTurn` is lock-free and a no-op unless
-      // this token owns the currently-live conversation, so it is safe here and
-      // safe to double-cancel with `inner.cancel()` (idempotent natively).
-      cancelVirtualTurn(conversationToken);
+      // this token owns the currently-live conversation.
+      //
+      // Guard on `mutexHeld`: onCancel also fires as implicit teardown after a
+      // stream completes normally (Dart delivers `done` by cancelling the
+      // subscription). On that path the inner stream's onDone has already run
+      // `releaseAndCleanup()`, which clears `mutexHeld` synchronously — so
+      // `mutexHeld` is false here and we skip cancelling a just-finished, about-
+      // to-be-reused `_virtualConv`. A genuine mid-flight cancel still holds the
+      // mutex, so `mutexHeld` is true and the cancel fires.
+      if (mutexHeld) cancelVirtualTurn(conversationToken);
       await inner?.cancel();
       await releaseAndCleanup();
     };


### PR DESCRIPTION
Addresses the teardown half of #364 and #373 (both from @Abdallah01, with production ANR evidence). Small, isolate-free, and independently shippable.

## The bug

`litert_lm_conversation_delete` blocks natively in `SessionBasic::~SessionBasic → ThreadPool::WaitUntilDone` — an **unbounded wait** for the in-flight generation to drain. Run on the platform thread under GPU throttle, that tail is tens of seconds → Android input-dispatch ANR + system kill. Reporter's evidence: **14/15 ANR traces** stuck in exactly this stack; one main-thread freeze of **15.5 s**, unblocking the millisecond `Conversation closed` printed. Healthy deletes (idle worker) are 6–8 ms — the cost is entirely the drain.

The fix is to **cancel the native decode before deleting**, so the drain returns in milliseconds.

## What was already correct

Explicit `subscription.cancel()` already reaches native on `main`: the raw stream's `onCancel → _cancelOn` was wired in the 0.16.2 virtual-session refactor, and Dart propagates `cancel()` through the `async*`/`.map()` chain. This PR closes the two teardown paths that still drained **without** cancelling first.

## Changes

1. **`LiteRtLmConversationHandle.close()`** — cancel the live decode before `_deleteConversation`. `session.close()` mid-generation on the single-session path hit the full drain; the virtual path already guarded this. `_cancelOn` is lock-free, so it interrupts a generation holding `_nativeMutex`.
2. **`startVirtualTurn.onCancel`** — cancel the native turn **explicitly**, not only via `inner`. A consumer cancel that lands while `onListen` is still awaiting the mutex or the create left `inner` null → the cancel never reached native, and `onListen` would then start a generation nobody consumes. A flag now makes `onListen` bail before launching that orphan turn.
3. **Docs** — `getResponseAsync`/`stopGeneration`: abandoning a stream (dropping the subscription without cancelling) cannot be intercepted; the accelerator decodes the whole turn. Consumers must `cancel()` or `stopGeneration()`. This matches @Abdallah01's app-side workaround.

## Invariants preserved (from #365/#372)

Cancel stays **lock-free** (must interrupt a mutex-holding generation, never await the mutex). Shutdown ordering unchanged — cancel only shortens the delete drain. No new UAF: on the virtual path `_cancelOn` targets `_virtualConv`, deleted only under the mutex being released. Double-cancel (`cancelVirtualTurn` + `inner.cancel()`) is idempotent natively.

## Verification

- Unit: 441 core + 31 litertlm tests green; analyze clean. (This teardown-ordering + FFI code isn't unit-testable without mockable bindings, same as #365/#372 — verified by structure + the race analysis above.)
- **On-device needed** — @Abdallah01 offered Android arm64 / Galaxy S25 / Gemma-4-E2B `.litertlm` / GPU. The check: after a mid-decode cancel, `[LiteRtLmFfi] Generation cancelled` must appear (reporter saw **zero** across 1.5M production log lines) and `Conversation closed` must follow within ms, not seconds.

## Not in scope

The **worker-isolate** move for the remaining synchronous-FFI UI jank (the larger half of #364) is a separate, phased change. This PR is the teardown/ANR half, which the reporter notes is what collapses the multi-second stall.

@Abdallah01 — could you run this branch on your workload and confirm the ANR is gone and `Generation cancelled` now appears?
