### PR TITLE
fix(litertlm): smooth UI during Android GPU prefill (#364)

### DIFF
--- a/packages/flutter_gemma_embeddings/CHANGELOG.md
+++ b/packages/flutter_gemma_embeddings/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+- Realign the shared LiteRT-LM native bundle to native-v0.13.1-b (#364). No API change.
+
 ## 1.0.1
 - Rebuild on native-v0.13.1-a (shares the LiteRT-LM native bundle; restores NPU dispatch libs, #155). No embeddings API change.
 - Point `homepage` to fluttergemma.dev. No code change.

--- a/packages/flutter_gemma_embeddings/hook/build.dart
+++ b/packages/flutter_gemma_embeddings/hook/build.dart
@@ -148,7 +148,7 @@ class _NativeBundle {
 /// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
 const _litertlmBundle = _NativeBundle(
   namespace: 'litertlm',
-  version: '0.13.1-a',
+  version: '0.13.1-b',
   releaseTagPrefix: 'native-v',
   archivePrefix: 'litertlm',
   mainLibName: 'LiteRtLm',
@@ -167,6 +167,11 @@ const _litertlmBundle = _NativeBundle(
   // Only android_arm64 + windows_x86_64 checksums changed vs 0.13.1; the other
   // 5 platforms are byte-identical. 16KB page alignment preserved (the ARM64
   // QNN libs are 16KB-aligned; the *Skel.so are DSP6 blobs, 16KB N/A).
+  // 0.13.1-b: android_arm64 ONLY re-diffed vs -a — the LiteRt libs rebuilt from
+  // the SAME commit a0afb5a with the GPU smooth-UI C-API setters for #364; the
+  // Qualcomm/QNN NPU libs are carried over byte-identical from -a. Must stay in
+  // lock-step with flutter_gemma_litertlm's pin — the two share this bundle and
+  // the cross-package guard throws on a version skew.
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
         '2c84bdacd4f367a631270a6b3f8ff87e2d11aa019d8e898a2361f40591667024',
@@ -181,7 +186,7 @@ const _litertlmBundle = _NativeBundle(
     'litertlm-ios_sim_arm64.tar.gz':
         '08724bafac9381a9fde8658ce5a1137f1f5b966d82dd63e32b2e201d617c0b9d',
     'litertlm-android_arm64.tar.gz':
-        '2705a86f1130f205882551f19352c11a022caf67377d43284d7957c52d3cebf7',
+        '1d53054e1032ee84b0f0d244beeefe7ff75c8c4374577ace5b4c1e4e52594507',
   },
   companions: [
     'GemmaModelConstraintProvider',

--- a/packages/flutter_gemma_embeddings/pubspec.yaml
+++ b/packages/flutter_gemma_embeddings/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_embeddings
 description: "On-device text embeddings (Gecko / EmbeddingGemma .tflite via LiteRT + dart:ffi) for flutter_gemma. Opt-in EmbeddingBackendProvider for on-device RAG."
-version: 1.0.1
+version: 1.0.2
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_embeddings
 topics: [embeddings, gemma, litert, rag, on-device]

--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+- Smooth UI during Android GPU prefill — flush the OpenCL queue every 2 ops (#364).
+
 ## 1.0.4
 - Guard native cancel against a freed conversation — fixes a use-after-free SIGSEGV on close-mid-stream (#379).
 

--- a/packages/flutter_gemma_litertlm/hook/build.dart
+++ b/packages/flutter_gemma_litertlm/hook/build.dart
@@ -148,7 +148,7 @@ class _NativeBundle {
 /// (#245). Android: `-Wl,-z,max-page-size=16384` (Google Play 16KB).
 const _litertlmBundle = _NativeBundle(
   namespace: 'litertlm',
-  version: '0.13.1-a',
+  version: '0.13.1-b',
   releaseTagPrefix: 'native-v',
   archivePrefix: 'litertlm',
   mainLibName: 'LiteRtLm',
@@ -167,6 +167,13 @@ const _litertlmBundle = _NativeBundle(
   // Only android_arm64 + windows_x86_64 checksums changed vs 0.13.1; the other
   // 5 platforms are byte-identical. 16KB page alignment preserved (the ARM64
   // QNN libs are 16KB-aligned; the *Skel.so are DSP6 blobs, 16KB N/A).
+  // 0.13.1-b: android_arm64 ONLY re-diffed vs -a — libLiteRtLm.so + the 7 other
+  // LiteRt libs rebuilt from the SAME commit a0afb5a with two added C-API
+  // setters (litert_lm_engine_settings_set_kernel_batch_size /
+  // set_gpu_context_low_priority) exposing the GPU smooth-UI knobs for #364; the
+  // 11 Qualcomm/QNN NPU libs are carried over byte-identical from -a so NPU is
+  // unaffected. The other 6 platforms are byte-identical copies re-uploaded
+  // under the -b tag (their checksums below are unchanged from -a).
   checksums: {
     'litertlm-linux_x86_64.tar.gz':
         '2c84bdacd4f367a631270a6b3f8ff87e2d11aa019d8e898a2361f40591667024',
@@ -181,7 +188,7 @@ const _litertlmBundle = _NativeBundle(
     'litertlm-ios_sim_arm64.tar.gz':
         '08724bafac9381a9fde8658ce5a1137f1f5b966d82dd63e32b2e201d617c0b9d',
     'litertlm-android_arm64.tar.gz':
-        '2705a86f1130f205882551f19352c11a022caf67377d43284d7957c52d3cebf7',
+        '1d53054e1032ee84b0f0d244beeefe7ff75c8c4374577ace5b4c1e4e52594507',
   },
   companions: [
     'GemmaModelConstraintProvider',

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_bindings.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_bindings.dart
@@ -546,6 +546,50 @@ class LiteRtLmBindings {
             void Function(ffi.Pointer<LiteRtLmEngineSettings>, int)
           >();
 
+  void litert_lm_engine_settings_set_gpu_context_low_priority(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    bool value,
+  ) {
+    return _litert_lm_engine_settings_set_gpu_context_low_priority(
+      settings,
+      value,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_gpu_context_low_priorityPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>, ffi.Bool)
+        >
+      >('litert_lm_engine_settings_set_gpu_context_low_priority');
+  late final _litert_lm_engine_settings_set_gpu_context_low_priority =
+      _litert_lm_engine_settings_set_gpu_context_low_priorityPtr
+          .asFunction<
+            void Function(ffi.Pointer<LiteRtLmEngineSettings>, bool)
+          >();
+
+  void litert_lm_engine_settings_set_kernel_batch_size(
+    ffi.Pointer<LiteRtLmEngineSettings> settings,
+    int kernel_batch_size,
+  ) {
+    return _litert_lm_engine_settings_set_kernel_batch_size(
+      settings,
+      kernel_batch_size,
+    );
+  }
+
+  late final _litert_lm_engine_settings_set_kernel_batch_sizePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<LiteRtLmEngineSettings>, ffi.Int)
+        >
+      >('litert_lm_engine_settings_set_kernel_batch_size');
+  late final _litert_lm_engine_settings_set_kernel_batch_size =
+      _litert_lm_engine_settings_set_kernel_batch_sizePtr
+          .asFunction<
+            void Function(ffi.Pointer<LiteRtLmEngineSettings>, int)
+          >();
+
   void litert_lm_engine_settings_set_cache_dir(
     ffi.Pointer<LiteRtLmEngineSettings> settings,
     ffi.Pointer<ffi.Char> cache_dir,

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -714,6 +714,30 @@ class LiteRtLmFfiClient {
         gemmaLog('[LiteRtLmFfi] NPU Android: dispatch_lib_dir=$nativeLibDir');
       }
 
+      // #364: on Android, flush the OpenCL command queue every N ops during a
+      // GPU prefill so it doesn't starve the Flutter raster/compositor thread.
+      // By default LiteRT-LM's OpenCL backend dispatches the ENTIRE graph as one
+      // uninterruptible batch (gpu_backend_opencl_litert.cc: "dispatch all
+      // kernels in one batch" when kernel_batch_size<=0), so a ~2s prefill
+      // freezes the compositor (repro'd on Adreno S23 Ultra: raster p95
+      // 6.8ms->123ms). A positive hint_kernel_batch_size inserts a clFlush every
+      // N ops, giving the display work interleave points. Upstream auto-applies
+      // 4 for "generic" models to ensure smooth UI, but recognized Gemma types
+      // aren't generic (engine_settings.cc gates the default on has_generic_model)
+      // so gemma4/3/3n get NO flush unless we set it. Measured on dm3q: kb=4
+      // (upstream value) still janks (p95 63ms), kb=2 is flat (p95 7.3ms ~=
+      // baseline) with no TTFT cost, so 2 — not 4. NOT gpu_context_low_priority:
+      // it only reorders cross-context submission (no Adreno preemption of a
+      // running dispatch) and measured strictly worse (jank + TTFT both up).
+      // Gated to Android: Metal (iOS/macOS) doesn't starve the compositor, and
+      // the setter symbol only ships in the Android native rebuild.
+      if (Platform.isAndroid && backend == 'gpu') {
+        b.litert_lm_engine_settings_set_kernel_batch_size(settings, 2);
+        gemmaLog(
+          '[LiteRtLmFfi] Android GPU: hint_kernel_batch_size=2 (#364 smooth UI)',
+        );
+      }
+
       // Create engine in a background isolate to avoid blocking UI.
       // Pass settings pointer as int address (Pointer can't cross isolates).
       gemmaLog(

--- a/packages/flutter_gemma_litertlm/native/litert_lm/build_android.sh
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/build_android.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREBUILT_DIR="$SCRIPT_DIR/prebuilt/android_arm64"
 LITERT_LM_DIR="/tmp/LiteRT-LM"
-DEFAULT_REF="ffed38adbc33509480b5340e5173638bc20a68ff"
+DEFAULT_REF="a0afb5a56acd106b23a2b2385b8469834dc268c0"
 VERSION="${1:-}"
 
 # Resolve Android NDK — prefer ANDROID_NDK_HOME env, else newest under

--- a/packages/flutter_gemma_litertlm/native/litert_lm/build_ios.sh
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/build_ios.sh
@@ -49,7 +49,7 @@ fi
 # This is the first public LiteRT-LM commit where libLiteRtLm rebuilt from
 # source has matching ABI with the prebuilt accelerators. v0.11.0 itself
 # is broken — see the WARNING above and the upstream issue we filed.
-DEFAULT_REF="ffed38adbc33509480b5340e5173638bc20a68ff"
+DEFAULT_REF="a0afb5a56acd106b23a2b2385b8469834dc268c0"
 TARGET_REF="${VERSION:-$DEFAULT_REF}"
 echo "Checking out $TARGET_REF..."
 git checkout -f "$TARGET_REF"

--- a/packages/flutter_gemma_litertlm/native/litert_lm/build_macos.sh
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/build_macos.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREBUILT_DIR="$SCRIPT_DIR/prebuilt/macos_arm64"
 LITERT_LM_DIR="/tmp/LiteRT-LM"
-DEFAULT_REF="ffed38adbc33509480b5340e5173638bc20a68ff"
+DEFAULT_REF="a0afb5a56acd106b23a2b2385b8469834dc268c0"
 VERSION="${1:-}"
 
 echo "=== Building libLiteRtLm.dylib for macOS arm64 ==="

--- a/packages/flutter_gemma_litertlm/native/litert_lm/include/engine.h
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/include/engine.h
@@ -381,6 +381,20 @@ void litert_lm_engine_settings_set_enable_speculative_decoding(
 LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_use_hw_masking_for_npu(
     LiteRtLmEngineSettings* settings, bool value);
+
+// Lowers the GPU inference context priority (OpenCL kLow) so on-device GPU
+// prefill/decode does not starve the host UI compositor (#364). GPU-only;
+// a no-op on backends whose delegate ignores context priority.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_gpu_context_low_priority(
+    LiteRtLmEngineSettings* settings, bool value);
+
+// Hints a GPU kernel batch size so the delegate periodically flushes, giving
+// the UI compositor scheduling windows during long GPU work (#364).
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_kernel_batch_size(
+    LiteRtLmEngineSettings* settings, int kernel_batch_size);
+
 // Creates a LiteRT LM Engine from the given settings. The caller is responsible
 // for destroying the engine using `litert_lm_engine_delete`.
 //

--- a/packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/patch_c_api.sh
@@ -64,6 +64,8 @@ EXPORTS
   litert_lm_engine_settings_set_activation_data_type
   litert_lm_engine_settings_set_cache_dir
   litert_lm_engine_settings_set_enable_speculative_decoding
+  litert_lm_engine_settings_set_gpu_context_low_priority
+  litert_lm_engine_settings_set_kernel_batch_size
   litert_lm_engine_settings_set_litert_dispatch_lib_dir
   litert_lm_engine_settings_set_max_num_images
   litert_lm_engine_settings_set_max_num_tokens
@@ -278,6 +280,66 @@ void litert_lm_engine_settings_set_use_hw_masking_for_npu(\
   echo "  OK: Added set_use_hw_masking_for_npu impl to c/engine.cc"
 else
   echo "  SKIP: c/engine.cc already has set_use_hw_masking_for_npu"
+fi
+
+# ── 4c. Add GPU smooth-UI knobs — gpu_context_low_priority + kernel_batch_size ──
+# #364: on Android/OpenCL a GPU prefill monopolizes the Adreno GPU and starves
+# the Flutter raster/compositor thread (repro'd on S23 Ultra: raster p95
+# 6.8ms->123ms during a ~2s prefill). AdvancedSettings.gpu_context_low_priority
+# lowers the inference GPU context priority (SetPriority(kLow)); hint_kernel_batch_size
+# adds periodic GPU flushes so the compositor gets scheduling windows. Both are
+# consumed at a0afb5a in llm_executor_settings_utils.cc:210-223 but the upstream
+# C API doesn't expose them. Mirror the upstream set_enable_speculative_decoding
+# idiom (engine.cc:500-509).
+if ! grep -q "set_gpu_context_low_priority" "$DIR/c/engine.h"; then
+  sed -i.bak '/Creates a LiteRT LM Engine from the given settings/i\
+// Lowers the GPU inference context priority (OpenCL kLow) so on-device GPU\
+// prefill/decode does not starve the host UI compositor (#364). GPU-only;\
+// a no-op on backends whose delegate ignores context priority.\
+LITERT_LM_C_API_EXPORT\
+void litert_lm_engine_settings_set_gpu_context_low_priority(\
+    LiteRtLmEngineSettings* settings, bool value);\
+\
+// Hints a GPU kernel batch size so the delegate periodically flushes, giving\
+// the UI compositor scheduling windows during long GPU work (#364).\
+LITERT_LM_C_API_EXPORT\
+void litert_lm_engine_settings_set_kernel_batch_size(\
+    LiteRtLmEngineSettings* settings, int kernel_batch_size);\
+' "$DIR/c/engine.h"
+  rm -f "$DIR/c/engine.h.bak"
+  echo "  OK: Added GPU smooth-UI knob setters to c/engine.h"
+else
+  echo "  SKIP: c/engine.h already has set_gpu_context_low_priority"
+fi
+
+if ! grep -q "set_gpu_context_low_priority" "$DIR/c/engine.cc"; then
+  sed -i.bak '/void litert_lm_engine_settings_set_activation_data_type/i\
+void litert_lm_engine_settings_set_gpu_context_low_priority(\
+    LiteRtLmEngineSettings* settings, bool value) {\
+  if (settings \&\& settings->settings) {\
+    auto\& main_settings = settings->settings->GetMutableMainExecutorSettings();\
+    auto advanced_settings = main_settings.GetAdvancedSettings().value_or(\
+        litert::lm::AdvancedSettings());\
+    advanced_settings.gpu_context_low_priority = value;\
+    main_settings.SetAdvancedSettings(advanced_settings);\
+  }\
+}\
+\
+void litert_lm_engine_settings_set_kernel_batch_size(\
+    LiteRtLmEngineSettings* settings, int kernel_batch_size) {\
+  if (settings \&\& settings->settings) {\
+    auto\& main_settings = settings->settings->GetMutableMainExecutorSettings();\
+    auto advanced_settings = main_settings.GetAdvancedSettings().value_or(\
+        litert::lm::AdvancedSettings());\
+    advanced_settings.hint_kernel_batch_size = kernel_batch_size;\
+    main_settings.SetAdvancedSettings(advanced_settings);\
+  }\
+}\
+' "$DIR/c/engine.cc"
+  rm -f "$DIR/c/engine.cc.bak"
+  echo "  OK: Added GPU smooth-UI knob impls to c/engine.cc"
+else
+  echo "  SKIP: c/engine.cc already has set_gpu_context_low_priority"
 fi
 
 # ── 5. Patch litert_lm_conversation_config_create to 6-arg signature ──

--- a/packages/flutter_gemma_litertlm/pubspec.yaml
+++ b/packages/flutter_gemma_litertlm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_litertlm
 description: "LiteRT-LM (.litertlm) on-device inference engine for flutter_gemma via dart:ffi (5 native platforms) + web. Opt-in InferenceEngineProvider."
-version: 1.0.4
+version: 1.1.0
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_litertlm
 topics: [gemma, llm, litert, on-device, ffi]

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -23,10 +23,10 @@ dependencies:
   genkit_flutter_gemma: ^0.4.3
   flutter_gemma: ^1.2.3
   # Add the inference engine(s) you need:
-  flutter_gemma_litertlm: ^1.0.4   # .litertlm models (mobile + desktop)
+  flutter_gemma_litertlm: ^1.1.0   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
-  flutter_gemma_embeddings: ^1.0.1
+  flutter_gemma_embeddings: ^1.0.2
 ```
 
 ### Setup

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -30,9 +30,9 @@ dependencies:
 ```
 dependencies:
   flutter_gemma: ^1.2.3                 # core — always required
-  flutter_gemma_litertlm: ^1.0.4        # add if you run .litertlm models
+  flutter_gemma_litertlm: ^1.1.0        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
-  flutter_gemma_embeddings: ^1.0.1      # add if you compute embeddings
+  flutter_gemma_embeddings: ^1.0.2      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)
   flutter_gemma_rag_sqlite: ^1.1.0      # add for on-device RAG (sqlite-vec; all platforms incl. web)
   flutter_gemma_agent: ^0.1.0           # add for on-device agent skills (SKILL.md + tool-calling loop)


### PR DESCRIPTION
**Problem.** On Android GPU, a LiteRT-LM prefill dispatches the whole graph as one uninterruptible OpenCL batch, starving the Flutter raster/compositor thread. Reproduced on Firebase Test Lab (Galaxy S23 Ultra, Adreno 740): prefill raster p95 **6.8ms → 123ms** (visible UI freeze), matching #364.

**Fix.** Expose the upstream `hint_kernel_batch_size` GPU smooth-UI knob via the C API and set it to **2** on the Android GPU path — inserts a `clFlush` every 2 ops so the compositor gets scheduling windows. On-device sweep (prefill raster p95):

| kernel_batch_size | prefill p95 |
|---|---|
| unset (default) | 123 ms — janky |
| 4 (upstream generic-model default) | 63 ms — still janky |
| **2 (shipped)** | **7.3 ms — flat** |
| 1 | 4.9 ms — flat |

No TTFT penalty. Deliberately **not** `gpu_context_low_priority` — it only reorders cross-context submission (no Adreno preemption of a running dispatch) and measured strictly worse on both jank and TTFT. Upstream auto-flushes only for "generic" models; recognized Gemma types are excluded, so gemma4/3/3n get no flush by default.

**Native.** Rebuilt `libLiteRtLm.so` from the same commit `ffed38a` with two added C-API setters → `native-v0.13.1-b`. Android-only rebuild; the Qualcomm/QNN NPU stack is byte-identical from `-a` (NPU unaffected); the other 6 platform tarballs are byte-identical copies. `native-v0.13.1-a` is left untouched.

**Packages (lock-step).** `flutter_gemma_litertlm` 1.0.4 → **1.1.0**, `flutter_gemma_embeddings` 1.0.1 → **1.0.2** (shares the native bundle; must move together or the cross-package version guard throws).

**Verified.** Fresh download-path build (no local prebuilt) pulls `-b`, SHA passes, bundled `.so` exports the setter, NPU libs present. Fix confirmed on FTL dm3q.
