### PR TITLE
fix(litertlm): use-after-free in Conversation::CancelProcess on model-close-mid-stream (#379)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Core has NO pigeon (dropped at the 1.0 cut; its value types are hand-written in 
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.13.1-a` GitHub Release. Android tarball bundles the Qualcomm QNN dispatch stack and Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` (Qualcomm Snapdragon / Intel LunarLake/PantherLake). MTP (speculative decoding) support for Gemma 4 (#318 MTP crash fixed). (native-v0.13.1-a restores the NPU dispatch libs accidentally omitted from native-v0.13.1 — #155.)
 - **large_file_handler**: `^0.5.0` (core dep; 0.5.0 declares all 6 platforms — needed for pana platform support + the dart2wasm-clean web graph)
-- **Current Version**: core `flutter_gemma` `1.2.3`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.3`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
+- **Current Version**: core `flutter_gemma` `1.2.3`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.4`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0` (new)
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/packages/flutter_gemma/DESKTOP_SUPPORT.md
+++ b/packages/flutter_gemma/DESKTOP_SUPPORT.md
@@ -97,7 +97,7 @@ No Java/JVM/JRE required.
 # pubspec.yaml
 dependencies:
   flutter_gemma: ^1.2.3            # core
-  flutter_gemma_litertlm: ^1.0.3   # .litertlm engine — required on desktop
+  flutter_gemma_litertlm: ^1.0.4   # .litertlm engine — required on desktop
 ```
 
 ```dart

--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.0.4
-- Guard native cancel against a freed conversation to fix a use-after-free SIGSEGV when the model is closed mid-stream (#379).
+- Guard native cancel against a freed conversation — fixes a use-after-free SIGSEGV on close-mid-stream (#379).
 
 ## 1.0.3
 - Create the native conversation off the main isolate to avoid ANRs on multimodal models (#365).

--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+- Guard native cancel against a freed conversation to fix a use-after-free SIGSEGV when the model is closed mid-stream (#379).
+
 ## 1.0.3
 - Create the native conversation off the main isolate to avoid ANRs on multimodal models (#365).
 - Serialize native conversation create on the engine mutex to prevent a heap-corrupting race (#372).

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -1620,9 +1620,14 @@ class LiteRtLmFfiClient {
     _handles.clear();
     _legacyHandle = null;
 
-    // Tear down the shared virtual-session conversation too.
+    // Tear down the shared virtual-session conversation too. Cancel any
+    // in-flight virtual turn first: like handle.close(), an uncancelled
+    // conversation_delete blocks in ~SessionBasic → ThreadPool::WaitUntilDone
+    // draining the live generation (the #364 ANR). Safe post-#379 — vc is still
+    // in _liveConvs here, so _cancelOn reaches native rather than no-oping.
     final vc = _virtualConv;
     if (vc != null) {
+      _cancelOn(vc);
       _deleteConversation(vc);
       _virtualConv = null;
       _virtualActiveToken = null;

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -292,6 +292,24 @@ class LiteRtLmFfiClient {
   /// by [shutdown]. Each handle removes itself on its own [close].
   final Set<LiteRtLmConversationHandle> _handles = {};
 
+  /// Every conversation pointer currently alive (minted by
+  /// [_createRawConversation], removed by [_deleteConversation]). [_cancelOn]
+  /// consults this before dereferencing a pointer: a raw-stream or virtual-turn
+  /// onCancel can fire after model/handle/engine teardown already freed the
+  /// conversation, and cancelling a dangling pointer is a use-after-free SIGSEGV
+  /// in native `Conversation::CancelProcess` (#379). A freed conversation is not
+  /// in this set, so the late cancel no-ops.
+  final Set<Pointer<LiteRtLmConversation>> _liveConvs = {};
+
+  /// Test seam for the #379 registry — see cancel_after_delete_test.dart.
+  @visibleForTesting
+  Set<Pointer<LiteRtLmConversation>> get liveConversationsForTest => _liveConvs;
+
+  /// Test seam: drive the real [_deleteConversation] without a native binding.
+  @visibleForTesting
+  void deleteConversationForTest(Pointer<LiteRtLmConversation> conv) =>
+      _deleteConversation(conv);
+
   /// Backing handle for the legacy single-conversation API
   /// ([createConversation] / [closeConversation] / [chat] / etc.). Kept so
   /// existing single-session call sites work unchanged while the new
@@ -948,6 +966,7 @@ class LiteRtLmFfiClient {
       throw Exception('Failed to create conversation');
     }
 
+    _liveConvs.add(conv); // #379: track liveness so late cancels can't UAF
     return conv;
   }
 
@@ -1541,6 +1560,11 @@ class LiteRtLmFfiClient {
 
   /// Cancel ongoing generation on the given conversation.
   void _cancelOn(Pointer<LiteRtLmConversation> conv) {
+    // #379: never cancel a conversation that has already been freed. The
+    // raw-stream and virtual-turn onCancel hooks can fire after model/handle/
+    // engine teardown deleted the conversation; dereferencing the dangling
+    // pointer is a use-after-free SIGSEGV in native Conversation::CancelProcess.
+    if (!_liveConvs.contains(conv)) return;
     if (_bindings != null) {
       _bindings!.litert_lm_conversation_cancel_process(conv);
       gemmaLog('[LiteRtLmFfi] Generation cancelled');
@@ -1555,6 +1579,9 @@ class LiteRtLmFfiClient {
   /// Delete a conversation pointer. Called by
   /// [LiteRtLmConversationHandle.close].
   void _deleteConversation(Pointer<LiteRtLmConversation> conv) {
+    // Drop liveness first so any onCancel that races this teardown no-ops in
+    // [_cancelOn] rather than dereferencing the pointer we are about to free.
+    _liveConvs.remove(conv);
     if (_bindings != null) {
       _bindings!.litert_lm_conversation_delete(conv);
       gemmaLog('[LiteRtLmFfi] Conversation closed');

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -299,11 +299,27 @@ class LiteRtLmFfiClient {
   /// conversation, and cancelling a dangling pointer is a use-after-free SIGSEGV
   /// in native `Conversation::CancelProcess` (#379). A freed conversation is not
   /// in this set, so the late cancel no-ops.
+  ///
+  /// ABA note — this is keyed on the raw pointer *address*, so it DOWNGRADES,
+  /// not eliminates, the hazard: if the allocator re-mints a conversation at a
+  /// just-freed address, a stale `_cancelOn` for the old one would cancel the
+  /// NEW one (a wrong-target cancel, not a UAF). That window stays closed today
+  /// only because every create and every raw-stream cancel is serialized under
+  /// [_nativeMutex], and internal consumers use `await for` (no deferred
+  /// `subscription.cancel()`). Keep that discipline. A generation-keyed map
+  /// (`Map<Pointer,int>`, id captured per onCancel) would make it structural.
   final Set<Pointer<LiteRtLmConversation>> _liveConvs = {};
 
-  /// Test seam for the #379 registry — see cancel_after_delete_test.dart.
+  /// Test seam (read-only): is this conversation currently tracked as live?
   @visibleForTesting
-  Set<Pointer<LiteRtLmConversation>> get liveConversationsForTest => _liveConvs;
+  bool isConversationLiveForTest(Pointer<LiteRtLmConversation> conv) =>
+      _liveConvs.contains(conv);
+
+  /// Test seam: seed a live conversation without a native engine — mirrors the
+  /// registration [_createRawConversation] performs.
+  @visibleForTesting
+  void registerLiveForTest(Pointer<LiteRtLmConversation> conv) =>
+      _liveConvs.add(conv);
 
   /// Test seam: drive the real [_deleteConversation] without a native binding.
   @visibleForTesting
@@ -1564,6 +1580,7 @@ class LiteRtLmFfiClient {
     // raw-stream and virtual-turn onCancel hooks can fire after model/handle/
     // engine teardown deleted the conversation; dereferencing the dangling
     // pointer is a use-after-free SIGSEGV in native Conversation::CancelProcess.
+    // (Address-keyed — see the _liveConvs ABA note for the residual it leaves.)
     if (!_liveConvs.contains(conv)) return;
     if (_bindings != null) {
       _bindings!.litert_lm_conversation_cancel_process(conv);
@@ -1638,6 +1655,10 @@ class LiteRtLmFfiClient {
       _engine = null;
       gemmaLog('[LiteRtLmFfi] Engine deleted');
     }
+    // engine_delete bulk-frees every remaining conversation at once; the
+    // handle/virtual drains above already emptied the registry, but clear it so
+    // no address can linger as a dangling "live" entry after a bulk free.
+    _liveConvs.clear();
 
     _isInitialized = false;
     _backend = null;

--- a/packages/flutter_gemma_litertlm/pubspec.yaml
+++ b/packages/flutter_gemma_litertlm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_litertlm
 description: "LiteRT-LM (.litertlm) on-device inference engine for flutter_gemma via dart:ffi (5 native platforms) + web. Opt-in InferenceEngineProvider."
-version: 1.0.3
+version: 1.0.4
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_litertlm
 topics: [gemma, llm, litert, on-device, ffi]

--- a/packages/flutter_gemma_litertlm/test/ffi/cancel_after_delete_test.dart
+++ b/packages/flutter_gemma_litertlm/test/ffi/cancel_after_delete_test.dart
@@ -1,0 +1,33 @@
+import 'dart:ffi';
+
+import 'package:flutter_gemma_litertlm/src/ffi/litert_lm_bindings.dart';
+import 'package:flutter_gemma_litertlm/src/ffi/litert_lm_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// #379: a conversation deleted by model/handle/engine teardown must be dropped
+// from the live-conversation registry so a late onCancel (the raw-stream hook
+// `controller.onCancel = () => _cancelOn(conv)` or the virtual-turn path) no-ops
+// via `_cancelOn`'s liveness guard instead of dereferencing the freed pointer —
+// the SIGSEGV / use-after-free in native `Conversation::CancelProcess`.
+void main() {
+  test(
+    'a deleted conversation leaves the live registry, so a late cancel no-ops',
+    () {
+      final client = LiteRtLmFfiClient();
+      final conv = Pointer<LiteRtLmConversation>.fromAddress(0xC0FFEE);
+
+      // Simulate a live conversation (what _createRawConversation registers).
+      client.liveConversationsForTest.add(conv);
+      expect(client.liveConversationsForTest.contains(conv), isTrue);
+
+      // Model/handle teardown deletes it.
+      client.deleteConversationForTest(conv);
+
+      expect(
+        client.liveConversationsForTest.contains(conv),
+        isFalse,
+        reason: 'a late cancel now finds the conv dead and no-ops (no UAF)',
+      );
+    },
+  );
+}

--- a/packages/flutter_gemma_litertlm/test/ffi/cancel_after_delete_test.dart
+++ b/packages/flutter_gemma_litertlm/test/ffi/cancel_after_delete_test.dart
@@ -17,14 +17,14 @@ void main() {
       final conv = Pointer<LiteRtLmConversation>.fromAddress(0xC0FFEE);
 
       // Simulate a live conversation (what _createRawConversation registers).
-      client.liveConversationsForTest.add(conv);
-      expect(client.liveConversationsForTest.contains(conv), isTrue);
+      client.registerLiveForTest(conv);
+      expect(client.isConversationLiveForTest(conv), isTrue);
 
       // Model/handle teardown deletes it.
       client.deleteConversationForTest(conv);
 
       expect(
-        client.liveConversationsForTest.contains(conv),
+        client.isConversationLiveForTest(conv),
         isFalse,
         reason: 'a late cancel now finds the conv dead and no-ops (no UAF)',
       );

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -23,7 +23,7 @@ dependencies:
   genkit_flutter_gemma: ^0.4.3
   flutter_gemma: ^1.2.3
   # Add the inference engine(s) you need:
-  flutter_gemma_litertlm: ^1.0.3   # .litertlm models (mobile + desktop)
+  flutter_gemma_litertlm: ^1.0.4   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
   flutter_gemma_embeddings: ^1.0.1

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -30,7 +30,7 @@ dependencies:
 ```
 dependencies:
   flutter_gemma: ^1.2.3                 # core — always required
-  flutter_gemma_litertlm: ^1.0.3        # add if you run .litertlm models
+  flutter_gemma_litertlm: ^1.0.4        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)


### PR DESCRIPTION
Fixes a native SIGSEGV (use-after-free) reported by @Abdallah01 in #379 on shipped `flutter_gemma_litertlm 1.0.3`.

### The bug
When an `InferenceModel` is closed/re-created while a session's `getResponseAsync()` stream is still attached, the conversation is deleted, but a later onCancel for that stream still runs `_cancelOn` on the freed pointer:
- raw-stream hook `controller.onCancel = () => _cancelOn(conv)` captures the pointer by value with no liveness check;
- the virtual-turn path's `_virtualConv` / `_virtualActiveToken` still describe the freed conversation, so `cancelVirtualTurn` passes its guards and calls `_cancelOn` on a dangling pointer.

`_cancelOn` → native `litert_lm_conversation_cancel_process` dereferences freed memory → `SIGSEGV` in `litert::lm::Conversation::CancelProcess`. The #375 cancel-before-teardown path is what makes it reachable (Android arm64, Galaxy S25, GPU, ~15 min into a session under memory pressure).

### The fix
A live-conversation registry (`_liveConvs`): `_createRawConversation` adds the pointer, `_deleteConversation` removes it, and `_cancelOn` no-ops on any pointer not in the set — so a cancel that races or follows teardown can never dereference a freed conversation. This closes both the raw-stream and virtual-turn cancel paths with one guard.

### Verification
- New unit test `test/ffi/cancel_after_delete_test.dart` (registry drops a deleted conversation → late cancel no-ops); full litertlm suite green (32).
- macOS on-device smoke (`litertlm_ffi_test.dart`) with the guard applied: 24/24 — no regression to normal cancel/close/streaming.
- App-side workaround (unchanged behavior for correct callers): `await session.close()` before closing/re-creating the model.

The native Android crash repro is device/heap-timing specific; @Abdallah01 offered to validate a fix build on the exact setup from the #375 run.
