### PR TITLE
docs: v0.14.0 follow-up consistency fixes

### DIFF
--- a/packages/flutter_gemma/MIGRATION.md
+++ b/packages/flutter_gemma/MIGRATION.md
@@ -47,6 +47,12 @@ Pick by what you actually used in 0.16.x:
 > You can add **both** engine packages and let the registry route each model by
 > its file type.
 
+> **New opt-in packages since 1.2/1.3** (not migration targets from the 0.16.x
+> monolith — they add new capabilities): `flutter_gemma_agent` (on-device agent
+> skills — SKILL.md + tool-calling loop) and `flutter_gemma_builtin_ai` (OS
+> system models — Gemini Nano on Android, Apple Foundation Models on iOS/macOS).
+> Add either only if you want that feature — see the README **Features** list.
+
 ## 2. main.dart — the one new call
 
 **Before (0.16.x):** engines were bundled into core; `initialize()` was optional.

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -7,7 +7,7 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/flutter_gemma)
 
-**The plugin supports not only Gemma, but also other models. Here's the full list of supported models:** [Gemma 4 E2B/E4B](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm), [Gemma3n E2B/E4B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview), [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B), [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT), [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it), [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it), [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B), [Qwen 2.5](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct), [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct), [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B), [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct), [SmolLM3 3B](https://huggingface.co/litert-community/SmolLM3-3B), [Phi-4 Mini Reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning), [Qwen2-VL 2B](https://huggingface.co/litert-community/Qwen2-VL-2B), [SmolVLM2 500M](https://huggingface.co/litert-community/SmolVLM2-500M), [LLaVA-OneVision 0.5B](https://huggingface.co/litert-community/LLaVA-OneVision-0.5B).
+**The plugin supports not only Gemma, but also other models. Here's the full list of supported models:** [Gemma 4 E2B/E4B](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm), [Gemma3n E2B/E4B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview), [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B), [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT), [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it), [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it), [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B), [Qwen 2.5](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct), [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct), [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B), [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct), [SmolLM3 3B](https://huggingface.co/litert-community/SmolLM3-3B), [Phi-4 Mini Reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning), [Qwen2-VL 2B](https://huggingface.co/litert-community/Qwen2-VL-2B), [SmolVLM2 500M](https://huggingface.co/litert-community/SmolVLM2-500M), [LLaVA-OneVision 0.5B](https://huggingface.co/litert-community/LLaVA-OneVision-0.5B), [TranslateGemma 4B](https://huggingface.co/google/translategemma-4b-it) (CPU-only).
 
 *Note: The flutter_gemma plugin supports Gemma 4 and Gemma3n (with **multimodal vision and audio support**), FastVLM, Qwen2-VL, SmolVLM2 and LLaVA-OneVision (vision), Gemma-3, FunctionGemma, Qwen3, Qwen 2.5, Phi-4 (incl. Phi-4 Mini Reasoning), DeepSeek R1, SmolLM and SmolLM3. Desktop platforms (macOS, Windows, Linux) require `.litertlm` model format.
 
