### PR TITLE
fix(core): bump iOS podspec s.version to 1.2.3

### DIFF
--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.2.2'
+  s.version          = '1.2.3'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,


### PR DESCRIPTION
Bumps the core iOS podspec `s.version` `1.2.2 → 1.2.3` to match `packages/flutter_gemma/pubspec.yaml` (already 1.2.3 on main). The version bump for 1.2.3 landed in pubspec + CHANGELOG but missed the podspec.

Cosmetic label only — Flutter resolves plugins by pub version, not pod version — but keeps Step 2 consistent. The macOS podspec (`1.1.2`, long-standing independent drift) is intentionally left untouched.

Ships in the core package, so **merge before publishing** `flutter_gemma` 1.2.3.
