### PR TITLE
docs: reflect 1.2.3 release version pins (website + CLAUDE.md + DESKTOP_SUPPORT.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Core has NO pigeon (dropped at the 1.0 cut; its value types are hand-written in 
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.13.1-a` GitHub Release. Android tarball bundles the Qualcomm QNN dispatch stack and Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` (Qualcomm Snapdragon / Intel LunarLake/PantherLake). MTP (speculative decoding) support for Gemma 4 (#318 MTP crash fixed). (native-v0.13.1-a restores the NPU dispatch libs accidentally omitted from native-v0.13.1 — #155.)
 - **large_file_handler**: `^0.5.0` (core dep; 0.5.0 declares all 6 platforms — needed for pana platform support + the dart2wasm-clean web graph)
-- **Current Version**: core `flutter_gemma` `1.2.2`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.2`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
+- **Current Version**: core `flutter_gemma` `1.2.3`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.3`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/packages/flutter_gemma/DESKTOP_SUPPORT.md
+++ b/packages/flutter_gemma/DESKTOP_SUPPORT.md
@@ -96,8 +96,8 @@ No Java/JVM/JRE required.
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_gemma: ^1.2.0            # core
-  flutter_gemma_litertlm: ^1.0.2   # .litertlm engine — required on desktop
+  flutter_gemma: ^1.2.3            # core
+  flutter_gemma_litertlm: ^1.0.3   # .litertlm engine — required on desktop
 ```
 
 ```dart

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,9 +21,9 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.2.2
+  flutter_gemma: ^1.2.3
   # Add the inference engine(s) you need:
-  flutter_gemma_litertlm: ^1.0.2   # .litertlm models (mobile + desktop)
+  flutter_gemma_litertlm: ^1.0.3   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
   flutter_gemma_embeddings: ^1.0.1

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,8 +29,8 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.2.2                 # core — always required
-  flutter_gemma_litertlm: ^1.0.2        # add if you run .litertlm models
+  flutter_gemma: ^1.2.3                 # core — always required
+  flutter_gemma_litertlm: ^1.0.3        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)


### PR DESCRIPTION
Reflects the 1.2.3 release across all documentation version pins (release skill Step 12a + Step 2 CLAUDE.md), so nothing points at the old versions after publish.

**Website (fluttergemma.dev — auto-deploys on merge):**
- `migration.md` (After / 1.0 setup): `flutter_gemma ^1.2.2 → ^1.2.3`, `flutter_gemma_litertlm ^1.0.2 → ^1.0.3`
- `genkit.md` (Genkit setup): same two pins

**Repo / package docs:**
- `CLAUDE.md` "Current Version": core `1.2.2 → 1.2.3`, litertlm `1.0.2 → 1.0.3`
- `packages/flutter_gemma/DESKTOP_SUPPORT.md`: core `^1.2.0 → ^1.2.3`, litertlm `^1.0.2 → ^1.0.3` (ships with core 1.2.3)

**Left unchanged:** the `Before (0.16.x)` migration example (`^0.16.3`); `mediapipe ^1.0.4` / `embeddings ^1.0.1` / `rag_* ^1.1.0` / `genkit_flutter_gemma ^0.4.3` (not part of this release).

Docs-only. Website fence check clean (all language-tagged fences in `website/content/docs` are `dart`; pubspec snippets are plain fences), so the Jaspr SSG build is unaffected. `firebase-hosting-merge.yml` auto-deploys on merge to main.

**Merge after** `flutter_gemma` 1.2.3 and `flutter_gemma_litertlm` 1.0.3 are published, so the docs never point ahead of pub.dev.
