### PR TITLE
docs: fix stale version pins + TTS README/CLAUDE coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,11 @@ flutter_gemma/                       # Dart pub workspace (monorepo root)
 │   ├── flutter_gemma_mediapipe/     # .task MediaPipe (own pigeon + Kotlin + Swift + web JS)
 │   ├── flutter_gemma_rag_qdrant/    # native RAG (qdrant-edge Rust FFI)
 │   ├── flutter_gemma_rag_sqlite/    # SQLite RAG — in-SQLite vec0 KNN (native sqlite3 FFI + web wasm)
-│   └── flutter_gemma_builtin_ai/    # OS built-in AI — Gemini Nano (Android) / Apple Foundation Models (iOS/macOS)
+│   ├── flutter_gemma_builtin_ai/    # OS built-in AI — Gemini Nano (Android) / Apple Foundation Models (iOS/macOS)
+│   ├── flutter_gemma_speech/        # opt-in on-device STT (moonshine) + TTS (Matcha) via LiteRT C API (shares libLiteRtLm)
+│   ├── flutter_gemma_agent/         # opt-in on-device agent skills (SKILL.md: text/JS/native-intent/MCP) over the function-calling loop
+│   ├── genkit_flutter_gemma/        # Firebase Genkit integration (flutter_gemma runtime + converters)
+│   └── genkit_hybrid/               # Genkit hybrid on-device + cloud helpers
 └── docs/                            # design docs, testing, benchmarks
 ```
 

--- a/packages/flutter_gemma/DESKTOP_SUPPORT.md
+++ b/packages/flutter_gemma/DESKTOP_SUPPORT.md
@@ -99,8 +99,8 @@ No Java/JVM/JRE required.
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_gemma: ^1.4.0            # core
-  flutter_gemma_litertlm: ^1.3.0   # .litertlm engine — required on desktop
+  flutter_gemma: ^1.4.1            # core
+  flutter_gemma_litertlm: ^1.3.1   # .litertlm engine — required on desktop
 ```
 
 ```dart

--- a/packages/flutter_gemma/MIGRATION.md
+++ b/packages/flutter_gemma/MIGRATION.md
@@ -24,8 +24,8 @@ dependencies:
 **After (1.0):**
 ```yaml
 dependencies:
