### PR TITLE
chore(website): flutter_gemma_litertlm ^1.3.0 → ^1.3.1

### DIFF
--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -23,7 +23,7 @@ dependencies:
   genkit_flutter_gemma: ^0.4.3
   flutter_gemma: ^1.4.0
   # Add the inference engine(s) you need:
-  flutter_gemma_litertlm: ^1.3.0   # .litertlm models (mobile + desktop)
+  flutter_gemma_litertlm: ^1.3.1   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
   flutter_gemma_embeddings: ^1.0.4

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -30,7 +30,7 @@ dependencies:
 ```
 dependencies:
   flutter_gemma: ^1.4.0                 # core — always required
-  flutter_gemma_litertlm: ^1.3.0        # add if you run .litertlm models
+  flutter_gemma_litertlm: ^1.3.1        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.4      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)


### PR DESCRIPTION
Reflect the just-published `flutter_gemma_litertlm` 1.3.1 in the docs pubspec snippets (`genkit.md`, `migration.md`). Follow-up to #393 (#390 GPU-only backend error + example CPU-default fix). Deferred until after publish so `pub get` on the copied snippet never lags the published version.