### PR TITLE
flutter_gemma_litertlm 1.0.3: ship the .litertlm ANR fixes (#365, #372, #364, #373)

### DIFF
--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3
+- Create the native conversation off the main isolate to avoid ANRs on multimodal models (#365).
+- Serialize native conversation create on the engine mutex to prevent a heap-corrupting race (#372).
+- Cancel native decode before tearing a conversation down to avoid a multi-second ANR (#364, #373).
+
 ## 1.0.2
 - Clamp `maxTokens` up to 1024 (min context for .litertlm) to fix the DYNAMIC_UPDATE_SLICE crash (#318).
 - Honor `maxOutputTokens` (session + chat) via native `set_max_output_tokens`; skipped on NPU.

--- a/packages/flutter_gemma_litertlm/pubspec.yaml
+++ b/packages/flutter_gemma_litertlm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_litertlm
 description: "LiteRT-LM (.litertlm) on-device inference engine for flutter_gemma via dart:ffi (5 native platforms) + web. Opt-in InferenceEngineProvider."
-version: 1.0.2
+version: 1.0.3
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_litertlm
 topics: [gemma, llm, litert, on-device, ffi]


### PR DESCRIPTION
Bumps `flutter_gemma_litertlm` 1.0.2 → 1.0.3 so the three `.litertlm` ANR fixes already merged to `main` actually reach users. All three landed after the last tag, but the package version was never bumped — at 1.0.2 (identical to the published version) they are stranded and cannot ship.

### What 1.0.3 ships (already on main; no new code here)
- **#365** (`9e808145`) — create the native conversation off the main isolate. `litert_lm_conversation_create` compiled the vision encoder's OpenCL kernels (`clBuildProgram` ~8.7s, Redmi Note 13 / Gemma 4 E2B) on the UI thread → `ANR: Input dispatching timed out`.
- **#372** (`90d3c20c`) — serialize native conversation create on `_nativeMutex`. The off-isolate create from #365 could race a second create on the non-reentrant engine (one live conversation, #966) → heap corruption. Also fixes a null-check crash when `shutdown()` is queued during create.
- **#364 / #373** (`598c0b5f`) — cancel native decode before tearing a conversation down. `conversation_delete` blocked in `~SessionBasic → ThreadPool::WaitUntilDone` for tens of seconds under GPU throttle → ANR (prod traces: 14/15 stuck in this stack, one 15.5s main-thread freeze). Field-verified on Galaxy S25.

### Scope
Version bump + CHANGELOG only — 2 files. This is the litertlm half of the 1.2.3 release; core `flutter_gemma` 1.2.3 is already bumped on main.

### Verification
`dart pub publish --dry-run`: clean (89 KB archive; only the expected pre-commit "uncommitted files" warning).