-  flutter_gemma: ^1.4.0                 # core — always required
-  flutter_gemma_litertlm: ^1.3.0        # add if you run .litertlm models
+  flutter_gemma: ^1.4.1                 # core — always required
+  flutter_gemma_litertlm: ^1.3.1        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.4      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -34,6 +34,7 @@ There is an example of using:
 - **🖼️ Multimodal Support:** Text + Image input with Gemma 4, Gemma3n, FastVLM, Qwen2-VL, SmolVLM2, and LLaVA-OneVision vision models (Gemma 4 / Gemma3n on all platforms incl. Web; Qwen2-VL / SmolVLM2 / LLaVA-OneVision on Android, iOS, and Desktop; FastVLM on Desktop)
 - **🎙️ Audio Input:** Record and send audio messages with Gemma 4 and Gemma3n E2B/E4B models (Android, iOS device, macOS/Windows/Linux via LiteRT-LM — not on Web)
 - **🎤 On-device Speech-to-Text:** Opt-in [`flutter_gemma_speech`](https://pub.dev/packages/flutter_gemma_speech) — transcribe audio fully offline with a selectable ASR model (moonshine today; Whisper / Parakeet profiles are follow-ons) via the LiteRT C API (Android, iOS, macOS, Windows, Linux; Web is a follow-on)
+- **🔊 On-device Text-to-Speech:** Opt-in [`flutter_gemma_speech`](https://pub.dev/packages/flutter_gemma_speech) — synthesize speech fully offline with a selectable model (Matcha today; kokoro / supertonic are follow-ons) via the LiteRT C API (Android, iOS, macOS, Windows, Linux; Web is a follow-on)
 - **🛠️ Function Calling:** Enable your models to call external functions and integrate with other services (supported by select models)
 - **🤖 On-device Agent Skills:** Opt-in [`flutter_gemma_agent`](https://pub.dev/packages/flutter_gemma_agent) — give the model `SKILL.md` skills (text / JavaScript / native-intent / MCP) it invokes through the function-calling loop, fully offline. Gallery-compatible. Android, iOS, macOS, Windows (Web not supported yet).
 - **🧠 Thinking Mode:** View the reasoning process of Gemma 4, DeepSeek R1, Qwen3, SmolLM3, and Phi-4 Mini Reasoning models with thinking blocks
@@ -1694,6 +1695,7 @@ Function calling is currently supported by the following models:
 | **Image Input (Multimodal)** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Verified on macOS Metal and Linux Vulkan (Gemma 4 + Gemma 3n) |
 | **Audio Input** | ✅ Full | ✅ Full ¹ | ❌ Not supported | ✅ `.litertlm` only | Gemma3n E2B/E4B + Gemma 4; iOS device-only; Desktop via FFI |
 | **Speech-to-Text** | ✅ Full | ✅ Full | ❌ Not supported | ✅ Full | `flutter_gemma_speech` (moonshine ASR); native only, arm64 on Android |
+| **Text-to-Speech** | ✅ Full | ✅ Full | ❌ Not supported | ✅ Full | `flutter_gemma_speech` (Matcha); native only, arm64 on Android |
 | **Function Calling** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Gemma 4 native (SDK chat template) |
 | **Thinking Mode** | ✅ Full | ✅ Full | ❌ Not supported | ✅ Full | Gemma 4 / DeepSeek / Qwen3 / SmolLM3 / Phi-4 Mini Reasoning; not available on Web yet (MediaPipe `.task` web has no `extraContext`; `.litertlm` web is not verified) |
 | **Stop Generation** | ✅ Full | ✅ Full | ✅ Full | ✅ Full | Cancel mid-process |

--- a/packages/genkit_flutter_gemma/README.md
+++ b/packages/genkit_flutter_gemma/README.md
@@ -46,11 +46,11 @@ register their providers in `FlutterGemma.initialize()`.
 ```yaml
 # pubspec.yaml (your app)
 dependencies:
-  genkit_flutter_gemma: ^0.4.0
-  flutter_gemma: ^1.0.0
-  flutter_gemma_litertlm: ^1.0.0   # only the engines/backends you actually use
-  flutter_gemma_mediapipe: ^1.0.0
-  flutter_gemma_embeddings: ^1.0.0
+  genkit_flutter_gemma: ^0.4.3
+  flutter_gemma: ^1.4.1
+  flutter_gemma_litertlm: ^1.3.1   # only the engines/backends you actually use
+  flutter_gemma_mediapipe: ^1.0.4
+  flutter_gemma_embeddings: ^1.0.4
 ```
 
 ```dart


### PR DESCRIPTION
Documentation-correctness pass against the published 1.4.1 / 0.2.0 state (found via a full docs + website audit).

### Stale version pins → published versions
- `packages/genkit_flutter_gemma/README.md` — install snippet was still on the 1.0-cut pins (`^0.4.0` / `^1.0.0`); bumped to `0.4.3` / `1.4.1` / `1.3.1` / `1.0.4`.
- `packages/flutter_gemma/MIGRATION.md`, `DESKTOP_SUPPORT.md` — `flutter_gemma ^1.4.0` → `^1.4.1`, `flutter_gemma_litertlm ^1.3.0` → `^1.3.1` (the website copies were already correct).

### README completeness
- Core README: added the **Text-to-Speech** feature bullet and the **Text-to-Speech** row in the Feature Comparison table (TTS shipped in 1.4.1 but was only mentioned in the What's-new blurb).

### Internal consistency
- `CLAUDE.md`: the `packages/` tree listed only the six 1.0-cut packages; added `flutter_gemma_speech`, `flutter_gemma_agent`, `genkit_flutter_gemma`, `genkit_hybrid`.

No capability claims were changed — the audit confirmed every TTS example uses the one input verified to work in 0.2.0, and all follow-on features (voice loop, kokoro/supertonic, Whisper/Parakeet) remain correctly labeled. Docs-only; no code, no dependency, no website change.
