### PR TITLE
fix(core): eliminate background_downloader temp-file leak + deterministic task IDs (#383)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Core has NO pigeon (dropped at the 1.0 cut; its value types are hand-written in 
 - **MediaPipe Web**: v0.10.27, Android/iOS: v0.10.33
 - **LiteRT-LM**: native libs from `native-v0.13.1-a` GitHub Release. Android tarball bundles the Qualcomm QNN dispatch stack and Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` (Qualcomm Snapdragon / Intel LunarLake/PantherLake). MTP (speculative decoding) support for Gemma 4 (#318 MTP crash fixed). (native-v0.13.1-a restores the NPU dispatch libs accidentally omitted from native-v0.13.1 — #155.)
 - **large_file_handler**: `^0.5.0` (core dep; 0.5.0 declares all 6 platforms — needed for pana platform support + the dart2wasm-clean web graph)
-- **Current Version**: core `flutter_gemma` `1.3.0`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.4`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0`, `flutter_gemma_builtin_ai` `0.1.0` (new)
+- **Current Version**: core `flutter_gemma` `1.3.1`, `flutter_gemma_rag_sqlite` `1.1.0`, `flutter_gemma_rag_qdrant` `1.1.0`; `flutter_gemma_litertlm` `1.0.4`, `flutter_gemma_mediapipe` `1.0.4`, `flutter_gemma_embeddings` `1.0.1`; `flutter_gemma_agent` `0.1.0`, `flutter_gemma_builtin_ai` `0.1.0` (new)
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+- Reclaim orphaned background_downloader temp files leaking in Android filesDir (#383).
+
 ## 1.3.0
 - Add ModelFileType.builtIn for OS system models (Gemini Nano / Apple FM)
 

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.3.1
-- Reclaim orphaned background_downloader temp files leaking in Android filesDir (#383).
+- Fix multi-GB background_downloader temp-file leak on Android (#383).
+- Deterministic download task IDs (sha256 of path triple) — stable across restarts and signed-URL rotation (#383).
+- getOrphanedFiles()/cleanupStorage() now surface and delete orphaned downloader fragments (#383).
+- Cancel tasks before reset in cleanup so paused temp files are deleted (#383).
+- Resume watchdog cancels the dead native task instead of leaking it (#383).
 
 ## 1.3.0
 - Add ModelFileType.builtIn for OS system models (Gemini Nano / Apple FM)

--- a/packages/flutter_gemma/example/integration_test/download_temp_reclaim_device_test.dart
+++ b/packages/flutter_gemma/example/integration_test/download_temp_reclaim_device_test.dart
@@ -1,0 +1,149 @@
+/// On-device validation of the #383 orphaned-download-temp reclaim.
+///
+/// The pure predicate is unit-tested off-device; what only a real Android device
+/// can confirm is the INTEGRATION: that `getApplicationSupportDirectory()`
+/// resolves to the same `filesDir` where `background_downloader` writes
+/// large-file temps, that the sweep enumerates + deletes there, and that a real
+/// download's temp actually lands in that directory.
+///
+/// Run (Android device / FTL):
+///   flutter test integration_test/download_temp_reclaim_device_test.dart -d <android>
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_gemma/core/model_management/utils/download_temp_reclaim.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'inference_test_helpers.dart' show registerTestEngines;
+
+const _gemma4Url =
+    'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm';
+const _token = String.fromEnvironment('HUGGINGFACE_TOKEN');
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await registerTestEngines();
+  });
+
+  // ── A. The sweep on a REAL Android filesDir ──────────────────────────────
+  testWidgets(
+    'A: getApplicationSupportDirectory is filesDir and the sweep deletes '
+    'orphaned temps there, keeping the keep-set and non-temp files',
+    (tester) async {
+      expect(Platform.isAndroid, isTrue, reason: 'device test is Android-only');
+
+      final dir = await getApplicationSupportDirectory();
+      print('[reclaim] applicationSupport = ${dir.path}');
+      // Android filesDir is under the app data dir (…/files), never external.
+      expect(dir.path.contains('/files'), isTrue, reason: 'expected filesDir');
+
+      final orphan = File(
+        p.join(dir.path, 'com.bbflight.background_downloader_TEST_orphan'),
+      )..writeAsBytesSync(List.filled(1024, 0));
+      final keep = File(
+        p.join(dir.path, 'com.bbflight.background_downloader_TEST_keep'),
+      )..writeAsBytesSync(List.filled(1024, 0));
+      final model = File(p.join(dir.path, 'test_model_TEST.litertlm'))
+        ..writeAsBytesSync(List.filled(1024, 0));
+
+      addTearDown(() {
+        for (final f in [orphan, keep, model]) {
+          if (f.existsSync()) f.deleteSync();
+        }
+      });
+
+      // minAge: 0 so the just-written synthetic temps are eligible (the
+      // "older-than" mtime guard itself is covered by the off-device unit test).
+      final reclaimed = await sweepOrphanedDownloadTemps(
+        dir,
+        keepPaths: {keep.path},
+        minAge: Duration.zero,
+      );
+
+      print('[reclaim] deleted $reclaimed file(s)');
+      expect(
+        orphan.existsSync(),
+        isFalse,
+        reason: 'orphan temp must be deleted',
+      );
+      expect(keep.existsSync(), isTrue, reason: 'keep-set temp must survive');
+      expect(model.existsSync(), isTrue, reason: 'a real model must survive');
+      expect(reclaimed, greaterThanOrEqualTo(1));
+    },
+  );
+
+  // ── B. A real download's temp lands in that same directory ───────────────
+  testWidgets(
+    'B: a live background_downloader partial for a 2.4GB model appears as a '
+    'com.bbflight.background_downloader* temp in getApplicationSupportDirectory',
+    (tester) async {
+      if (_token.isEmpty) {
+        markTestSkipped(
+          'HUGGINGFACE_TOKEN not provided — skipping the real-download temp '
+          'location check (Test A already validates the sweep on real filesDir; '
+          "the location is also confirmed by #383's own logcat).",
+        );
+        return;
+      }
+      final dir = await getApplicationSupportDirectory();
+
+      bool hasBgTemp() => dir
+          .listSync(followLinks: false)
+          .any(
+            (e) =>
+                e is File && p.basename(e.path).startsWith(kDownloadTempPrefix),
+          );
+
+      final cancel = CancelToken();
+      // Fire the download; don't await — we only need it to START writing its
+      // temp. Swallow the cancellation/other errors.
+      unawaited(() async {
+        try {
+          await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
+              .fromNetwork(_gemma4Url, token: _token)
+              .withCancelToken(cancel)
+              .withProgress((_) {})
+              .install();
+        } catch (_) {
+          // Cancellation / network error — expected; we only wanted the temp.
+        }
+      }());
+
+      // Poll up to ~90s for the native worker to create the temp.
+      var appeared = false;
+      for (var i = 0; i < 45 && !appeared; i++) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+        appeared = hasBgTemp();
+      }
+      cancel.cancel();
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      print('[reclaim] live download temp seen in filesDir: $appeared');
+      expect(
+        appeared,
+        isTrue,
+        reason:
+            'a 2.4GB download must create a com.bbflight.background_downloader* '
+            'temp in getApplicationSupportDirectory() — that is exactly the dir '
+            'the reclaim sweep scans',
+      );
+
+      // Best-effort cleanup of any partial we just created.
+      for (final e in dir.listSync(followLinks: false)) {
+        if (e is File && p.basename(e.path).startsWith(kDownloadTempPrefix)) {
+          try {
+            e.deleteSync();
+          } catch (_) {}
+        }
+      }
+    },
+  );
+}

--- a/packages/flutter_gemma/example/integration_test/download_temp_reclaim_device_test.dart
+++ b/packages/flutter_gemma/example/integration_test/download_temp_reclaim_device_test.dart
@@ -184,8 +184,16 @@ void main() {
         reason: 'a background_downloader* file must be flagged as a fragment',
       );
 
+      // Protect every non-fragment orphaned file already surfaced above so a
+      // persistent device's real installed models (with no active download
+      // task) can never be swept by this test — only the synthetic fragment
+      // (and any other real fragments) are fair game for cleanup (#383).
+      final protectedFiles = orphaned
+          .where((o) => !o.isDownloadFragment)
+          .map((o) => o.filename)
+          .toList();
       final deleted = await ModelFileSystemManager.cleanupOrphanedFiles(
-        protectedFiles: const [],
+        protectedFiles: protectedFiles,
       );
       print('[reclaim] cleanupOrphanedFiles deleted $deleted file(s)');
       expect(

--- a/packages/flutter_gemma/example/integration_test/download_temp_reclaim_device_test.dart
+++ b/packages/flutter_gemma/example/integration_test/download_temp_reclaim_device_test.dart
@@ -13,8 +13,11 @@ library;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter_gemma/core/model_management/utils/download_temp_reclaim.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/mobile/flutter_gemma_mobile.dart';
+import 'package:flutter_gemma/mobile/smart_downloader.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path/path.dart' as p;
@@ -144,6 +147,212 @@ void main() {
           } catch (_) {}
         }
       }
+    },
+  );
+
+  // ── C. A synthetic fragment is surfaced + deletable via the public API ──
+  testWidgets(
+    'C: a com.bbflight.background_downloader* fragment is surfaced by '
+    'getOrphanedFiles (isDownloadFragment) and removed by cleanupOrphanedFiles',
+    (tester) async {
+      expect(Platform.isAndroid, isTrue, reason: 'device test is Android-only');
+
+      final dir = await getApplicationSupportDirectory();
+      final fragment = File(p.join(dir.path, '${kDownloadTempPrefix}_TESTFRAG'))
+        ..writeAsBytesSync(List.filled(1024, 0));
+
+      addTearDown(() {
+        if (fragment.existsSync()) fragment.deleteSync();
+      });
+
+      final orphaned = await ModelFileSystemManager.getOrphanedFiles(
+        protectedFiles: const [],
+      );
+      final match = orphaned.where((o) => o.path == fragment.path).toList();
+      print(
+        '[reclaim] getOrphanedFiles surfaced ${orphaned.length} entr(y/ies)',
+      );
+      expect(
+        match.length,
+        1,
+        reason:
+            'the fragment must be surfaced exactly once by getOrphanedFiles',
+      );
+      expect(
+        match.single.isDownloadFragment,
+        isTrue,
+        reason: 'a background_downloader* file must be flagged as a fragment',
+      );
+
+      final deleted = await ModelFileSystemManager.cleanupOrphanedFiles(
+        protectedFiles: const [],
+      );
+      print('[reclaim] cleanupOrphanedFiles deleted $deleted file(s)');
+      expect(
+        fragment.existsSync(),
+        isFalse,
+        reason: 'cleanupOrphanedFiles must delete the fragment',
+      );
+    },
+  );
+
+  // ── D. Legacy resume-record reconciliation purges the legacy record + its
+  //      temp, but keeps a current-scheme record + its temp (#383/R2) ──────
+  //
+  // `_reclaimOrphanedDownloadTemps` (MobileModelManager) is private, so this
+  // drives the same public decision primitives it uses — `computeTaskId`,
+  // `reconcileResumeRecord`, `ReclaimDecision` — against the REAL
+  // `FileDownloader().database.storage`, mirroring the loop in
+  // mobile_model_manager.dart. The reconcile scope is narrowed to only the two
+  // taskIds this test creates (rather than every group record in real
+  // storage) so the test can never mutate unrelated resume state that may
+  // already exist on a shared test device.
+  testWidgets(
+    'D: reconciliation purges a legacy resume record + its temp, keeps a '
+    'current-scheme record + its temp',
+    (tester) async {
+      expect(Platform.isAndroid, isTrue, reason: 'device test is Android-only');
+
+      final dir = await getApplicationSupportDirectory();
+      final downloader = FileDownloader();
+      // ignore: invalid_use_of_visible_for_testing_member
+      final storage = downloader.database.storage;
+
+      const baseDirectory = BaseDirectory.applicationSupport;
+      const directory = '';
+      const legacyFilename = 'legacy_model_TESTFRAG.litertlm';
+      const currentFilename = 'current_model_TESTFRAG.litertlm';
+
+      final expectedLegacyId = computeTaskId(
+        baseDirectory,
+        directory,
+        legacyFilename,
+      );
+      // Deliberately NOT the id its own (base, directory, filename) triple
+      // computes — that mismatch is the definition of "legacy": a taskId
+      // minted before #383/#2 introduced the deterministic
+      // sha256(base|directory|filename) scheme.
+      final legacyTaskId = 'legacy-pre-383-$expectedLegacyId';
+      final currentTaskId = computeTaskId(
+        baseDirectory,
+        directory,
+        currentFilename,
+      );
+
+      final legacyTemp = File(
+        p.join(dir.path, '${kDownloadTempPrefix}_TESTFRAG_legacy'),
+      )..writeAsBytesSync(List.filled(1024, 0));
+      final currentTemp = File(
+        p.join(dir.path, '${kDownloadTempPrefix}_TESTFRAG_current'),
+      )..writeAsBytesSync(List.filled(1024, 0));
+      // Older than kDownloadTempMinReclaimAge so the purge branch is eligible
+      // — a just-written temp is deliberately spared (reconcileResumeRecord).
+      final old = DateTime.now().subtract(const Duration(minutes: 30));
+      legacyTemp.setLastModifiedSync(old);
+      currentTemp.setLastModifiedSync(old);
+
+      final legacyTask = DownloadTask(
+        taskId: legacyTaskId,
+        url: 'https://example.invalid/$legacyFilename',
+        filename: legacyFilename,
+        directory: directory,
+        baseDirectory: baseDirectory,
+        group: SmartDownloader.downloadGroup,
+      );
+      final currentTask = DownloadTask(
+        taskId: currentTaskId,
+        url: 'https://example.invalid/$currentFilename',
+        filename: currentFilename,
+        directory: directory,
+        baseDirectory: baseDirectory,
+        group: SmartDownloader.downloadGroup,
+      );
+
+      addTearDown(() async {
+        // Best-effort: clean up everything this test created — the legacy
+        // record/temp are expected to already be gone (the test purges them
+        // itself), and the current-scheme record/temp are KEPT by design, so
+        // this is what actually removes them afterwards.
+        for (final id in [legacyTaskId, currentTaskId]) {
+          try {
+            await storage.removeResumeData(id);
+          } catch (_) {}
+          try {
+            await storage.removePausedTask(id);
+          } catch (_) {}
+          try {
+            await downloader.database.deleteRecordWithId(id);
+          } catch (_) {}
+        }
+        for (final f in [legacyTemp, currentTemp]) {
+          if (f.existsSync()) f.deleteSync();
+        }
+      });
+
+      await storage.storeResumeData(ResumeData(legacyTask, legacyTemp.path));
+      await storage.storeResumeData(ResumeData(currentTask, currentTemp.path));
+
+      // Mirror MobileModelManager._reclaimOrphanedDownloadTemps's reconcile
+      // loop against the REAL storage, scoped to only the two records this
+      // test created (see class comment above for why).
+      final pausedIds = (await storage.retrieveAllPausedTasks())
+          .map((t) => t.taskId)
+          .toSet();
+      final allIds = (await downloader.allTasks(
+        allGroups: true,
+      )).map((t) => t.taskId).toSet();
+      final nativeRunningIds = allIds.difference(pausedIds);
+      final ourIds = {legacyTaskId, currentTaskId};
+
+      for (final r in await storage.retrieveAllResumeData()) {
+        if (r.task.group != SmartDownloader.downloadGroup) continue;
+        if (!ourIds.contains(r.task.taskId)) continue;
+        final expectedId = computeTaskId(
+          r.task.baseDirectory,
+          r.task.directory,
+          r.task.filename,
+        );
+        final tempAge = DateTime.now().difference(
+          await File(r.tempFilepath).lastModified(),
+        );
+        final decision = reconcileResumeRecord(
+          taskId: r.task.taskId,
+          expectedId: expectedId,
+          isNativeRunning: nativeRunningIds.contains(r.task.taskId),
+          tempAge: tempAge,
+        );
+        if (decision != ReclaimDecision.purge) continue;
+        try {
+          await File(r.tempFilepath).delete();
+        } catch (_) {}
+        await storage.removeResumeData(r.task.taskId);
+        await storage.removePausedTask(r.task.taskId);
+        await downloader.database.deleteRecordWithId(r.task.taskId);
+        print('[reclaim] purged legacy record ${r.task.taskId} (#383/R2 test)');
+      }
+
+      expect(
+        legacyTemp.existsSync(),
+        isFalse,
+        reason: "legacy record's temp must be purged",
+      );
+      expect(
+        currentTemp.existsSync(),
+        isTrue,
+        reason: "current-scheme record's temp must survive",
+      );
+
+      final remaining = await storage.retrieveAllResumeData();
+      expect(
+        remaining.any((r) => r.task.taskId == legacyTaskId),
+        isFalse,
+        reason: 'legacy resume record must be removed',
+      );
+      expect(
+        remaining.any((r) => r.task.taskId == currentTaskId),
+        isTrue,
+        reason: 'current-scheme resume record must survive',
+      );
     },
   );
 }

--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.2.3'
+  s.version          = '1.3.1'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,

--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -366,6 +366,25 @@ class MobileModelManager extends ModelFileManager {
         gemmaLog('Cleaned up $cleanedCount tasks of type ${type.name}');
       }
 
+      // Cancel only THIS type's tasks (deletes their paused temps) before the
+      // group reset; cancelling the whole group here would abort an unrelated
+      // model type's in-flight download (#383/#5).
+      try {
+        final groupTasks = await downloader.allTasks(
+          group: SmartDownloader.downloadGroup,
+          includeTasksWaitingToRetry: true,
+        );
+        final ofType = groupTasks
+            .where((t) => _detectModelType(t.filename) == type)
+            .map((t) => t.taskId)
+            .toList();
+        if (ofType.isNotEmpty) {
+          await downloader.cancelTasksWithIds(ofType);
+        }
+      } catch (e) {
+        gemmaLog('Failed to cancel ${type.name} tasks before reset: $e');
+      }
+
       // Reset background_downloader tasks
       try {
         await downloader.reset(group: SmartDownloader.downloadGroup);
@@ -688,15 +707,24 @@ class MobileModelManager extends ModelFileManager {
       // 1. Get protected files from ModelRepository
       final protectedFiles = await _getAllProtectedFiles();
 
-      // 2. Enhanced file system cleanup
+      final downloader = FileDownloader();
+      // 2. Cancel every task in the group FIRST — cancellation deletes paused
+      //    temp files (reset() only clears records), so this must precede both
+      //    reset and the fragment sweep (#383/#5).
+      final groupTasks = await downloader.allTasks(
+        group: SmartDownloader.downloadGroup,
+        includeTasksWaitingToRetry: true,
+      );
+      await downloader.cancelTasksWithIds(
+        groupTasks.map((t) => t.taskId).toList(),
+      );
+      // 3. Reset residual records.
+      await downloader.reset(group: SmartDownloader.downloadGroup);
+      // 4. Filesystem cleanup last — now only truly-orphaned fragments remain.
       await ModelFileSystemManager.cleanupOrphanedFiles(
         protectedFiles: protectedFiles,
         enableResumeDetection: true,
       );
-
-      // 3. Background_downloader cleanup
-      final downloader = FileDownloader();
-      await downloader.reset(group: SmartDownloader.downloadGroup);
 
       gemmaLog('UnifiedModelManager: Cleanup completed');
     } catch (e) {

--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -84,41 +84,46 @@ class MobileModelManager extends ModelFileManager {
       final keep = <String>{};
       for (final r in resumeData) {
         if (r.task.group != SmartDownloader.downloadGroup) continue;
-        final expectedId = computeTaskId(
-          r.task.baseDirectory,
-          r.task.directory,
-          r.task.filename,
-        );
-        Duration tempAge;
         try {
-          tempAge = DateTime.now().difference(
-            await File(r.tempFilepath).lastModified(),
+          final expectedId = computeTaskId(
+            r.task.baseDirectory,
+            r.task.directory,
+            r.task.filename,
           );
-        } catch (_) {
-          tempAge =
-              kDownloadTempMinReclaimAge; // treat unknown mtime as eligible-old
-        }
-        final decision = reconcileResumeRecord(
-          taskId: r.task.taskId,
-          expectedId: expectedId,
-          isNativeRunning: nativeRunningIds.contains(r.task.taskId),
-          tempAge: tempAge,
-        );
-        switch (decision) {
-          case ReclaimDecision.keep:
-            keep.add(r.tempFilepath);
-          case ReclaimDecision.skip:
-            break;
-          case ReclaimDecision.purge:
-            try {
-              await File(r.tempFilepath).delete();
-            } catch (_) {}
-            await storage.removeResumeData(r.task.taskId);
-            await storage.removePausedTask(r.task.taskId);
-            await downloader.database.deleteRecordWithId(r.task.taskId);
-            gemmaLog(
-              'Reclaimed legacy download record ${r.task.taskId} (#383)',
+          Duration tempAge;
+          try {
+            tempAge = DateTime.now().difference(
+              await File(r.tempFilepath).lastModified(),
             );
+          } catch (_) {
+            tempAge =
+                kDownloadTempMinReclaimAge; // treat unknown mtime as eligible-old
+          }
+          final decision = reconcileResumeRecord(
+            taskId: r.task.taskId,
+            expectedId: expectedId,
+            isNativeRunning: nativeRunningIds.contains(r.task.taskId),
+            tempAge: tempAge,
+          );
+          switch (decision) {
+            case ReclaimDecision.keep:
+              keep.add(r.tempFilepath);
+            case ReclaimDecision.skip:
+              break;
+            case ReclaimDecision.purge:
+              try {
+                await File(r.tempFilepath).delete();
+              } catch (_) {}
+              await storage.removeResumeData(r.task.taskId);
+              await storage.removePausedTask(r.task.taskId);
+              await downloader.database.deleteRecordWithId(r.task.taskId);
+              gemmaLog(
+                'Reclaimed legacy download record ${r.task.taskId} (#383)',
+              );
+          }
+        } catch (e) {
+          gemmaLog('Reclaim: skipped record ${r.task.taskId} ($e) (#383)');
+          continue;
         }
       }
 

--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -60,54 +60,81 @@ class MobileModelManager extends ModelFileManager {
       // the active-tasks gate below reflects reality (avoids racing — and then
       // deleting — a just-restarted download's temp on cold start).
       await Future<void>.delayed(const Duration(seconds: 5));
-
       final downloader = FileDownloader();
-      // Pull resume data the OS stored in native SharedPreferences while the app
-      // was dead into the Dart store, so a killed-mid-download partial becomes a
-      // tracked resumable (and is protected by the keep-set below) instead of
-      // being mistaken for an orphan.
       await downloader.resumeFromBackground();
 
-      // A running or queued download's temp lives only in the native worker's
-      // memory — invisible here. Deleting during any active download can unlink
-      // a live temp and fail its final move. Only sweep when nothing is active.
-      final active = await downloader.allTasks(allGroups: true);
-      if (active.isNotEmpty) {
-        // Log the skip so a stuck/zombie task record blocking reclaim on every
-        // launch is diagnosable from a log dump instead of being a silent no-op
-        // (the invisibility that made the original #383 leak hard to find).
+      // Narrow the blanket gate to GENUINELY-RUNNING native tasks. A legacy
+      // record re-materialized by resumeFromBackground() shows up as a *paused*
+      // task; gating on "any active task" would let one stale paused record wedge
+      // reclaim forever — exactly the R2 upgrade-mid-download scenario (#383).
+      // ignore: invalid_use_of_visible_for_testing_member
+      final storage = downloader.database.storage;
+      final pausedIds = (await storage.retrieveAllPausedTasks())
+          .map((t) => t.taskId)
+          .toSet();
+      final allIds = (await downloader.allTasks(
+        allGroups: true,
+      )).map((t) => t.taskId).toSet();
+      final nativeRunningIds = allIds.difference(pausedIds);
+
+      // Reconcile every group-scoped resume record against the current scheme,
+      // BEFORE the blanket sweep. Purge legacy records (temp + resume/paused/db
+      // state); keep current-scheme and still-running temps.
+      final resumeData = await storage.retrieveAllResumeData();
+      final keep = <String>{};
+      for (final r in resumeData) {
+        if (r.task.group != SmartDownloader.downloadGroup) continue;
+        final expectedId = computeTaskId(
+          r.task.baseDirectory,
+          r.task.directory,
+          r.task.filename,
+        );
+        Duration tempAge;
+        try {
+          tempAge = DateTime.now().difference(
+            await File(r.tempFilepath).lastModified(),
+          );
+        } catch (_) {
+          tempAge =
+              kDownloadTempMinReclaimAge; // treat unknown mtime as eligible-old
+        }
+        final decision = reconcileResumeRecord(
+          taskId: r.task.taskId,
+          expectedId: expectedId,
+          isNativeRunning: nativeRunningIds.contains(r.task.taskId),
+          tempAge: tempAge,
+        );
+        switch (decision) {
+          case ReclaimDecision.keep:
+            keep.add(r.tempFilepath);
+          case ReclaimDecision.skip:
+            break;
+          case ReclaimDecision.purge:
+            try {
+              await File(r.tempFilepath).delete();
+            } catch (_) {}
+            await storage.removeResumeData(r.task.taskId);
+            await storage.removePausedTask(r.task.taskId);
+            await downloader.database.deleteRecordWithId(r.task.taskId);
+            gemmaLog(
+              'Reclaimed legacy download record ${r.task.taskId} (#383)',
+            );
+        }
+      }
+
+      // Blanket filesystem sweep only when nothing is actively writing a temp.
+      if (nativeRunningIds.isNotEmpty) {
         gemmaLog(
-          'Download-temp reclaim skipped: ${active.length} active task(s) (#383)',
+          'Download-temp sweep skipped: ${nativeRunningIds.length} running task(s) (#383)',
         );
         return;
       }
-
-      // Temp paths a valid pending resume would append to — must be read AFTER
-      // resumeFromBackground() so restart-resumable partials are preserved.
-      // `database.storage` is the live PersistentStorage the downloader already
-      // uses; reading it here (rather than spinning up a second
-      // LocalStorePersistentStorage isolate on the same on-disk store) avoids a
-      // concurrent-access conflict. The getter is marked @visibleForTesting —
-      // advisory only; it's a stable `get storage => _storage`, and its removal
-      // would fail at compile time, never silently.
-      // ignore: invalid_use_of_visible_for_testing_member
-      final resumeData = await downloader.database.storage
-          .retrieveAllResumeData();
-      final keep = resumeData.map((r) => r.tempFilepath).toSet();
-
-      // background_downloader writes large-file partials into applicationSupport,
-      // which on Android is context.filesDir (path_provider maps
-      // getApplicationSupportDirectory() → getFilesDir()).
       final dir = await getApplicationSupportDirectory();
       final reclaimed = await sweepOrphanedDownloadTemps(dir, keepPaths: keep);
-      // Log unconditionally: reclaimed == 0 must be a distinct, greppable event
-      // so "swept, nothing to do" is never confused with "reclaim never applied"
-      // or "matched candidates but every delete failed" (all left a real leak).
       gemmaLog(
         'Download-temp reclaim: kept ${keep.length}, reclaimed $reclaimed (#383)',
       );
     } catch (e, st) {
-      // Reclaim is best-effort housekeeping; never surface it to the caller.
       gemmaLog('Orphaned download-temp reclaim failed (non-fatal): $e\n$st');
     }
   }

--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -29,6 +29,87 @@ class MobileModelManager extends ModelFileManager {
         'UnifiedModelManager: active-model restore failed, starting with no active model: $e\n$st',
       );
     }
+    // Reclaim multi-GB download temp files orphaned by failed / cancelled /
+    // process-killed downloads (#383). Fire-and-forget: it must never block or
+    // fail app startup, and it self-delays past WorkManager rescheduling before
+    // reading the "no active downloads" gate.
+    unawaited(_reclaimOrphanedDownloadTemps());
+  }
+
+  /// Deletes orphaned `background_downloader` partial temp files left in the
+  /// Android persistent internal dir (`filesDir`) by downloads that failed,
+  /// were cancelled, or died with the process (#383).
+  ///
+  /// background_downloader streams a large-file download into a randomly-named
+  /// temp `filesDir/com.bbflight.background_downloader<rand>` and only moves it
+  /// to the model path on success. On a resumable failure it deliberately KEEPS
+  /// the partial; a fresh retry or a process-kill/WorkManager-restart then
+  /// allocates a NEW temp and orphans the old one — filesDir is never reclaimed
+  /// by the OS, so multi-GB partials accumulate forever.
+  ///
+  /// This runs only when it is SAFE: a live/queued download's temp path is not
+  /// visible from Dart, so the sweep bails if any task is active, skips temps
+  /// touched recently (a just-(re)started download), and preserves temps a
+  /// valid pending resume would reuse.
+  Future<void> _reclaimOrphanedDownloadTemps() async {
+    // Temp-file lifecycle + `filesDir` location are Android-specific; on iOS the
+    // resume data is opaque (not a temp path) and the leak doesn't apply.
+    if (!Platform.isAndroid) return;
+    try {
+      // Let WorkManager finish re-registering any process-killed download so
+      // the active-tasks gate below reflects reality (avoids racing — and then
+      // deleting — a just-restarted download's temp on cold start).
+      await Future<void>.delayed(const Duration(seconds: 5));
+
+      final downloader = FileDownloader();
+      // Pull resume data the OS stored in native SharedPreferences while the app
+      // was dead into the Dart store, so a killed-mid-download partial becomes a
+      // tracked resumable (and is protected by the keep-set below) instead of
+      // being mistaken for an orphan.
+      await downloader.resumeFromBackground();
+
+      // A running or queued download's temp lives only in the native worker's
+      // memory — invisible here. Deleting during any active download can unlink
+      // a live temp and fail its final move. Only sweep when nothing is active.
+      final active = await downloader.allTasks(allGroups: true);
+      if (active.isNotEmpty) {
+        // Log the skip so a stuck/zombie task record blocking reclaim on every
+        // launch is diagnosable from a log dump instead of being a silent no-op
+        // (the invisibility that made the original #383 leak hard to find).
+        gemmaLog(
+          'Download-temp reclaim skipped: ${active.length} active task(s) (#383)',
+        );
+        return;
+      }
+
+      // Temp paths a valid pending resume would append to — must be read AFTER
+      // resumeFromBackground() so restart-resumable partials are preserved.
+      // `database.storage` is the live PersistentStorage the downloader already
+      // uses; reading it here (rather than spinning up a second
+      // LocalStorePersistentStorage isolate on the same on-disk store) avoids a
+      // concurrent-access conflict. The getter is marked @visibleForTesting —
+      // advisory only; it's a stable `get storage => _storage`, and its removal
+      // would fail at compile time, never silently.
+      // ignore: invalid_use_of_visible_for_testing_member
+      final resumeData = await downloader.database.storage
+          .retrieveAllResumeData();
+      final keep = resumeData.map((r) => r.tempFilepath).toSet();
+
+      // background_downloader writes large-file partials into applicationSupport,
+      // which on Android is context.filesDir (path_provider maps
+      // getApplicationSupportDirectory() → getFilesDir()).
+      final dir = await getApplicationSupportDirectory();
+      final reclaimed = await sweepOrphanedDownloadTemps(dir, keepPaths: keep);
+      // Log unconditionally: reclaimed == 0 must be a distinct, greppable event
+      // so "swept, nothing to do" is never confused with "reclaim never applied"
+      // or "matched candidates but every delete failed" (all left a real leak).
+      gemmaLog(
+        'Download-temp reclaim: kept ${keep.length}, reclaimed $reclaimed (#383)',
+      );
+    } catch (e, st) {
+      // Reclaim is best-effort housekeeping; never surface it to the caller.
+      gemmaLog('Orphaned download-temp reclaim failed (non-fatal): $e\n$st');
+    }
   }
 
   /// Rehydrate `_activeInferenceModel` from the identity that
@@ -260,7 +341,7 @@ class MobileModelManager extends ModelFileManager {
 
       // Reset background_downloader tasks
       try {
-        await downloader.reset(group: 'flutter_gemma_downloads');
+        await downloader.reset(group: SmartDownloader.downloadGroup);
       } catch (e) {
         gemmaLog('Failed to reset background_downloader tasks: $e');
       }
@@ -588,7 +669,7 @@ class MobileModelManager extends ModelFileManager {
 
       // 3. Background_downloader cleanup
       final downloader = FileDownloader();
-      await downloader.reset(group: 'flutter_gemma_downloads');
+      await downloader.reset(group: SmartDownloader.downloadGroup);
 
       gemmaLog('UnifiedModelManager: Cleanup completed');
     } catch (e) {

--- a/packages/flutter_gemma/lib/core/model_management/types/storage_info.dart
+++ b/packages/flutter_gemma/lib/core/model_management/types/storage_info.dart
@@ -40,6 +40,10 @@ class StorageStats {
       orphanedFiles.fold(0, (sum, f) => sum + f.sizeBytes);
 
   double get totalSizeMB => totalSizeBytes / (1024 * 1024);
+
+  /// Download fragments (`background_downloader` partial temps, #383) live
+  /// out-of-tree in `applicationSupport`/`filesDir`, outside the model dir
+  /// that [totalSizeMB] scans — so this can exceed [totalSizeMB].
   double get orphanedSizeMB => orphanedFilesSize / (1024 * 1024);
 
   @override

--- a/packages/flutter_gemma/lib/core/model_management/types/storage_info.dart
+++ b/packages/flutter_gemma/lib/core/model_management/types/storage_info.dart
@@ -6,18 +6,22 @@ class OrphanedFileInfo {
   final String path;
   final int sizeBytes;
   final DateTime? lastModified;
+  final bool isDownloadFragment;
 
   const OrphanedFileInfo({
     required this.filename,
     required this.path,
     required this.sizeBytes,
     this.lastModified,
+    this.isDownloadFragment = false,
   });
 
   double get sizeMB => sizeBytes / (1024 * 1024);
 
   @override
-  String toString() => '$filename (${sizeMB.toStringAsFixed(2)} MB)';
+  String toString() =>
+      '$filename${isDownloadFragment ? ' [download fragment]' : ''} '
+      '(${sizeMB.toStringAsFixed(2)} MB)';
 }
 
 /// Storage statistics

--- a/packages/flutter_gemma/lib/core/model_management/utils/download_temp_reclaim.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/download_temp_reclaim.dart
@@ -1,0 +1,92 @@
+/// Decision logic + filesystem walk for reclaiming orphaned
+/// `background_downloader` partial temp files (#383), split out so both the
+/// pure predicate and the directory sweep are testable — the predicate as a
+/// pure unit test, the sweep as an on-device integration test — without the
+/// surrounding `FileDownloader` / `path_provider` / gate machinery.
+///
+/// `MobileModelManager._reclaimOrphanedDownloadTemps` owns the SAFETY GATES
+/// (Android-only, no active downloads, `resumeFromBackground()` first, the
+/// resume keep-set) and calls [sweepOrphanedDownloadTemps] to do the walk.
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Filename prefix `background_downloader` gives every partial temp file
+/// (`com.bbflight.background_downloader<Random.nextInt()>`, no extension).
+const String kDownloadTempPrefix = 'com.bbflight.background_downloader';
+
+/// How recently a temp file must have been touched to be considered possibly
+/// LIVE (a download can start writing a beat before its task is Dart-visible).
+/// Only temps older than this are candidates for deletion.
+const Duration kDownloadTempMinReclaimAge = Duration(minutes: 10);
+
+/// Whether the file at [path] (basename [basename]) is an orphaned download
+/// temp safe to delete.
+///
+/// Deletes ONLY when ALL hold:
+/// - the name is a `background_downloader` temp ([kDownloadTempPrefix]);
+/// - the path is NOT in [keepPaths] (temps a valid pending resume would reuse);
+/// - the file is OLDER than [minAge] (never touch a possibly-live temp — the
+///   guard is deliberately "older than", the opposite of "younger than", so a
+///   just-(re)started download whose task is momentarily invisible is spared).
+///
+/// [age] is `now - file.modified`. Callers pass it so the function stays pure.
+bool shouldReclaimDownloadTemp({
+  required String basename,
+  required String path,
+  required Set<String> keepPaths,
+  required Duration age,
+  Duration minAge = kDownloadTempMinReclaimAge,
+}) {
+  if (!basename.startsWith(kDownloadTempPrefix)) return false;
+  if (keepPaths.contains(path)) return false;
+  if (age < minAge) return false;
+  return true;
+}
+
+/// Walks [dir] (non-recursive) and deletes every file for which
+/// [shouldReclaimDownloadTemp] is true. Returns the number deleted.
+///
+/// This is ONLY the filesystem walk — the caller MUST have already applied the
+/// safety gates (Android-only, no active downloads, `resumeFromBackground()`,
+/// and built [keepPaths] from the resume store). Best-effort: an undeletable or
+/// vanished file is skipped, never thrown.
+///
+/// [now] is injectable so tests are deterministic.
+Future<int> sweepOrphanedDownloadTemps(
+  Directory dir, {
+  required Set<String> keepPaths,
+  Duration minAge = kDownloadTempMinReclaimAge,
+  DateTime? now,
+}) async {
+  if (!dir.existsSync()) return 0;
+  final at = now ?? DateTime.now();
+  var reclaimed = 0;
+  await for (final entity in dir.list(followLinks: false)) {
+    if (entity is! File) continue;
+    final FileStat stat;
+    try {
+      stat = await entity.stat();
+    } catch (_) {
+      continue; // vanished between list() and stat()
+    }
+    if (!shouldReclaimDownloadTemp(
+      basename: p.basename(entity.path),
+      path: entity.path,
+      keepPaths: keepPaths,
+      age: at.difference(stat.modified),
+      minAge: minAge,
+    )) {
+      continue;
+    }
+    try {
+      await entity.delete();
+      reclaimed++;
+    } catch (_) {
+      // Locked / already removed — skip.
+    }
+  }
+  return reclaimed;
+}

--- a/packages/flutter_gemma/lib/core/model_management/utils/download_temp_reclaim.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/download_temp_reclaim.dart
@@ -90,3 +90,31 @@ Future<int> sweepOrphanedDownloadTemps(
   }
   return reclaimed;
 }
+
+/// Outcome of reconciling one persisted resume record against the current
+/// task-ID scheme during reclaim (#383/R2).
+enum ReclaimDecision { keep, purge, skip }
+
+/// Decide what to do with a group-scoped resume record whose temp is [tempAge] old.
+///
+/// - [taskId] == [expectedId] → current-scheme record → `keep` (protect its temp).
+/// - [isNativeRunning] → WorkManager is actively writing this temp → `keep`.
+/// - otherwise it is a legacy/foreign-scheme record: `purge` if the temp is older
+///   than [minAge], else `skip` (a just-rescheduled killed task may be about to
+///   resume it — the same 10-min guard the blanket sweep uses).
+ReclaimDecision reconcileResumeRecord({
+  required String taskId,
+  required String expectedId,
+  required bool isNativeRunning,
+  required Duration tempAge,
+  Duration minAge = kDownloadTempMinReclaimAge,
+}) {
+  if (taskId == expectedId) return ReclaimDecision.keep;
+  if (isNativeRunning) return ReclaimDecision.keep;
+  if (tempAge < minAge) return ReclaimDecision.skip;
+  return ReclaimDecision.purge;
+}
+
+/// Whether [basename] is a `background_downloader` partial temp file (#383/#3).
+bool isDownloadFragmentName(String basename) =>
+    basename.startsWith(kDownloadTempPrefix);

--- a/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
@@ -163,16 +163,20 @@ class ModelFileSystemManager {
           final name = path.basename(entity.path);
           if (!isDownloadFragmentName(name)) continue;
           if (keep.contains(entity.path)) continue;
-          final stat = await entity.stat();
-          orphaned.add(
-            OrphanedFileInfo(
-              filename: name,
-              path: entity.path,
-              sizeBytes: stat.size,
-              lastModified: stat.modified,
-              isDownloadFragment: true,
-            ),
-          );
+          try {
+            final stat = await entity.stat();
+            orphaned.add(
+              OrphanedFileInfo(
+                filename: name,
+                path: entity.path,
+                sizeBytes: stat.size,
+                lastModified: stat.modified,
+                isDownloadFragment: true,
+              ),
+            );
+          } catch (_) {
+            continue; // vanished mid-scan (e.g. a concurrent reclaim)
+          }
         }
       } catch (e) {
         gemmaLog('Fragment scan failed (non-fatal): $e');

--- a/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
@@ -185,7 +185,7 @@ class ModelFileSystemManager {
 
       // Check active tasks
       final allTasks = await downloader.allTasks(
-        group: 'smart_downloads',
+        group: SmartDownloader.downloadGroup,
         includeTasksWaitingToRetry: true,
       );
 

--- a/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
@@ -144,6 +144,41 @@ class ModelFileSystemManager {
       );
     }
 
+    // Downloader partial temps are extensionless and live in applicationSupport
+    // (Android filesDir), outside the model dir — invisible to the loop above
+    // (#383/#3, #6). Scan for them so getOrphanedFiles/cleanupStorage can report
+    // and delete them. Android-only: iOS uses opaque URLSession resume data with
+    // no filesDir temp. A live/resumable temp is spared via the resume keep-set;
+    // explicit cleanup additionally cancels all group tasks first (#383/#5).
+    if (Platform.isAndroid) {
+      try {
+        final downloader = FileDownloader();
+        // ignore: invalid_use_of_visible_for_testing_member
+        final keep = (await downloader.database.storage.retrieveAllResumeData())
+            .map((r) => r.tempFilepath)
+            .toSet();
+        final supportDir = await getApplicationSupportDirectory();
+        for (final entity in supportDir.listSync(followLinks: false)) {
+          if (entity is! File) continue;
+          final name = path.basename(entity.path);
+          if (!isDownloadFragmentName(name)) continue;
+          if (keep.contains(entity.path)) continue;
+          final stat = await entity.stat();
+          orphaned.add(
+            OrphanedFileInfo(
+              filename: name,
+              path: entity.path,
+              sizeBytes: stat.size,
+              lastModified: stat.modified,
+              isDownloadFragment: true,
+            ),
+          );
+        }
+      } catch (e) {
+        gemmaLog('Fragment scan failed (non-fatal): $e');
+      }
+    }
+
     return orphaned;
   }
 

--- a/packages/flutter_gemma/lib/core/model_management/utils/resume_checker.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/resume_checker.dart
@@ -93,7 +93,7 @@ class ResumeChecker {
       // 3. Check if we have a tracked task for this file in FileDownloader
       // First check active tasks
       final allTasks = await _downloader.allTasks(
-        group: 'flutter_gemma_downloads',
+        group: SmartDownloader.downloadGroup,
         includeTasksWaitingToRetry: true,
       );
 

--- a/packages/flutter_gemma/lib/mobile/flutter_gemma_mobile.dart
+++ b/packages/flutter_gemma/lib/mobile/flutter_gemma_mobile.dart
@@ -5,14 +5,17 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart'; // MethodChannel — used by file_system_manager.dart part
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:background_downloader/background_downloader.dart';
+import 'smart_downloader.dart'; // SmartDownloader.downloadGroup — single source of truth for the task group
 
 import '../flutter_gemma.dart';
 import '../core/di/service_registry.dart';
 import '../core/domain/model_source.dart';
 import '../core/services/model_repository.dart' as repo;
 import '../core/model_management/constants/preferences_keys.dart';
+import '../core/model_management/utils/download_temp_reclaim.dart';
 import '../core/utils/file_name_utils.dart';
 import '../core/registry/engine_registry.dart';
 import '../core/registry/embedding_registry.dart';

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter_gemma/core/domain/download_error.dart';
@@ -18,6 +20,18 @@ const int kMaxResumeAttempts = 3;
 /// this, the task is presumed silently dead (#355) and the stream is closed.
 @visibleForTesting
 const Duration kResumeWatchdog = Duration(seconds: 90);
+
+/// Deterministic background_downloader task ID for a model download (#383/#2).
+///
+/// Derived only from the stable `Task.split` identity — NOT the url (so a rotated
+/// signed URL still maps to the same partial) and NOT the absolute path (so an iOS
+/// app-container UUID change on every update doesn't churn the id). `Object.hashCode`
+/// is not a spec-stable key across runs/SDKs; sha256 of the triple is.
+///
+/// Not `@visibleForTesting`: it is a real internal API used in production by both
+/// the download path and the reclaim reconciliation (`mobile_model_manager`).
+String computeTaskId(BaseDirectory base, String directory, String filename) =>
+    sha256.convert(utf8.encode('${base.name}|$directory|$filename')).toString();
 
 /// Returns a [Timer] that fires [onTimeout] after [timeout] unless cancelled.
 /// The download loop cancels it when the next progress/status event arrives, and
@@ -447,22 +461,30 @@ class SmartDownloader {
       return;
     }
 
-    // Generate deterministic taskId based on URL + targetPath
-    // This prevents duplicate downloads of the same file
-    final taskId =
-        '${url.hashCode.toUnsigned(32).toRadixString(16)}_${targetPath.hashCode.toUnsigned(32).toRadixString(16)}';
+    // taskId + task location come from the same stable split triple; compute
+    // inside the try so a path_provider failure routes to the retry/backoff
+    // catch below rather than escaping the retry loop.
+    late final String taskId;
+    late final BaseDirectory baseDirectory;
+    late final String directory;
+    late final String filename;
 
     gemmaLog(
       '🔵 _downloadWithSmartRetry called - attempt $currentAttempt/$maxRetries',
     );
     gemmaLog('🔵 URL: $url');
     gemmaLog('🔵 Target: $targetPath');
-    gemmaLog('🔵 TaskId: $taskId');
 
     // Declare listener outside try block so it's accessible in catch
     StreamSubscription? listener;
 
     try {
+      (baseDirectory, directory, filename) = await Task.split(
+        filePath: targetPath,
+      );
+      taskId = computeTaskId(baseDirectory, directory, filename);
+      gemmaLog('🔵 TaskId: $taskId');
+
       final downloader = FileDownloader();
 
       // Check if task already exists (e.g., after app restart or sleep/wake)
@@ -567,10 +589,6 @@ class SmartDownloader {
         await completer.future;
         return;
       }
-
-      final (baseDirectory, directory, filename) = await Task.split(
-        filePath: targetPath,
-      );
 
       // Auto-detect allowPause based on URL
       // HuggingFace uses weak ETags - resume not reliable

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -90,7 +90,12 @@ ResumeAction decideFailedDownloadAction({
 /// - Auto-detects resume support based on server (HuggingFace = no resume)
 /// - Android foreground service for large files (>500MB by default)
 class SmartDownloader {
-  static const String _downloadGroup = 'smart_downloads';
+  /// The background_downloader task group ALL model downloads run under.
+  /// Single source of truth — cleanup / resume code that queries or resets
+  /// tasks must use this exact group, or it operates on an empty set and
+  /// silently no-ops (this is what caused the #383 leak amplifier: three call
+  /// sites used the stale literal `'flutter_gemma_downloads'`).
+  static const String downloadGroup = 'smart_downloads';
   static const int _foregroundThresholdMB = 500;
 
   // Track if FileDownloader has been configured
@@ -578,7 +583,7 @@ class SmartDownloader {
       final task = DownloadTask(
         taskId: taskId,
         url: url,
-        group: _downloadGroup,
+        group: downloadGroup,
         headers: token != null
             ? {
                 'Authorization': 'Bearer $token',

--- a/packages/flutter_gemma/lib/mobile/smart_downloader.dart
+++ b/packages/flutter_gemma/lib/mobile/smart_downloader.dart
@@ -494,6 +494,15 @@ class SmartDownloader {
           '🔵 Task $taskId already in progress, attaching to existing...',
         );
 
+        // A paused/killed-mid-download task emits nothing until resumed. The
+        // attach path used to only listen → the watchdog fired → a permanent
+        // wedge (#383/R1). Resume it so it actually makes progress.
+        if (existingTask is DownloadTask &&
+            await downloader.taskCanResume(existingTask)) {
+          gemmaLog('🔵 Existing task $taskId is resumable — resuming');
+          await downloader.resume(existingTask);
+        }
+
         // Create completer to wait for existing task completion
         final completer = Completer<void>();
 
@@ -835,6 +844,11 @@ class SmartDownloader {
       gemmaLog('🔵 Enqueueing task ${task.taskId}...');
       final result = await downloader.enqueue(task);
       gemmaLog('🔵 Enqueue result: $result');
+      if (!result) {
+        throw const DownloadException(
+          DownloadError.network('enqueue() returned false'),
+        );
+      }
 
       // Notify about task ID for cancellation
       onTaskCreated?.call(task.taskId); // ← ADD: Notify task created
@@ -1112,8 +1126,24 @@ class SmartDownloader {
     _resumeWatchdogs[taskId] = armResumeWatchdog(
       progress: progress,
       onTimeout: () {
-        gemmaLog('⏱️ Resume watchdog fired for $taskId — closing as failed');
+        gemmaLog(
+          '⏱️ Resume watchdog fired for $taskId — cancelling + closing as failed',
+        );
         _resumeWatchdogs.remove(taskId);
+        // Cancel the presumed-dead native task and purge its persisted state so
+        // task/metadata/temp don't leak (#383/#4). Fire-and-forget: settling the
+        // install as failed must not wait on native cancellation.
+        final downloader = FileDownloader();
+        unawaited(() async {
+          try {
+            await downloader.cancelTaskWithId(taskId);
+            // ignore: invalid_use_of_visible_for_testing_member
+            final storage = downloader.database.storage;
+            await storage.removeResumeData(taskId);
+            await storage.removePausedTask(taskId);
+            await downloader.database.deleteRecordWithId(taskId);
+          } catch (_) {}
+        }());
         if (!progress.isClosed) {
           progress.addError(
             const DownloadException(

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.3.0
+version: 1.3.1
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma
@@ -28,7 +28,7 @@ dependencies:
   path_provider: ^2.1.4
   plugin_platform_interface: ^2.0.2
   shared_preferences: ^2.5.2
-  background_downloader: ^9.2.3
+  background_downloader: ^9.5.6
   # Native Assets build hooks (for hook/build.dart)
   hooks: ^2.0.0
   code_assets: ^1.2.0

--- a/packages/flutter_gemma/test/core/download_temp_reclaim_sweep_test.dart
+++ b/packages/flutter_gemma/test/core/download_temp_reclaim_sweep_test.dart
@@ -1,0 +1,179 @@
+/// Host-VM coverage for the I/O half of the #383 reclaim: the directory walk
+/// `sweepOrphanedDownloadTemps`. The pure predicate is covered in
+/// `download_temp_reclaim_test.dart`; the on-device test exercises the walk on a
+/// real Android `filesDir` but with `minAge: 0`, which disables the age gate at
+/// the only place the real `stat.modified → age` wiring runs. These tests drive
+/// that wiring end-to-end on a `systemTemp` sandbox with real file mtimes and an
+/// injected `now`, so the "never delete a possibly-live temp" property is
+/// verified through the actual filesystem — no device, no mocks.
+library;
+
+import 'dart:io';
+
+import 'package:flutter_gemma/core/model_management/utils/download_temp_reclaim.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('sweepOrphanedDownloadTemps (#383)', () {
+    late Directory sandbox;
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('sweep_reclaim_');
+    });
+    tearDown(() {
+      if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+    });
+
+    // A fixed reference clock; file mtimes are set relative to it so `age` is
+    // exact and independent of wall-clock during the run.
+    final nowRef = DateTime(2026, 1, 1, 12, 0, 0);
+    const minAge = Duration(minutes: 10);
+    final oldMtime = nowRef.subtract(const Duration(minutes: 30));
+    final freshMtime = nowRef.subtract(const Duration(minutes: 2));
+
+    File writeFile(String name, {required DateTime mtime}) {
+      final f = File(p.join(sandbox.path, name))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      f.setLastModifiedSync(mtime);
+      return f;
+    }
+
+    test('mixed sweep, age gate LIVE: deletes only the old orphan; keeps the '
+        'fresh temp, the keep-set temp, and a real model', () async {
+      final orphan = writeFile(
+        'com.bbflight.background_downloader111',
+        mtime: oldMtime,
+      );
+      final freshOrphan = writeFile(
+        'com.bbflight.background_downloader222',
+        mtime: freshMtime,
+      );
+      final keep = writeFile(
+        'com.bbflight.background_downloader333',
+        mtime: oldMtime,
+      );
+      final model = writeFile('gemma-4-E2B-it.litertlm', mtime: oldMtime);
+
+      final reclaimed = await sweepOrphanedDownloadTemps(
+        sandbox,
+        keepPaths: {keep.path},
+        minAge: minAge,
+        now: nowRef,
+      );
+
+      expect(reclaimed, 1);
+      expect(
+        orphan.existsSync(),
+        isFalse,
+        reason: 'old, unreferenced temp is deleted',
+      );
+      expect(
+        freshOrphan.existsSync(),
+        isTrue,
+        reason: 'fresh temp spared — could be a just-restarted download',
+      );
+      expect(
+        keep.existsSync(),
+        isTrue,
+        reason: 'keep-set temp (pending resume) preserved',
+      );
+      expect(model.existsSync(), isTrue, reason: 'a real model is preserved');
+    });
+
+    test('a fresh orphan alone survives and returns 0 (never unlink a '
+        'possibly-live download via the real mtime path)', () async {
+      final freshOrphan = writeFile(
+        'com.bbflight.background_downloader777',
+        mtime: freshMtime,
+      );
+      final reclaimed = await sweepOrphanedDownloadTemps(
+        sandbox,
+        keepPaths: const {},
+        minAge: minAge,
+        now: nowRef,
+      );
+      expect(reclaimed, 0);
+      expect(freshOrphan.existsSync(), isTrue);
+    });
+
+    test('a single old orphan is deleted and the count is exactly 1', () async {
+      final orphan = writeFile(
+        'com.bbflight.background_downloader1',
+        mtime: oldMtime,
+      );
+      final reclaimed = await sweepOrphanedDownloadTemps(
+        sandbox,
+        keepPaths: const {},
+        minAge: minAge,
+        now: nowRef,
+      );
+      expect(reclaimed, 1);
+      expect(orphan.existsSync(), isFalse);
+    });
+
+    test('a prefix-named SUBDIRECTORY is skipped, never deleted', () async {
+      final subdir = Directory(
+        p.join(sandbox.path, 'com.bbflight.background_downloader_dir'),
+      )..createSync();
+      final reclaimed = await sweepOrphanedDownloadTemps(
+        sandbox,
+        keepPaths: const {},
+        minAge: minAge,
+        now: nowRef,
+      );
+      expect(reclaimed, 0);
+      expect(
+        subdir.existsSync(),
+        isTrue,
+        reason: 'a Directory is not a File; the entity-type guard must skip it',
+      );
+    });
+
+    test(
+      'a prefix-named SYMLINK is skipped and its target is not '
+      'followed/deleted (pins followLinks:false)',
+      () async {
+        // A prefix-named, OLD target: if a future change flipped the walk to
+        // followLinks:true, the link would resolve to this File, pass both the
+        // prefix and age guards, and be deleted — this test would then fail.
+        final target = writeFile('real_target_file', mtime: oldMtime);
+        final link = Link(
+          p.join(sandbox.path, 'com.bbflight.background_downloader_link'),
+        )..createSync(target.path);
+
+        final reclaimed = await sweepOrphanedDownloadTemps(
+          sandbox,
+          keepPaths: const {},
+          minAge: minAge,
+          now: nowRef,
+        );
+
+        expect(reclaimed, 0);
+        expect(
+          link.existsSync(),
+          isTrue,
+          reason:
+              'a Link is not a File under followLinks:false; must be spared',
+        );
+        expect(
+          target.existsSync(),
+          isTrue,
+          reason: 'the symlink target must never be followed and deleted',
+        );
+      },
+      skip: Platform.isWindows
+          ? 'symlink creation needs privilege on Windows'
+          : false,
+    );
+
+    test('a non-existent directory returns 0 without throwing', () async {
+      final gone = Directory(p.join(sandbox.path, 'does_not_exist'));
+      expect(await sweepOrphanedDownloadTemps(gone, keepPaths: const {}), 0);
+    });
+
+    test('an empty directory returns 0', () async {
+      expect(await sweepOrphanedDownloadTemps(sandbox, keepPaths: const {}), 0);
+    });
+  });
+}

--- a/packages/flutter_gemma/test/core/download_temp_reclaim_test.dart
+++ b/packages/flutter_gemma/test/core/download_temp_reclaim_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_gemma/core/model_management/utils/download_temp_reclaim.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const dir = '/data/data/app/files';
+  String p(String name) => '$dir/$name';
+  const old = Duration(minutes: 30);
+  const fresh = Duration(minutes: 2);
+
+  group('shouldReclaimDownloadTemp (#383)', () {
+    test('deletes an old, unreferenced background_downloader temp', () {
+      expect(
+        shouldReclaimDownloadTemp(
+          basename: 'com.bbflight.background_downloader123456',
+          path: p('com.bbflight.background_downloader123456'),
+          keepPaths: const {},
+          age: old,
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps a non-background_downloader file (a real model)', () {
+      expect(
+        shouldReclaimDownloadTemp(
+          basename: 'gemma-4-E2B-it.litertlm',
+          path: p('gemma-4-E2B-it.litertlm'),
+          keepPaths: const {},
+          age: old,
+        ),
+        isFalse,
+      );
+    });
+
+    test('keeps a temp referenced by a valid pending resume (keep-set)', () {
+      final path = p('com.bbflight.background_downloader999');
+      expect(
+        shouldReclaimDownloadTemp(
+          basename: 'com.bbflight.background_downloader999',
+          path: path,
+          keepPaths: {path},
+          age: old,
+        ),
+        isFalse,
+      );
+    });
+
+    test('keeps a FRESH temp — mtime guard is "older than", never delete a '
+        'possibly-live download (the architect-flagged direction)', () {
+      expect(
+        shouldReclaimDownloadTemp(
+          basename: 'com.bbflight.background_downloader777',
+          path: p('com.bbflight.background_downloader777'),
+          keepPaths: const {},
+          age: fresh,
+        ),
+        isFalse,
+      );
+    });
+
+    test('deletes exactly at the age boundary (>= minAge deletes)', () {
+      // age == minAge is not "< minAge", so it is reclaimable.
+      expect(
+        shouldReclaimDownloadTemp(
+          basename: 'com.bbflight.background_downloader1',
+          path: p('com.bbflight.background_downloader1'),
+          keepPaths: const {},
+          age: kDownloadTempMinReclaimAge,
+        ),
+        isTrue,
+      );
+      // One tick younger is spared.
+      expect(
+        shouldReclaimDownloadTemp(
+          basename: 'com.bbflight.background_downloader1',
+          path: p('com.bbflight.background_downloader1'),
+          keepPaths: const {},
+          age: kDownloadTempMinReclaimAge - const Duration(seconds: 1),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/packages/flutter_gemma/test/core/download_temp_reclaim_test.dart
+++ b/packages/flutter_gemma/test/core/download_temp_reclaim_test.dart
@@ -81,4 +81,93 @@ void main() {
       );
     });
   });
+
+  group('reconcileResumeRecord (#383/R2)', () {
+    const old = Duration(minutes: 30);
+    const fresh = Duration(minutes: 2);
+
+    test('current-scheme record (taskId == expectedId) → keep', () {
+      expect(
+        reconcileResumeRecord(
+          taskId: 'abc',
+          expectedId: 'abc',
+          isNativeRunning: false,
+          tempAge: old,
+        ),
+        ReclaimDecision.keep,
+      );
+    });
+
+    test(
+      'current-scheme id with a FRESH temp still → keep (precedence guard)',
+      () {
+        // taskId == expectedId must win over the tempAge < minAge → skip branch;
+        // this pins the branch ORDER so a future reorder can't misclassify a valid
+        // current-scheme record as skip.
+        expect(
+          reconcileResumeRecord(
+            taskId: 'abc',
+            expectedId: 'abc',
+            isNativeRunning: false,
+            tempAge: fresh,
+          ),
+          ReclaimDecision.keep,
+        );
+      },
+    );
+
+    test(
+      'legacy record that WorkManager is running → keep (do not corrupt a live write)',
+      () {
+        expect(
+          reconcileResumeRecord(
+            taskId: 'legacy',
+            expectedId: 'sha',
+            isNativeRunning: true,
+            tempAge: old,
+          ),
+          ReclaimDecision.keep,
+        );
+      },
+    );
+
+    test('legacy, not running, old temp → purge', () {
+      expect(
+        reconcileResumeRecord(
+          taskId: 'legacy',
+          expectedId: 'sha',
+          isNativeRunning: false,
+          tempAge: old,
+        ),
+        ReclaimDecision.purge,
+      );
+    });
+
+    test(
+      'legacy, not running, FRESH temp → skip (rescheduleKilledTasks race guard)',
+      () {
+        expect(
+          reconcileResumeRecord(
+            taskId: 'legacy',
+            expectedId: 'sha',
+            isNativeRunning: false,
+            tempAge: fresh,
+          ),
+          ReclaimDecision.skip,
+        );
+      },
+    );
+  });
+
+  group('isDownloadFragmentName (#383/#3)', () {
+    test('a background_downloader temp basename → true', () {
+      expect(
+        isDownloadFragmentName('com.bbflight.background_downloader1234'),
+        isTrue,
+      );
+    });
+    test('a model file → false', () {
+      expect(isDownloadFragmentName('gemma-4-E2B-it.litertlm'), isFalse);
+    });
+  });
 }

--- a/packages/flutter_gemma/test/mobile/download_task_id_test.dart
+++ b/packages/flutter_gemma/test/mobile/download_task_id_test.dart
@@ -1,0 +1,52 @@
+import 'package:background_downloader/background_downloader.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_gemma/mobile/smart_downloader.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('computeTaskId (#383/#2)', () {
+    test('is a deterministic sha256 hex of the split triple', () {
+      final id = computeTaskId(
+        BaseDirectory.applicationSupport,
+        'models',
+        'g.task',
+      );
+      expect(
+        id,
+        sha256.convert('applicationSupport|models|g.task'.codeUnits).toString(),
+      );
+      expect(id.length, 64);
+    });
+
+    test('each triple component independently changes the id', () {
+      const base = BaseDirectory.applicationSupport;
+      final baseline = computeTaskId(base, 'models', 'm.task');
+      expect(
+        computeTaskId(BaseDirectory.applicationDocuments, 'models', 'm.task'),
+        isNot(baseline),
+        reason: 'baseDirectory feeds the hash',
+      );
+      expect(
+        computeTaskId(base, 'other', 'm.task'),
+        isNot(baseline),
+        reason: 'directory feeds the hash',
+      );
+      expect(
+        computeTaskId(base, 'models', 'n.task'),
+        isNot(baseline),
+        reason: 'filename feeds the hash',
+      );
+    });
+
+    test('id is a total function of the triple — same triple, same id', () {
+      // Determinism is the property the reclaim reconciliation relies on: a
+      // record recomputes to its own id across runs. url is not an input (a
+      // rotated signed URL cannot change it); the absolute-path invariance (R3,
+      // iOS container churn) is exercised end-to-end in the device test.
+      expect(
+        computeTaskId(BaseDirectory.applicationSupport, 'models', 'm.task'),
+        computeTaskId(BaseDirectory.applicationSupport, 'models', 'm.task'),
+      );
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: background_downloader
-      sha256: aceacec2b2a72ec3a8862ab5895fcbbc71ab33765f3619d57963f3110dd268e3
+      sha256: d27fcaf94f738032f1e6db098230799bf31ae7bf184f173fc9a752fcdae75c0e
       url: "https://pub.dev"
     source: hosted
-    version: "9.5.5"
+    version: "9.5.6"
   boolean_selector:
     dependency: transitive
     description:

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.3.0
+  flutter_gemma: ^1.3.1
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.1.0   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,7 +29,7 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.3.0                 # core — always required
+  flutter_gemma: ^1.3.1                 # core — always required
   flutter_gemma_litertlm: ^1.1.0        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.2      # add if you compute embeddings


### PR DESCRIPTION
## What

Failed / cancelled / process-killed large-file model downloads leaked multi-GB `background_downloader` temp files (`com.bbflight.background_downloader<rand>`) in Android `filesDir` — persistent internal storage the OS never reclaims. Reported in #383 with an exceptionally detailed source-level breakdown by @alan-insam. Fixes all five findings plus the migration needed to make the task-ID change regression-free.

## Changes

- **#1 group mismatch** — one `SmartDownloader.downloadGroup` constant; every cleanup / resume call site routed through it (three used the stale `flutter_gemma_downloads` literal ≠ the `smart_downloads` group downloads run under — the leak amplifier).
- **#2 non-deterministic task IDs** — `sha256` of the stable `Task.split` triple (baseDirectory / directory / filename), not `hashCode` and not the URL. Stable across process restarts, signed-URL rotation, and iOS app-container UUID churn.
- **#3 / #6 invisible fragments** — `getOrphanedFiles()` now scans `filesDir` for `com.bbflight.background_downloader*` temps (flagged `isDownloadFragment`); `cleanupStorage()` deletes them.
- **#4 watchdog leak** — the resume watchdog now cancels the native task and purges its resume/paused/db records before failing; the attach path calls `resume()` on a recovered paused task instead of stalling until timeout.
- **#5 reset vs cancel** — cleanup cancels tasks (which deletes paused temp files) before `reset()`; `performCleanup` whole-group, `_cleanupAllTasksOfType` type-scoped.

### Anti-regression migration

Legacy resume records written by a pre-1.3.1 version are reconciled and purged at startup **before** the reclaim gate — a `resumeFromBackground()`-materialized paused record no longer wedges it — and the blanket sweep only skips when a task is genuinely running (`nativeRunningIds = allTasks − pausedTasks`), with a 10-min mtime guard against a just-rescheduled download.

## Behaviour notes

- The plugin now drives the process's first `resumeFromBackground()`.
- A partial from an older plugin version is reclaimed on next launch (its record is reconciled), not silently stranded.
- Android-only: reclaim + fragment scan are `Platform.isAndroid`-gated; iOS/macOS/web unaffected (the id-scheme change on iOS is a net improvement — stable across container-UUID rotation).

## Verification

- Host-VM: `flutter analyze` 0 errors/warnings, `flutter test` 470/470, `flutter build web` clean.
- Cross-platform compile: iOS, macOS, and Android `--release` all build clean.
- Device (Firebase Test Lab, Galaxy S23 Ultra / Android 14): 4/4 tests pass — orphan-fragment cleanup and the legacy-record reconciliation verified against real `background_downloader` storage.

Targets `flutter_gemma` 1.3.1. Pins `background_downloader ^9.5.6`.

Fixes #383