@@ -1029,7 +1029,7 @@ await FlutterGemma.installModel(
 - ✅ **EmbeddingGemma** - `litert-community/` requires access
 
 **Public models (no auth needed):**
-- ❌ **DeepSeek, Qwen3, Qwen 2.5, SmolLM, Phi-4, FastVLM** - Public repos
+- ❌ **DeepSeek, Qwen3, Qwen 2.5, SmolLM, SmolLM3, Phi-4, FastVLM, Qwen2-VL, SmolVLM2, LLaVA-OneVision** - Public repos
 
 **Get your token:** https://huggingface.co/settings/tokens
 
@@ -1554,6 +1554,9 @@ chat.generateChatResponseAsync().listen((response) {
 | [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct) | 3.9GB | ✅ | ✅ | ✅ |
 | [Phi-4 Mini Reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning) | 2.8GB | ✅ | ✅ | ❌ |
 | [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B) | 1.7GB | ❌ | ✅ | ❌ |
+| [TranslateGemma 4B](https://huggingface.co/google/translategemma-4b-it) † | 2-4GB | ❌ | ✅ | ❌ |
+
+† **TranslateGemma is CPU-only** and ships only as a community MediaPipe `.task` bundle ([`barakplasma/translategemma-4b-it-android-task-quantized`](https://huggingface.co/barakplasma/translategemma-4b-it-android-task-quantized)) — there's no desktop `.litertlm` build, and its float32 `EMBEDDING_LOOKUP` layout crashes the LiteRT GPU partitioner on Metal/WebGPU, so it does not run on Desktop or Web. See the [Model Capabilities](#model-capabilities) note for details.
 
 ### 📊 Text Embedding Models
 

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -19,7 +19,7 @@ SmolLM and more — see [Models](/docs/models) for the full list.
 - **Local Execution:** Run Gemma and other LLMs (Qwen, DeepSeek, Phi, FastVLM, SmolLM, …) directly on user devices for enhanced privacy and offline functionality.
 - **Platform Support:** Compatible with iOS, Android, Web, macOS, Windows, and Linux.
 - **Desktop Support:** Native desktop apps with GPU acceleration via LiteRT-LM, called directly from Dart through `dart:ffi` — no JVM/JRE bundling. See [Desktop Support](/docs/desktop).
-- **Multimodal Support:** Text + image input with Gemma 4, Gemma3n, and FastVLM vision models. See [Multimodal](/docs/multimodal).
+- **Multimodal Support:** Text + image input with Gemma 4, Gemma3n, FastVLM, Qwen2-VL, SmolVLM2, and LLaVA-OneVision vision models. See [Multimodal](/docs/multimodal).
 - **Audio Input:** Record and send audio messages with Gemma 4 and Gemma3n models (Android, iOS device, Desktop).
 - **Function Calling:** Let models call external functions and integrate with other services. See [Function Calling](/docs/function-calling).
 - **Agent Skills:** Give the model a catalog of `SKILL.md` skills it picks and runs itself — text, JS, native intents, or MCP tools. See [Agent Skills](/docs/agent).

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -35,7 +35,6 @@ dependencies:
   flutter_gemma_embeddings: ^1.0.3      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)
   flutter_gemma_rag_sqlite: ^1.1.0      # add for on-device RAG (sqlite-vec; all platforms incl. web)
-  flutter_gemma_agent: ^0.1.0           # add for on-device agent skills (SKILL.md + tool-calling loop)
 ```
 
 Pick by what you actually used in 0.16.x:
@@ -54,6 +53,12 @@ Not sure which format your models are? Desktop is always `.litertlm`
 You can add **both** engine packages and let the registry route each model by its
 file type.
 </Info>
+
+> **New opt-in packages since 1.2/1.3** (not migration targets from the 0.16.x
+> monolith — they add new capabilities): `flutter_gemma_agent` (on-device agent
+> skills — SKILL.md + tool-calling loop) and `flutter_gemma_builtin_ai` (OS
+> system models — Gemini Nano on Android, Apple Foundation Models on iOS/macOS).
+> Add either only if you want that feature. See [Getting Started](/docs/getting-started).
 
 ## 2. main.dart — the one new call
 

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -148,7 +148,7 @@ await FlutterGemma.installModel(modelType: ModelType.general)
 | [LLaVA-OneVision 0.5B](https://huggingface.co/litert-community/LLaVA-OneVision-0.5B) | 0.83GB | ✅ | ✅ | ❌ |
 | [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT) | 0.5GB | ✅ | ✅ | ✅ |
 | [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it) | 0.3GB | ✅ | ✅ | ✅ |
-| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ✅ |
+| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ❌ |
 | [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ✅ |
 | [Qwen 2.5 1.5B](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct) | 1.6GB | ✅ | ✅ | ❌ |
 | [Qwen 2.5 0.5B](https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct) | 0.5GB | ❌ | ✅ | ❌ |


### PR DESCRIPTION
Doc-only consistency follow-up after the v0.14.0 release (PR #387) — the nice-to-have items surfaced by the doc review that weren't in the release.

- **FunctionGemma 270M Web mark → ❌** — website `models.md` said Web ✅ while the README said ❌; web `.litertlm` has no function calling, so ❌ is correct. Now consistent.
- **TranslateGemma 4B** added to the README top supported-models list + the Platform-Support download table (with the CPU-only footnote) — was capabilities-table-only before.
- **README public-models (no-auth) list** — added SmolLM3, Qwen2-VL, SmolVLM2, LLaVA-OneVision.
- **Migration guides** — `flutter_gemma_agent` / `flutter_gemma_builtin_ai` are post-1.0 packages (agent in 1.2, builtin_ai in 1.3), not migrate-from-0.16.x targets, so they're moved out of the "your 0.16.3 deps" dependency block into a dedicated "new opt-in packages since 1.2/1.3" note (both `MIGRATION.md` and website `migration.md`).
- **getting-started.md** multimodal list — added Qwen2-VL / SmolVLM2 / LLaVA-OneVision.

`jaspr build` verified (no SSG errors). No code, docs only.
