### PR TITLE
feat(speech): robust model-agnostic TTS text frontend + neural G2P (0.3.0)

### DIFF
--- a/packages/flutter_gemma/example/integration_test/tts_neural_g2p_test.dart
+++ b/packages/flutter_gemma/example/integration_test/tts_neural_g2p_test.dart
@@ -1,0 +1,71 @@
+// On-device neural G2P (dp_g2p graph) e2e — installs the Matcha-TTS bundle
+// and drives `TtsCore.neuralG2p` directly (not the public synthesize() API)
+// to verify the 4th LiteRT graph loads and produces IPA phonemes for words
+// that need the neural OOV fallback.
+//
+// NOTE: this test runs ON-DEVICE and its actual run is DEFERRED to Task 12
+// (this machine's disk is tight; Task 7 only wrote the code + this file).
+//
+// This reaches into `flutter_gemma_speech`'s `lib/src/...` (TtsCore,
+// TtsModelProfile) rather than the public barrel — TtsCore.neuralG2p is not
+// (yet) exposed on the public SpeechSynthesizer surface, and this test's
+// purpose is to white-box-verify the graph load + decode, mirroring how
+// `tts_core_test.dart` (package-internal unit tests) already imports
+// `package:flutter_gemma_speech/src/litert/tts_core.dart`.
+//
+// Run: cd packages/flutter_gemma/example && \
+//   flutter test integration_test/tts_neural_g2p_test.dart -d macos
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart'
+    show FlutterGemma, FlutterGemmaPlugin, TtsModelSpec, TtsModelType;
+import 'package:flutter_gemma_speech/flutter_gemma_speech.dart'
+    show LiteRtTtsBackend;
+import 'package:flutter_gemma_speech/src/litert/tts_core.dart' show TtsCore;
+import 'package:flutter_gemma_speech/src/model/tts_model_profile.dart'
+    show TtsModelProfile;
+
+const _modelUrl =
+    'https://huggingface.co/litert-community/Matcha-TTS/resolve/main/';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'neuralG2p produces IPA phonemes via the dp_g2p graph',
+    (_) async {
+      await FlutterGemma.initialize(ttsBackends: const [LiteRtTtsBackend()]);
+
+      await FlutterGemma.installTts()
+          .fromNetwork(_modelUrl)
+          .ofType(TtsModelType.matcha)
+          .install();
+
+      final manager = FlutterGemmaPlugin.instance.modelManager;
+      final activeModel = manager.activeTtsModel;
+      if (activeModel is! TtsModelSpec) {
+        fail('No active TTS model after install()');
+      }
+      final artifactPaths = await manager.getModelFilePaths(activeModel);
+      if (artifactPaths == null || artifactPaths.isEmpty) {
+        fail('Active TTS model files not found on disk');
+      }
+
+      final core = await TtsCore.load(
+        profile: TtsModelProfile.forType(activeModel.ttsModelType),
+        artifactPaths: artifactPaths,
+      );
+
+      try {
+        expect(core.neuralG2p('world'), 'wˈɜːld');
+
+        final chomsky = core.neuralG2p('chomsky');
+        expect(chomsky, isNotEmpty);
+        expect(chomsky.contains('ˈ'), isTrue);
+      } finally {
+        core.dispose();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+}

--- a/packages/flutter_gemma/example/integration_test/tts_robustness_test.dart
+++ b/packages/flutter_gemma/example/integration_test/tts_robustness_test.dart
@@ -185,4 +185,39 @@ void main() {
     },
     timeout: const Timeout(Duration(minutes: 10)),
   );
+
+  testWidgets(
+    'non-speech clause: "Sounds good! 👍" skips the emoji clause and still speaks the rest',
+    (_) async {
+      await FlutterGemma.initialize(ttsBackends: const [LiteRtTtsBackend()]);
+
+      await FlutterGemma.installTts()
+          .fromNetwork(_modelUrl)
+          .ofType(TtsModelType.matcha)
+          .install();
+
+      final synth = await FlutterGemma.getActiveTts();
+
+      try {
+        // The "👍" clause maps to zero symbols; the fix skips it instead of
+        // erroring the whole request, so "Sounds good!" still synthesizes.
+        final pcm = await synth.synthesize('Sounds good! 👍');
+        final rms = _rms(pcm);
+
+        debugPrint(
+          'TTS-ROBUST<<<case=non_speech_clause bytes=${pcm.length} rms=${rms.toStringAsFixed(4)}>>>',
+        );
+
+        expect(pcm.isNotEmpty, isTrue, reason: 'PCM output was empty');
+        expect(
+          rms,
+          greaterThan(0.02),
+          reason: 'RMS too close to silence: $rms',
+        );
+      } finally {
+        await synth.close();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
 }

--- a/packages/flutter_gemma/example/integration_test/tts_robustness_test.dart
+++ b/packages/flutter_gemma/example/integration_test/tts_robustness_test.dart
@@ -1,0 +1,188 @@
+// On-device robustness gate (Task 12) — run by the controller:
+//   flutter test integration_test/tts_robustness_test.dart -d <device>
+//
+// Exercises the robust TTS text frontend (punctuation-as-symbols,
+// numbers/acronyms, neural OOV G2P, clause chunking) end-to-end through the
+// public API (initialize -> installTts -> getActiveTts -> synthesize),
+// asserting each case completes without throwing and produces non-silent
+// PCM. This is a TOLERANCE/behavioral gate, not a byte-exact oracle (that is
+// `tts_matcha_test.dart`'s job on the clean "Hello world." path).
+//
+// NOTE: the >MAX_MEL single-clause overflow case is covered by a Task-3 unit
+// test (deterministic input length) and is intentionally NOT duplicated here
+// — reliably driving text past the mel-frame ceiling via natural text is
+// flaky by construction.
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart'
+    show FlutterGemma, TtsModelType;
+import 'package:flutter_gemma_speech/flutter_gemma_speech.dart'
+    show LiteRtTtsBackend;
+
+const _modelUrl =
+    'https://huggingface.co/litert-community/Matcha-TTS/resolve/main/';
+
+double _rms(Uint8List pcm) {
+  final samples = Int16List.sublistView(pcm);
+  var sumSquares = 0.0;
+  for (final s in samples) {
+    sumSquares += (s / 32768.0) * (s / 32768.0);
+  }
+  return math.sqrt(sumSquares / samples.length);
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'punctuation: "Sure, I can help with that." synthesizes without throwing (non-silent)',
+    (_) async {
+      await FlutterGemma.initialize(ttsBackends: const [LiteRtTtsBackend()]);
+
+      await FlutterGemma.installTts()
+          .fromNetwork(_modelUrl)
+          .ofType(TtsModelType.matcha)
+          .install();
+
+      final synth = await FlutterGemma.getActiveTts();
+
+      try {
+        final pcm = await synth.synthesize('Sure, I can help with that.');
+        final rms = _rms(pcm);
+
+        debugPrint(
+          'TTS-ROBUST<<<case=punctuation bytes=${pcm.length} rms=${rms.toStringAsFixed(4)}>>>',
+        );
+
+        expect(pcm.isNotEmpty, isTrue, reason: 'PCM output was empty');
+        expect(
+          rms,
+          greaterThan(0.02),
+          reason: 'RMS too close to silence: $rms',
+        );
+      } finally {
+        await synth.close();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+
+  testWidgets(
+    'number: "Meet in 2023." synthesizes without throwing (non-silent, verifies number normalization)',
+    (_) async {
+      await FlutterGemma.initialize(ttsBackends: const [LiteRtTtsBackend()]);
+
+      await FlutterGemma.installTts()
+          .fromNetwork(_modelUrl)
+          .ofType(TtsModelType.matcha)
+          .install();
+
+      final synth = await FlutterGemma.getActiveTts();
+
+      try {
+        final pcm = await synth.synthesize('Meet in 2023.');
+        final rms = _rms(pcm);
+
+        debugPrint(
+          'TTS-ROBUST<<<case=number bytes=${pcm.length} rms=${rms.toStringAsFixed(4)}>>>',
+        );
+
+        expect(pcm.isNotEmpty, isTrue, reason: 'PCM output was empty');
+        expect(
+          rms,
+          greaterThan(0.02),
+          reason: 'RMS too close to silence: $rms',
+        );
+      } finally {
+        await synth.close();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+
+  testWidgets(
+    'OOV via neural: "Chomsky syntax." synthesizes without throwing (non-silent, routes through dp_g2p)',
+    (_) async {
+      await FlutterGemma.initialize(ttsBackends: const [LiteRtTtsBackend()]);
+
+      await FlutterGemma.installTts()
+          .fromNetwork(_modelUrl)
+          .ofType(TtsModelType.matcha)
+          .install();
+
+      final synth = await FlutterGemma.getActiveTts();
+
+      try {
+        final pcm = await synth.synthesize('Chomsky syntax.');
+        final rms = _rms(pcm);
+
+        debugPrint(
+          'TTS-ROBUST<<<case=oov_neural bytes=${pcm.length} rms=${rms.toStringAsFixed(4)}>>>',
+        );
+
+        expect(pcm.isNotEmpty, isTrue, reason: 'PCM output was empty');
+        expect(
+          rms,
+          greaterThan(0.02),
+          reason: 'RMS too close to silence: $rms',
+        );
+      } finally {
+        await synth.close();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+
+  testWidgets(
+    'chunking: "One. Two. Three." (3 clauses) synthesizes without throwing and is longer than a one-clause clip',
+    (_) async {
+      await FlutterGemma.initialize(ttsBackends: const [LiteRtTtsBackend()]);
+
+      await FlutterGemma.installTts()
+          .fromNetwork(_modelUrl)
+          .ofType(TtsModelType.matcha)
+          .install();
+
+      final synth = await FlutterGemma.getActiveTts();
+
+      try {
+        // Baseline: a single clause, for a loose "multi-clause is longer"
+        // comparison (chunked clauses are synthesized independently and
+        // their audio concatenated, so 3 clauses should be at least as long
+        // as 1).
+        final baselinePcm = await synth.synthesize('One.');
+        final baselineSamples = baselinePcm.length ~/ 2;
+
+        final pcm = await synth.synthesize('One. Two. Three.');
+        final rms = _rms(pcm);
+        final sampleCount = pcm.length ~/ 2;
+
+        debugPrint(
+          'TTS-ROBUST<<<case=chunking bytes=${pcm.length} rms=${rms.toStringAsFixed(4)} '
+          'samples=$sampleCount baselineSamples=$baselineSamples>>>',
+        );
+
+        expect(pcm.isNotEmpty, isTrue, reason: 'PCM output was empty');
+        expect(
+          rms,
+          greaterThan(0.02),
+          reason: 'RMS too close to silence: $rms',
+        );
+        expect(
+          sampleCount,
+          greaterThanOrEqualTo(baselineSamples),
+          reason:
+              'Multi-clause audio ($sampleCount samples) shorter than a single-clause '
+              'baseline ($baselineSamples samples) — clause concatenation looks broken',
+        );
+      } finally {
+        await synth.close();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+}

--- a/packages/flutter_gemma/example/pubspec.lock
+++ b/packages/flutter_gemma/example/pubspec.lock
@@ -281,7 +281,7 @@ packages:
       path: "../../flutter_gemma_speech"
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   flutter_inappwebview:
     dependency: transitive
     description:

--- a/packages/flutter_gemma_speech/CHANGELOG.md
+++ b/packages/flutter_gemma_speech/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0
+- feat: robust TTS text frontend — punctuation-as-symbols, numbers/acronyms, neural OOV G2P, clause chunking; fail-loud on overflow.
+
 ## 0.2.0
 - Add on-device TTS (Matcha): installTts/getActiveTts, selectable model, PCM output.
 

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_chunk.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_chunk.dart
@@ -1,0 +1,30 @@
+// Pure-Dart helper: splice per-clause PCM segments (produced by the TTS
+// worker's clause chunker in `tts_worker.dart`) into one continuous 16-bit
+// PCM buffer, inserting a fixed silence gap between clauses so consecutive
+// segments don't click together. No FFI, unit-testable in isolation.
+library;
+
+import 'dart:typed_data';
+
+/// Concatenate 16-bit PCM segments [segs], inserting [silenceSamples] of
+/// silence (`silenceSamples * 2` zero bytes) BETWEEN segments — not before
+/// the first or after the last. A single-segment input is returned
+/// untouched (no gap to insert).
+Uint8List concatPcmWithSilence(
+  List<Uint8List> segs, {
+  required int silenceSamples,
+}) {
+  final gap = silenceSamples * 2;
+  var total = 0;
+  for (var i = 0; i < segs.length; i++) {
+    total += segs[i].length + (i > 0 ? gap : 0);
+  }
+  final out = Uint8List(total);
+  var off = 0;
+  for (var i = 0; i < segs.length; i++) {
+    if (i > 0) off += gap; // zero-filled by Uint8List's default allocation.
+    out.setRange(off, off + segs[i].length, segs[i]);
+    off += segs[i].length;
+  }
+  return out;
+}

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
@@ -39,7 +39,7 @@
 //
 // Leak-safety: buffer create/lock/read/unlock/destroy mirrors
 // `litert_embedding_core.dart`'s forward-pass pattern; `load`'s partial-
-// failure cleanup mirrors `SttCore.load`, generalized to 3 compiled graphs
+// failure cleanup mirrors `SttCore.load`, generalized to 4 compiled graphs
 // (a failure loading e.g. the decoder frees the already-loaded text-encoder
 // + the shared environment before rethrowing).
 
@@ -146,10 +146,10 @@ class _LoadedGraph {
 
 /// Loads + compiles one `.tflite` graph at [path], mirroring the
 /// model/options/compiled sequence `SttCore.load` runs for its single model
-/// — generalized so [TtsCore.load] can call it 3 times (text-encoder,
-/// decoder, vocoder). On any failure partway through, frees whatever handles
-/// it already created for THIS graph before rethrowing; the caller is
-/// responsible for freeing any earlier, already-succeeded graphs + the
+/// — generalized so [TtsCore.load] can call it 4 times (text-encoder,
+/// decoder, vocoder, dp_g2p). On any failure partway through, frees whatever
+/// handles it already created for THIS graph before rethrowing; the caller
+/// is responsible for freeing any earlier, already-succeeded graphs + the
 /// shared environment.
 _LoadedGraph _loadGraph(
   LiteRtBindings bindings,
@@ -303,7 +303,7 @@ class TtsCore {
     // the decoder graph fails to compile after the text-encoder already
     // loaded) frees everything already allocated instead of leaking it — the
     // LiteRT native heap is process-global and is NOT reclaimed by the
-    // isolate dying. Mirrors `SttCore.load`, generalized to 3 graphs.
+    // isolate dying. Mirrors `SttCore.load`, generalized to 4 graphs.
     LiteRtEnvironment? environment;
     final loadedGraphs = <_LoadedGraph>[];
     try {
@@ -455,7 +455,13 @@ class TtsCore {
   /// `runGraph`. Returns 16-bit little-endian mono PCM with NO WAV header
   /// (length `ylen * hop * 2` bytes) — the example's `pcmToWav` adds a
   /// header in Phase 3.
-  Uint8List synthesize(MatchaFrontendInput input) {
+  ///
+  /// [seed] seeds the CFM decoder's initial Gaussian noise (defaults to
+  /// [ttsCfmSeed], the golden-reproducible value). The worker's clause
+  /// chunker passes `ttsCfmSeed + i` per clause so a single-clause input —
+  /// e.g. the `'Hello world.'` golden — still synthesizes with
+  /// `seed == ttsCfmSeed`, byte-identical to before this parameter existed.
+  Uint8List synthesize(MatchaFrontendInput input, {int seed = ttsCfmSeed}) {
     if (_disposed) {
       throw StateError('TtsCore is disposed');
     }
@@ -510,10 +516,10 @@ class TtsCore {
       ymask[t] = 1.0;
     }
 
-    // --- Euler CFM ODE loop, ttsCfmSeed-fixed Gaussian noise so
-    // synthesize() is byte-reproducible run-to-run (the Phase-3 golden
-    // depends on this). ---
-    final rnd = math.Random(ttsCfmSeed);
+    // --- Euler CFM ODE loop, seed-fixed Gaussian noise so synthesize() is
+    // byte-reproducible run-to-run (the Phase-3 golden depends on the
+    // default `seed == ttsCfmSeed`). ---
+    final rnd = math.Random(seed);
     final x = Float32List(_nFeats * _maxMel);
     for (var f = 0; f < _nFeats; f++) {
       for (var t = 0; t < ylen; t++) {

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
@@ -396,7 +396,15 @@ class TtsCore {
       running += w[t];
       cum[t] = running;
     }
-    final ylen = cum[_maxText - 1].clamp(1.0, _maxMel.toDouble()).toInt();
+    final rawYlen = cum[_maxText - 1];
+    if (rawYlen.ceil() > _maxMel) {
+      throw StateError(
+        'TtsCore: predicted ${rawYlen.ceil()} mel frames > MAX_MEL $_maxMel '
+        '(~${(_maxMel * _hop / _sampleRate).toStringAsFixed(1)}s cap). '
+        'Chunk the text into shorter clauses.',
+      );
+    }
+    final ylen = rawYlen.clamp(1.0, _maxMel.toDouble()).toInt();
 
     final muY = Float32List(_nFeats * _maxMel);
     final ymask = Float32List(_maxMel);

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
@@ -1,9 +1,9 @@
 // Synchronous, isolate-agnostic native core for Matcha-TTS on-device
 // synthesis.
 //
-// Owns the LiteRT C API handles (one environment + 3 compiled graphs:
-// text-encoder, CFM decoder, HiFi-GAN vocoder) for a `matchaCfm` pipeline.
-// `synthesize()` runs the blocking forward passes + host-side ODE math
+// Owns the LiteRT C API handles (one environment + 4 compiled graphs:
+// text-encoder, CFM decoder, HiFi-GAN vocoder, dp_g2p) for a `matchaCfm`
+// pipeline. `synthesize()` runs the blocking forward passes + host-side ODE math
 // synchronously on the calling thread — like `SttCore.transcribe`, it is
 // meant to be driven from a background isolate so the UI isolate stays free.
 //
@@ -27,9 +27,10 @@
 //
 // Generic over [TtsModelProfile] — only `TtsPipelineKind.matchaCfm` is
 // implemented; kokoro/supertonic profiles are documented follow-ons. The
-// `dp_g2p` graph is intentionally NOT loaded here — it's the neural OOV
-// fallback, and the dictionary-only `TtsTextFrontend` (Task 2.2) covers the
-// golden path; loading it is a Phase-2 residual.
+// `dp_g2p` graph IS loaded here (4th compiled graph) and exposed via
+// `TtsCore.neuralG2p` — it's the neural OOV fallback used when a word is
+// missing from the dictionary; the dictionary-only path stays the golden
+// path via `TtsTextFrontend` (Task 2.2).
 //
 // Determinism: the Euler CFM decoder's initial noise is drawn from a FIXED
 // seed ([ttsCfmSeed]) via Box-Muller ([nextGaussian]), so [TtsCore.synthesize]
@@ -59,6 +60,7 @@ import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma_litertlm/litert_bindings.dart';
 
 import '../model/tts_model_profile.dart';
+import '../tts/neural_g2p_decode.dart';
 import '../tts/tts_frontend_input.dart';
 
 /// The Euler CFM decoder's fixed Gaussian-noise seed. Fixed (not
@@ -213,6 +215,7 @@ class TtsCore {
     required this._textEncoder,
     required this._decoder,
     required this._vocoder,
+    required this._dpG2p,
     required this._nFeats,
     required this._nChannels,
     required this._maxText,
@@ -223,6 +226,13 @@ class TtsCore {
     required this._nTimesteps,
     required this._melStd,
     required this._melMean,
+    required this._g2pChar2idx,
+    required this._g2pIdx2ph,
+    required this._g2pCharRepeats,
+    required this._g2pStart,
+    required this._g2pEnd,
+    required this._g2pMaxT,
+    required this._g2pNPhonemes,
   });
 
   final LiteRtBindings _bindings;
@@ -230,6 +240,7 @@ class TtsCore {
   final _LoadedGraph _textEncoder;
   final _LoadedGraph _decoder;
   final _LoadedGraph _vocoder;
+  final _LoadedGraph _dpG2p;
 
   final int _nFeats;
   final int _nChannels;
@@ -242,12 +253,22 @@ class TtsCore {
   final double _melStd;
   final double _melMean;
 
+  // Neural G2P (dp_g2p) vocab + framing params, read from `g2p_meta.json` at
+  // load time so `neuralG2p` can stay synchronous (no file I/O per word).
+  final Map<String, int> _g2pChar2idx;
+  final Map<int, String> _g2pIdx2ph;
+  final int _g2pCharRepeats;
+  final int _g2pStart;
+  final int _g2pEnd;
+  final int _g2pMaxT;
+  final int _g2pNPhonemes;
+
   bool _disposed = false;
 
-  /// Loads `config.json` and compiles the 3 Matcha graphs (text-encoder,
-  /// decoder, vocoder) for [backend]. Heavy — call once, from a background
-  /// isolate. [artifactPaths] is filename -> on-disk-path for the model
-  /// bundle (from `RuntimeConfig.artifactPaths`).
+  /// Loads `config.json` + `g2p_meta.json` and compiles the 4 Matcha graphs
+  /// (text-encoder, decoder, vocoder, dp_g2p) for [backend]. Heavy — call
+  /// once, from a background isolate. [artifactPaths] is filename ->
+  /// on-disk-path for the model bundle (from `RuntimeConfig.artifactPaths`).
   static Future<TtsCore> load({
     required TtsModelProfile profile,
     required Map<String, String> artifactPaths,
@@ -317,11 +338,31 @@ class TtsCore {
       );
       loadedGraphs.add(vocoder);
 
-      // dp_g2p (profile.g2pFile) is intentionally NOT loaded — it's the
-      // neural OOV fallback; the dictionary-only TtsTextFrontend (Task 2.2)
-      // covers the golden path. Loading it is a documented Phase-2 residual.
+      final dpG2p = _loadGraph(
+        bindings,
+        environment,
+        _artifactPath(artifactPaths, profile.g2pFile),
+        accelerator,
+      );
+      loadedGraphs.add(dpG2p);
 
-      gemmaLog('[TtsCore] loaded: backend=$backend, 3 graphs compiled');
+      final g2pMetaPath = _artifactPath(artifactPaths, profile.g2pMetaFile);
+      final g2pMeta =
+          jsonDecode(await File(g2pMetaPath).readAsString())
+              as Map<String, dynamic>;
+      final g2pChar2idx = (g2pMeta['char2idx'] as Map<String, dynamic>).map(
+        (k, v) => MapEntry(k, (v as num).toInt()),
+      );
+      final g2pIdx2ph = (g2pMeta['idx2ph'] as Map<String, dynamic>).map(
+        (k, v) => MapEntry(int.parse(k), v as String),
+      );
+      final g2pCharRepeats = (g2pMeta['char_repeats'] as num).toInt();
+      final g2pStart = (g2pMeta['start'] as num).toInt();
+      final g2pEnd = (g2pMeta['end'] as num).toInt();
+      final g2pMaxT = (g2pMeta['MAXT'] as num).toInt();
+      final g2pNPhonemes = (g2pMeta['n_phonemes'] as num).toInt();
+
+      gemmaLog('[TtsCore] loaded: backend=$backend, 4 graphs compiled');
 
       return TtsCore._(
         bindings: bindings,
@@ -329,6 +370,7 @@ class TtsCore {
         textEncoder: textEncoder,
         decoder: decoder,
         vocoder: vocoder,
+        dpG2p: dpG2p,
         nFeats: nFeats,
         nChannels: nChannels,
         maxText: maxText,
@@ -339,6 +381,13 @@ class TtsCore {
         nTimesteps: nTimesteps,
         melStd: melStd,
         melMean: melMean,
+        g2pChar2idx: g2pChar2idx,
+        g2pIdx2ph: g2pIdx2ph,
+        g2pCharRepeats: g2pCharRepeats,
+        g2pStart: g2pStart,
+        g2pEnd: g2pEnd,
+        g2pMaxT: g2pMaxT,
+        g2pNPhonemes: g2pNPhonemes,
       );
     } catch (_) {
       for (final graph in loadedGraphs) {
@@ -353,6 +402,50 @@ class TtsCore {
 
   /// Output sample rate (Hz), read from `config.json`.
   int get sampleRate => _sampleRate;
+
+  /// Runs [word] through the neural dp_g2p graph — the OOV fallback for
+  /// words missing from the pronunciation dictionary — and returns its IPA
+  /// phoneme string. Synchronous (no file I/O; `g2p_meta.json` was already
+  /// parsed in [load]), so it's safe to call per-word from the frontend (the
+  /// `NeuralG2pResolver` adapter is `core.neuralG2p`). Framing/decoding is
+  /// [encodeG2pInput]/[decodeG2pOutput] (Task 6) — this method only runs the
+  /// native forward pass and picks the per-position argmax over the
+  /// `n_phonemes`-wide logits.
+  String neuralG2p(String word) {
+    if (_disposed) {
+      throw StateError('TtsCore is disposed');
+    }
+    final x = encodeG2pInput(
+      word,
+      _g2pChar2idx,
+      charRepeats: _g2pCharRepeats,
+      start: _g2pStart,
+      end: _g2pEnd,
+      maxT: _g2pMaxT,
+    );
+    final logits = _runGraph(
+      _dpG2p.compiledModel,
+      [
+        ([1, _g2pMaxT], x),
+      ],
+      [
+        [1, _g2pMaxT, _g2pNPhonemes],
+      ],
+    )[0];
+    final argmax = List<int>.generate(_g2pMaxT, (t) {
+      var best = 0;
+      var bestV = logits[t * _g2pNPhonemes];
+      for (var p = 1; p < _g2pNPhonemes; p++) {
+        final v = logits[t * _g2pNPhonemes + p];
+        if (v > bestV) {
+          bestV = v;
+          best = p;
+        }
+      }
+      return best;
+    });
+    return decodeG2pOutput(argmax, _g2pIdx2ph, end: _g2pEnd);
+  }
 
   /// Runs the full Matcha forward pass for a prepared frontend [input]:
   /// text-encoder -> host duration + Glow-TTS length regulator -> N-step
@@ -612,12 +705,12 @@ class TtsCore {
     }
   }
 
-  /// Destroys all 3 compiled graphs' handles + the shared environment.
-  /// Mirrors `SttCore.dispose`, x3.
+  /// Destroys all 4 compiled graphs' handles + the shared environment.
+  /// Mirrors `SttCore.dispose`, x4.
   void dispose() {
     if (_disposed) return;
     _disposed = true;
-    for (final graph in [_textEncoder, _decoder, _vocoder]) {
+    for (final graph in [_textEncoder, _decoder, _vocoder, _dpG2p]) {
       _bindings.destroyCompiledModel(graph.compiledModel);
       _bindings.destroyOptions(graph.options);
       _bindings.destroyModel(graph.model);

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_core.dart
@@ -59,7 +59,7 @@ import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma_litertlm/litert_bindings.dart';
 
 import '../model/tts_model_profile.dart';
-import '../tts/tts_text_frontend.dart';
+import '../tts/tts_frontend_input.dart';
 
 /// The Euler CFM decoder's fixed Gaussian-noise seed. Fixed (not
 /// time-derived) so [TtsCore.synthesize] is byte-reproducible run-to-run —
@@ -362,7 +362,7 @@ class TtsCore {
   /// `runGraph`. Returns 16-bit little-endian mono PCM with NO WAV header
   /// (length `ylen * hop * 2` bytes) — the example's `pcmToWav` adds a
   /// header in Phase 3.
-  Uint8List synthesize(TtsFrontendInput input) {
+  Uint8List synthesize(MatchaFrontendInput input) {
     if (_disposed) {
       throw StateError('TtsCore is disposed');
     }

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
@@ -257,6 +257,11 @@ Future<void> _workerEntry(_WorkerInit init) async {
   final TtsCore core;
   final TtsTextFrontend frontend;
   final TtsTextNormalizer normalizer;
+  // Tracks the core once TtsCore.load succeeds, purely so the catch block
+  // below can free it if a LATER step (frontend or normalizer) throws —
+  // otherwise a fully-loaded native core (4 compiled graphs + environment)
+  // would be abandoned: isolate exit does not free FFI/native allocations.
+  TtsCore? loadedCore;
   try {
     // Core loads first: the frontend needs `core.neuralG2p` (the dp_g2p
     // graph) to resolve out-of-vocabulary words that aren't in the
@@ -267,6 +272,7 @@ Future<void> _workerEntry(_WorkerInit init) async {
       artifactPaths: init.artifactPaths,
       backend: init.backend,
     );
+    loadedCore = core;
     frontend = await TtsTextFrontend.load(
       init.profile,
       init.artifactPaths,
@@ -280,6 +286,7 @@ Future<void> _workerEntry(_WorkerInit init) async {
     // isolate exit.
     normalizer = TtsTextNormalizer.forLocale(init.profile.locale, {});
   } catch (e, st) {
+    loadedCore?.dispose();
     gemmaLog('[TtsWorker] load failed: $e\n$st');
     init.replyTo.send('TTS worker failed to load: $e');
     return;

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
@@ -10,9 +10,16 @@
 //
 // Unlike `SttWorker` (which owns only `SttCore`, tokenizer included inside
 // the core), this worker owns TWO objects: `TtsTextFrontend` and `TtsCore`.
-// Setup loads both; each request runs `frontend.encode(text)` then
-// `core.synthesize(input)`. Only `TtsCore` holds native handles, so only
-// `core.dispose()` runs in the teardown `finally`.
+// Setup loads both plus a `TtsTextNormalizer` (for `splitClauses`, needs no
+// symbols). Each request splits `text` into clauses so the CFM decoder's
+// `MAX_MEL` cap (and its perceptual quality — the model was trained on
+// clause-length utterances) doesn't get exceeded by long replies: every
+// clause is `frontend.encode`d and `core.synthesize`d with its own CFM seed
+// (`ttsCfmSeed + clauseIndex`, so a single-clause request's seed is
+// unchanged), and the resulting PCM segments are spliced with a short
+// inter-clause silence (`concatPcmWithSilence`, `tts_chunk.dart`). Only
+// `TtsCore` holds native handles, so only `core.dispose()` runs in the
+// teardown `finally`.
 //
 // Only sendable values cross the port: file paths + profile + backend
 // (setup), a `String` (request), and a `Uint8List` of 16-bit PCM samples
@@ -28,6 +35,8 @@ import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
 import '../model/tts_model_profile.dart';
 import '../tts/tts_text_frontend.dart';
+import '../tts/tts_text_normalizer.dart';
+import 'tts_chunk.dart';
 import 'tts_core.dart';
 
 /// Handshake payload the worker sends back once the frontend + native model
@@ -247,6 +256,10 @@ Future<void> _workerEntry(_WorkerInit init) async {
   gemmaLogLevel = init.logLevel;
   final TtsTextFrontend frontend;
   final TtsCore core;
+  // splitClauses only reads punctuation, so an empty symbol set is fine —
+  // the normalizer is built purely to reuse the locale-selected clause
+  // splitter, not to normalize/encode text (that stays `frontend.encode`).
+  final normalizer = TtsTextNormalizer.forLocale(init.profile.locale, {});
   try {
     frontend = await TtsTextFrontend.load(init.profile, init.artifactPaths);
     core = await TtsCore.load(
@@ -267,8 +280,20 @@ Future<void> _workerEntry(_WorkerInit init) async {
     await for (final msg in commandPort) {
       if (msg is _SynthRequest) {
         try {
-          final input = frontend.encode(msg.text);
-          final pcm = core.synthesize(input);
+          final clauses = normalizer.splitClauses(msg.text);
+          final units = clauses.isEmpty ? <String>[msg.text] : clauses;
+          final segs = <Uint8List>[];
+          for (var i = 0; i < units.length; i++) {
+            final input = frontend.encode(units[i]);
+            if (input.realLen <= 1) continue; // empty chunk → no audio.
+            segs.add(core.synthesize(input, seed: ttsCfmSeed + i));
+          }
+          final pcm = segs.isEmpty
+              ? Uint8List(0)
+              : concatPcmWithSilence(
+                  segs,
+                  silenceSamples: (core.sampleRate * 0.12).round(),
+                );
           init.replyTo.send(_SynthReply(msg.id, pcm, null));
         } catch (e) {
           init.replyTo.send(_SynthReply(msg.id, null, e.toString()));

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
@@ -248,11 +248,7 @@ Future<void> _workerEntry(_WorkerInit init) async {
   final TtsTextFrontend frontend;
   final TtsCore core;
   try {
-    frontend = await TtsTextFrontend.load(
-      configPath: init.artifactPaths[init.profile.configFile]!,
-      dictPath: init.artifactPaths[init.profile.dictFile]!,
-      embeddingPath: init.artifactPaths[init.profile.embeddingFile]!,
-    );
+    frontend = await TtsTextFrontend.load(init.profile, init.artifactPaths);
     core = await TtsCore.load(
       profile: init.profile,
       artifactPaths: init.artifactPaths,

--- a/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
+++ b/packages/flutter_gemma_speech/lib/src/litert/tts_worker.dart
@@ -1,6 +1,6 @@
 // Long-lived background isolate that owns the entire Matcha-TTS pipeline:
 // both the text frontend (dictionary G2P + host embedding gather, Task 2.2)
-// and the native LiteRT core (3 compiled graphs + the CFM/vocoder forward
+// and the native LiteRT core (4 compiled graphs + the CFM/vocoder forward
 // passes, Task 2.3). The forward passes are blocking synchronous FFI calls;
 // running them (and the frontend's dictionary lookups + 275k-entry load)
 // here keeps the UI isolate's event loop free. Direct analog of
@@ -254,19 +254,31 @@ class TtsWorker {
 Future<void> _workerEntry(_WorkerInit init) async {
   // Seed this isolate's per-isolate log level from the main-isolate snapshot.
   gemmaLogLevel = init.logLevel;
-  final TtsTextFrontend frontend;
   final TtsCore core;
-  // splitClauses only reads punctuation, so an empty symbol set is fine —
-  // the normalizer is built purely to reuse the locale-selected clause
-  // splitter, not to normalize/encode text (that stays `frontend.encode`).
-  final normalizer = TtsTextNormalizer.forLocale(init.profile.locale, {});
+  final TtsTextFrontend frontend;
+  final TtsTextNormalizer normalizer;
   try {
-    frontend = await TtsTextFrontend.load(init.profile, init.artifactPaths);
+    // Core loads first: the frontend needs `core.neuralG2p` (the dp_g2p
+    // graph) to resolve out-of-vocabulary words that aren't in the
+    // dictionary. Loading order doesn't affect output — only which OOV
+    // words the frontend can resolve without throwing.
     core = await TtsCore.load(
       profile: init.profile,
       artifactPaths: init.artifactPaths,
       backend: init.backend,
     );
+    frontend = await TtsTextFrontend.load(
+      init.profile,
+      init.artifactPaths,
+      neuralG2p: core.neuralG2p,
+    );
+    // splitClauses only reads punctuation, so an empty symbol set is fine —
+    // the normalizer is built purely to reuse the locale-selected clause
+    // splitter, not to normalize/encode text (that stays `frontend.encode`).
+    // Built inside the try so a future non-`en` locale's UnimplementedError
+    // surfaces as a descriptive load-failure reply instead of a bare
+    // isolate exit.
+    normalizer = TtsTextNormalizer.forLocale(init.profile.locale, {});
   } catch (e, st) {
     gemmaLog('[TtsWorker] load failed: $e\n$st');
     init.replyTo.send('TTS worker failed to load: $e');

--- a/packages/flutter_gemma_speech/lib/src/model/tts_model_profile.dart
+++ b/packages/flutter_gemma_speech/lib/src/model/tts_model_profile.dart
@@ -22,6 +22,12 @@ enum TtsPipelineKind {
   matchaCfm,
 }
 
+/// How text becomes the model's encoder input.
+enum TextRepresentation { phonemeSymbols, subwordTokens, rawChars }
+
+/// For phonemeSymbols models only: how graphemes become phonemes.
+enum G2pStrategy { dictionary, dictionaryPlusNeural, neuralOnly, none }
+
 /// Runtime descriptor for one TTS model family — the pipeline kind plus the
 /// role of each file in the model bundle. `TtsCore` needs this to know which
 /// `.tflite` to load for which stage; it does not auto-detect roles from the
@@ -37,7 +43,10 @@ class TtsModelProfile {
       g2pFile = 'dp_g2p_matcha_fp16.tflite',
       configFile = 'config.json',
       dictFile = 'g2p_dict.txt.gz',
-      embeddingFile = 'emb.bin';
+      embeddingFile = 'emb.bin',
+      representation = TextRepresentation.phonemeSymbols,
+      g2p = G2pStrategy.dictionaryPlusNeural,
+      locale = 'en_us';
 
   /// Which end-to-end synthesis pipeline this profile drives.
   final TtsPipelineKind pipeline;
@@ -63,6 +72,16 @@ class TtsModelProfile {
 
   /// Speaker/style embedding file.
   final String embeddingFile;
+
+  /// How text becomes the model's encoder input.
+  final TextRepresentation representation;
+
+  /// For phonemeSymbols models only: how graphemes become phonemes. Null for
+  /// token models.
+  final G2pStrategy? g2p;
+
+  /// Selects the `TtsTextNormalizer` (Task 4); matcha → `'en_us'`.
+  final String locale;
 
   /// Resolve the runtime profile for [t]. Only [TtsModelType.matcha] is
   /// wired; kokoro/supertonic are follow-ons and throw (fail-loud — never

--- a/packages/flutter_gemma_speech/lib/src/model/tts_model_profile.dart
+++ b/packages/flutter_gemma_speech/lib/src/model/tts_model_profile.dart
@@ -41,6 +41,7 @@ class TtsModelProfile {
       decoderFile = 'matcha_decoder_fp16.tflite',
       vocoderFile = 'matcha_vocoder_fp16.tflite',
       g2pFile = 'dp_g2p_matcha_fp16.tflite',
+      g2pMetaFile = 'g2p_meta.json',
       configFile = 'config.json',
       dictFile = 'g2p_dict.txt.gz',
       embeddingFile = 'emb.bin',
@@ -62,6 +63,11 @@ class TtsModelProfile {
 
   /// Grapheme-to-phoneme model file.
   final String g2pFile;
+
+  /// Neural G2P side-car: `char2idx`/`idx2ph` vocab + framing params
+  /// (`char_repeats`/`start`/`end`/`MAXT`/`n_phonemes`) that `TtsCore` needs
+  /// to run [g2pFile] and decode its output into IPA (`TtsCore.neuralG2p`).
+  final String g2pMetaFile;
 
   /// Bundle config file carrying the numeric synthesis params (read by
   /// `TtsCore`, not this profile).

--- a/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
@@ -1,0 +1,61 @@
+library;
+
+import 'tts_text_normalizer.dart';
+export 'tts_text_normalizer.dart';
+
+/// English impl of [TtsTextNormalizer], PRESERVING punctuation as model
+/// symbols. [symbols] is the model's symbol set (config.json `symbols`) — only
+/// marks the model knows survive as SymbolToken; the rest are dropped as
+/// non-speech (logged). Numbers/acronyms/markdown handled in Task 5.
+class EnglishTextNormalizer implements TtsTextNormalizer {
+  const EnglishTextNormalizer(this.symbols);
+  final Set<String> symbols;
+
+  @override
+  List<NormToken> normalize(String text) {
+    final out = <NormToken>[];
+    final buf = StringBuffer();
+    void flushWord() {
+      if (buf.isNotEmpty) {
+        out.add(WordToken(buf.toString().toLowerCase()));
+        buf.clear();
+      }
+    }
+
+    for (final rune in text.runes) {
+      final ch = String.fromCharCode(rune);
+      if (RegExp(r'[A-Za-z]').hasMatch(ch)) {
+        buf.write(ch);
+      } else if (ch == ' ' || RegExp(r'\s').hasMatch(ch)) {
+        flushWord();
+        if (out.isNotEmpty && out.last is! SymbolToken) {
+          out.add(const SymbolToken(' '));
+        }
+      } else {
+        flushWord();
+        if (symbols.contains(ch)) out.add(SymbolToken(ch));
+        // else: non-speech char (Task 5 handles numbers/markdown); drop here.
+      }
+    }
+    flushWord();
+    return out;
+  }
+
+  @override
+  List<String> splitClauses(String text) {
+    final parts = <String>[];
+    final buf = StringBuffer();
+    for (final rune in text.runes) {
+      final ch = String.fromCharCode(rune);
+      buf.write(ch);
+      if ('.!?,;:'.contains(ch)) {
+        final s = buf.toString().trim();
+        if (s.isNotEmpty) parts.add(s);
+        buf.clear();
+      }
+    }
+    final tail = buf.toString().trim();
+    if (tail.isNotEmpty) parts.add(tail);
+    return parts;
+  }
+}

--- a/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
@@ -52,6 +52,11 @@ class EnglishTextNormalizer implements TtsTextNormalizer {
       // year: two pairs
       return '${_below100(n ~/ 100)} ${_below100(n % 100)}'.trim();
     }
+    if (n >= 1000000) {
+      // Beyond standard word expansion: spell out digit-by-digit rather than
+      // overflow _below1000000's internal 0-999 assumptions (RangeError).
+      return digits.split('').map((d) => _ones[int.parse(d)]).join(' ');
+    }
     return _below1000000(n);
   }
 

--- a/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
@@ -30,7 +30,11 @@ class EnglishTextNormalizer implements TtsTextNormalizer {
   String _preclean(String text) {
     var s = text;
     s = s.replaceAll(RegExp(r'https?://\S+'), ' '); // URLs
-    s = s.replaceAll(RegExp(r'`{1,3}[^`]*`{1,3}'), ' '); // inline/fenced code
+    // inline/fenced code: strip the backtick delimiters but KEEP the inner
+    // text — LLM replies commonly wrap speakable values/words/commands in
+    // backticks (e.g. "The answer is `42`."), and dropping the content
+    // silently loses it (#PR-panel).
+    s = s.replaceAllMapped(RegExp(r'`{1,3}([^`]*)`{1,3}'), (m) => ' ${m[1]} ');
     s = s.replaceAll(RegExp(r'[*_#>~|]'), ' '); // markdown punctuation
     s = s.replaceAllMapped(
       RegExp(r'\b\d[\d,]*\b'), // numbers

--- a/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
@@ -49,8 +49,15 @@ class EnglishTextNormalizer implements TtsTextNormalizer {
       return digits.split('').map((d) => _ones[int.parse(d)]).join(' ');
     }
     if (digits.length == 4 && n >= 1100 && n <= 9999) {
-      // year: two pairs
-      return '${_below100(n ~/ 100)} ${_below100(n % 100)}'.trim();
+      // year: two pairs, e.g. 2023 -> "twenty twenty three". The last two
+      // digits need special-casing: a round pair (2000) reads as a plain
+      // number ("two thousand"), and 01-09 (2005) needs the "oh" that a
+      // naive _below100(5) -> "five" would drop ("twenty oh five").
+      final firstPair = n ~/ 100;
+      final lastPair = n % 100;
+      if (lastPair == 0) return _below1000000(n);
+      if (lastPair <= 9) return '${_below100(firstPair)} oh ${_ones[lastPair]}';
+      return '${_below100(firstPair)} ${_below100(lastPair)}'.trim();
     }
     if (n >= 1000000) {
       // Beyond standard word expansion: spell out digit-by-digit rather than

--- a/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/english_text_normalizer.dart
@@ -6,13 +6,70 @@ export 'tts_text_normalizer.dart';
 /// English impl of [TtsTextNormalizer], PRESERVING punctuation as model
 /// symbols. [symbols] is the model's symbol set (config.json `symbols`) — only
 /// marks the model knows survive as SymbolToken; the rest are dropped as
-/// non-speech (logged). Numbers/acronyms/markdown handled in Task 5.
+/// non-speech. Numbers/years/acronyms are expanded to words and markdown/URLs
+/// are stripped by [_preclean] before tokenization.
 class EnglishTextNormalizer implements TtsTextNormalizer {
   const EnglishTextNormalizer(this.symbols);
   final Set<String> symbols;
 
+  static final _letter = RegExp(r'[A-Za-z]');
+  static final _whitespace = RegExp(r'\s');
+
+  static const _ones = [
+    'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight',
+    'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
+    'sixteen', 'seventeen', 'eighteen', 'nineteen', //
+  ];
+  static const _tens = [
+    '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy',
+    'eighty', 'ninety', //
+  ];
+
+  /// Strips markdown/URLs and expands numbers/years/acronyms to words, ahead
+  /// of the rune loop below. No-op on already-clean text.
+  String _preclean(String text) {
+    var s = text;
+    s = s.replaceAll(RegExp(r'https?://\S+'), ' '); // URLs
+    s = s.replaceAll(RegExp(r'`{1,3}[^`]*`{1,3}'), ' '); // inline/fenced code
+    s = s.replaceAll(RegExp(r'[*_#>~|]'), ' '); // markdown punctuation
+    s = s.replaceAllMapped(
+      RegExp(r'\b\d[\d,]*\b'), // numbers
+      (m) => ' ${_numberToWords(m[0]!.replaceAll(',', ''))} ',
+    );
+    s = s.replaceAllMapped(
+      RegExp(r'\b[A-Z]{2,}\b'), // ALL-CAPS acronyms
+      (m) => ' ${m[0]!.split('').join(' ')} ',
+    );
+    return s;
+  }
+
+  String _numberToWords(String digits) {
+    final n = int.tryParse(digits);
+    if (n == null) {
+      return digits.split('').map((d) => _ones[int.parse(d)]).join(' ');
+    }
+    if (digits.length == 4 && n >= 1100 && n <= 9999) {
+      // year: two pairs
+      return '${_below100(n ~/ 100)} ${_below100(n % 100)}'.trim();
+    }
+    return _below1000000(n);
+  }
+
+  String _below100(int n) => n < 20
+      ? _ones[n]
+      : '${_tens[n ~/ 10]}${n % 10 == 0 ? '' : ' ${_ones[n % 10]}'}';
+
+  String _below1000(int n) => n < 100
+      ? _below100(n)
+      : '${_ones[n ~/ 100]} hundred${n % 100 == 0 ? '' : ' ${_below100(n % 100)}'}';
+
+  String _below1000000(int n) => n < 1000
+      ? _below1000(n)
+      : '${_below1000(n ~/ 1000)} thousand${n % 1000 == 0 ? '' : ' ${_below1000(n % 1000)}'}';
+
   @override
   List<NormToken> normalize(String text) {
+    text = _preclean(text);
     final out = <NormToken>[];
     final buf = StringBuffer();
     void flushWord() {
@@ -24,9 +81,9 @@ class EnglishTextNormalizer implements TtsTextNormalizer {
 
     for (final rune in text.runes) {
       final ch = String.fromCharCode(rune);
-      if (RegExp(r'[A-Za-z]').hasMatch(ch)) {
+      if (_letter.hasMatch(ch)) {
         buf.write(ch);
-      } else if (ch == ' ' || RegExp(r'\s').hasMatch(ch)) {
+      } else if (ch == ' ' || _whitespace.hasMatch(ch)) {
         flushWord();
         if (out.isNotEmpty && out.last is! SymbolToken) {
           out.add(const SymbolToken(' '));
@@ -34,7 +91,7 @@ class EnglishTextNormalizer implements TtsTextNormalizer {
       } else {
         flushWord();
         if (symbols.contains(ch)) out.add(SymbolToken(ch));
-        // else: non-speech char (Task 5 handles numbers/markdown); drop here.
+        // else: non-speech char; drop.
       }
     }
     flushWord();

--- a/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
@@ -1,0 +1,179 @@
+/// Matcha-TTS text frontend — `text -> IPA (dictionary G2P) -> symbol ids ->
+/// blank-interspersed ids + text mask -> host-side emb.bin gather -> symbol
+/// embeddings`. Pure Dart, no FFI. The analog of STT's `HfTokenizer`: this is
+/// the input `TtsCore` (Task 2.3) feeds to the Matcha text-encoder graph.
+///
+/// The algorithm is transcribed verbatim from the verified reconstruction
+/// script `matcha_synth.dart` (`main()`, config/dict/emb parsing + G2P +
+/// blank-intersperse + gather).
+library;
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import '../model/tts_model_profile.dart';
+import 'tts_frontend_input.dart';
+import 'tts_text_frontend.dart';
+
+/// Pure-Dart Matcha-TTS text frontend: dictionary G2P + blank-intersperse +
+/// host-side embedding gather. No neural fallback — OOV words throw.
+class MatchaTextFrontend implements TtsTextFrontend {
+  /// Pure constructor from already-parsed data (unit-testable, no file I/O).
+  MatchaTextFrontend({
+    required this.symbolToId,
+    required this.dictionary,
+    required this.embeddingTable,
+    required this.nChannels,
+    required this.maxText,
+    this.locale = 'en_us',
+    this.neuralG2p,
+  });
+
+  /// IPA char -> symbol id (178-symbol table for the real Matcha bundle).
+  final Map<String, int> symbolToId;
+
+  /// Lowercase word -> IPA string (274,927 entries for the real bundle).
+  final Map<String, String> dictionary;
+
+  /// [nSymbols * nChannels] row-major phoneme embedding table.
+  final Float32List embeddingTable;
+
+  /// Embedding width (192 for the real Matcha bundle).
+  final int nChannels;
+
+  /// Max text length in symbol slots (256 for the real Matcha bundle).
+  final int maxText;
+
+  /// Selects the normalizer for this frontend (Task 9); matcha -> `'en_us'`.
+  final String locale;
+
+  /// Neural G2P fallback for OOV words (Task 11 wires this in via the
+  /// worker); null until then, so OOV words still throw.
+  final NeuralG2pResolver? neuralG2p;
+
+  /// Parse the real Matcha bundle files: `config.json` (symbols +
+  /// n_channels + MAX_TEXT), `g2p_dict.txt.gz` (gzipped word -> IPA
+  /// dictionary), `emb.bin` (little-endian f32 phoneme embedding table).
+  static Future<MatchaTextFrontend> load(
+    TtsModelProfile profile,
+    Map<String, String> paths, {
+    NeuralG2pResolver? neuralG2p,
+  }) async {
+    final configPath = paths[profile.configFile]!;
+    final dictPath = paths[profile.dictFile]!;
+    final embeddingPath = paths[profile.embeddingFile]!;
+
+    final config =
+        jsonDecode(await File(configPath).readAsString())
+            as Map<String, dynamic>;
+    final symbols = (config['symbols'] as List).cast<String>();
+    final symbolToId = <String, int>{
+      // last-wins on duplicates, matches Python dict comprehension.
+      for (var i = 0; i < symbols.length; i++) symbols[i]: i,
+    };
+    final nChannels = (config['n_channels'] as num).toInt();
+    final maxText = (config['MAX_TEXT'] as num).toInt();
+
+    final gzBytes = await File(dictPath).readAsBytes();
+    final dictText = utf8.decode(gzip.decode(gzBytes));
+    final dictionary = <String, String>{};
+    for (final line in const LineSplitter().convert(dictText)) {
+      final tab = line.indexOf('\t');
+      if (tab < 0) continue;
+      dictionary[line.substring(0, tab)] = line.substring(tab + 1);
+    }
+
+    final embBytes = await File(embeddingPath).readAsBytes();
+    final embBd = ByteData.sublistView(embBytes);
+    final embeddingTable = Float32List(embBytes.length ~/ 4);
+    for (var i = 0; i < embeddingTable.length; i++) {
+      embeddingTable[i] = embBd.getFloat32(i * 4, Endian.little);
+    }
+
+    return MatchaTextFrontend(
+      symbolToId: symbolToId,
+      dictionary: dictionary,
+      embeddingTable: embeddingTable,
+      nChannels: nChannels,
+      maxText: maxText,
+      locale: profile.locale,
+      neuralG2p: neuralG2p,
+    );
+  }
+
+  /// text -> frontend input. Throws [StateError] on an OOV word (this
+  /// frontend is dictionary-only; the neural `dp_g2p` fallback needs FFI and
+  /// belongs to `TtsCore`).
+  @override
+  MatchaFrontendInput encode(String text) {
+    // --- G2P: text -> IPA (dictionary path only) ---
+    final hasTrailingPeriod = text.endsWith('.');
+    final core = hasTrailingPeriod ? text.substring(0, text.length - 1) : text;
+    final words = core.trim().split(RegExp(r'\s+'));
+    final ipaParts = <String>[];
+    for (final w in words) {
+      final wordIpa = dictionary[w.toLowerCase()];
+      if (wordIpa == null) {
+        throw StateError(
+          'OOV word "$w" — neural dp_g2p fallback not yet wired '
+          '(dictionary-only frontend)',
+        );
+      }
+      ipaParts.add(wordIpa);
+    }
+    final ipa = ipaParts.join(' ') + (hasTrailingPeriod ? '.' : '');
+
+    // --- IPA chars -> symbol ids ---
+    final pids = <int>[];
+    for (final rune in ipa.runes) {
+      final ch = String.fromCharCode(rune);
+      final id = symbolToId[ch];
+      if (id != null) {
+        pids.add(id);
+      } else {
+        throw StateError(
+          'TtsTextFrontend: IPA symbol "$ch" (U+${rune.toRadixString(16)}) '
+          'is not in the 178-symbol table — cannot synthesize "$text".',
+        );
+      }
+    }
+    if (pids.isEmpty) {
+      throw StateError(
+        'TtsTextFrontend: no symbols mapped for "$text" — cannot synthesize '
+        '(all IPA characters were outside the symbol table).',
+      );
+    }
+
+    final realLen = 2 * pids.length + 1;
+    if (realLen > maxText) {
+      throw StateError(
+        'TtsTextFrontend: chunk needs $realLen slots > MAX_TEXT $maxText '
+        '(chunk before encode). Text: "$text".',
+      );
+    }
+
+    // --- blank-interspersed ids[maxText] + tmask[maxText] ---
+    final ids = List<int>.filled(maxText, 0);
+    for (var i = 0; i < pids.length; i++) {
+      final pos = 1 + 2 * i;
+      ids[pos] = pids[i];
+    }
+    final textMask = Float32List(maxText);
+    for (var t = 0; t < maxText; t++) {
+      textMask[t] = t < realLen ? 1.0 : 0.0;
+    }
+
+    // --- host emb.bin gather -> [maxText * nChannels] ---
+    final symbolEmbeddings = Float32List(maxText * nChannels);
+    for (var t = 0; t < maxText; t++) {
+      final srcBase = ids[t] * nChannels;
+      final dstBase = t * nChannels;
+      for (var c = 0; c < nChannels; c++) {
+        symbolEmbeddings[dstBase + c] = embeddingTable[srcBase + c];
+      }
+    }
+
+    return MatchaFrontendInput(symbolEmbeddings, textMask, realLen);
+  }
+}

--- a/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
@@ -55,6 +55,15 @@ class MatchaTextFrontend implements TtsTextFrontend {
   /// worker); null until then, so OOV words still throw.
   final NeuralG2pResolver? neuralG2p;
 
+  /// Normalizer for [locale]/[symbolToId], built once at construction —
+  /// [locale] and [symbolToId] are fixed for the lifetime of the frontend,
+  /// so rebuilding a ~178-element symbol set on every [encode] call (once
+  /// per clause per request) is wasted work.
+  late final TtsTextNormalizer _normalizer = TtsTextNormalizer.forLocale(
+    locale,
+    symbolToId.keys.toSet(),
+  );
+
   /// Parse the real Matcha bundle files: `config.json` (symbols +
   /// n_channels + MAX_TEXT), `g2p_dict.txt.gz` (gzipped word -> IPA
   /// dictionary), `emb.bin` (little-endian f32 phoneme embedding table).
@@ -110,11 +119,7 @@ class MatchaTextFrontend implements TtsTextFrontend {
   @override
   MatchaFrontendInput encode(String text) {
     // --- normalize: text -> tagged tokens (words + preserved symbols) ---
-    final normalizer = TtsTextNormalizer.forLocale(
-      locale,
-      symbolToId.keys.toSet(),
-    );
-    final tokens = normalizer.normalize(text);
+    final tokens = _normalizer.normalize(text);
 
     // --- G2P: tokens -> IPA (dictionary first, neural fallback, else throw) ---
     final ipa = StringBuffer();

--- a/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
@@ -151,10 +151,11 @@ class MatchaTextFrontend implements TtsTextFrontend {
       }
     }
     if (pids.isEmpty) {
-      throw StateError(
-        'MatchaTextFrontend: no symbols mapped for "$text" — cannot '
-        'synthesize (all IPA characters were outside the symbol table).',
-      );
+      // Non-speech clause (e.g. a lone emoji or a symbol outside the
+      // model's table): a defined empty input, not a fail-loud error — the
+      // worker's `realLen <= 1` guard skips it and moves on to the next
+      // clause instead of erroring the whole synthesis request.
+      return MatchaFrontendInput(Float32List(0), Float32List(0), 0);
     }
 
     final realLen = 2 * pids.length + 1;

--- a/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/matcha_text_frontend.dart
@@ -15,9 +15,12 @@ import 'dart:typed_data';
 import '../model/tts_model_profile.dart';
 import 'tts_frontend_input.dart';
 import 'tts_text_frontend.dart';
+import 'tts_text_normalizer.dart';
 
-/// Pure-Dart Matcha-TTS text frontend: dictionary G2P + blank-intersperse +
-/// host-side embedding gather. No neural fallback — OOV words throw.
+/// Pure-Dart Matcha-TTS text frontend: text normalizer (tagged tokens) +
+/// dictionary G2P + optional neural fallback + blank-intersperse +
+/// host-side embedding gather. OOV words throw when no neural resolver is
+/// wired.
 class MatchaTextFrontend implements TtsTextFrontend {
   /// Pure constructor from already-parsed data (unit-testable, no file I/O).
   MatchaTextFrontend({
@@ -102,53 +105,62 @@ class MatchaTextFrontend implements TtsTextFrontend {
     );
   }
 
-  /// text -> frontend input. Throws [StateError] on an OOV word (this
-  /// frontend is dictionary-only; the neural `dp_g2p` fallback needs FFI and
-  /// belongs to `TtsCore`).
+  /// text -> frontend input. G2P is dictionary-first: OOV words route
+  /// through [neuralG2p] when wired, else throw [StateError].
   @override
   MatchaFrontendInput encode(String text) {
-    // --- G2P: text -> IPA (dictionary path only) ---
-    final hasTrailingPeriod = text.endsWith('.');
-    final core = hasTrailingPeriod ? text.substring(0, text.length - 1) : text;
-    final words = core.trim().split(RegExp(r'\s+'));
-    final ipaParts = <String>[];
-    for (final w in words) {
-      final wordIpa = dictionary[w.toLowerCase()];
-      if (wordIpa == null) {
-        throw StateError(
-          'OOV word "$w" — neural dp_g2p fallback not yet wired '
-          '(dictionary-only frontend)',
-        );
+    // --- normalize: text -> tagged tokens (words + preserved symbols) ---
+    final normalizer = TtsTextNormalizer.forLocale(
+      locale,
+      symbolToId.keys.toSet(),
+    );
+    final tokens = normalizer.normalize(text);
+
+    // --- G2P: tokens -> IPA (dictionary first, neural fallback, else throw) ---
+    final ipa = StringBuffer();
+    for (final tok in tokens) {
+      if (tok is SymbolToken) {
+        ipa.write(tok.symbol);
+      } else if (tok is WordToken) {
+        final hit = dictionary[tok.word];
+        if (hit != null) {
+          ipa.write(hit);
+        } else if (neuralG2p != null) {
+          ipa.write(neuralG2p!(tok.word));
+        } else {
+          throw StateError(
+            'MatchaTextFrontend: OOV word "${tok.word}" and no neural '
+            'resolver wired.',
+          );
+        }
       }
-      ipaParts.add(wordIpa);
     }
-    final ipa = ipaParts.join(' ') + (hasTrailingPeriod ? '.' : '');
 
     // --- IPA chars -> symbol ids ---
     final pids = <int>[];
-    for (final rune in ipa.runes) {
+    for (final rune in ipa.toString().runes) {
       final ch = String.fromCharCode(rune);
       final id = symbolToId[ch];
       if (id != null) {
         pids.add(id);
       } else {
         throw StateError(
-          'TtsTextFrontend: IPA symbol "$ch" (U+${rune.toRadixString(16)}) '
+          'MatchaTextFrontend: IPA symbol "$ch" (U+${rune.toRadixString(16)}) '
           'is not in the 178-symbol table — cannot synthesize "$text".',
         );
       }
     }
     if (pids.isEmpty) {
       throw StateError(
-        'TtsTextFrontend: no symbols mapped for "$text" — cannot synthesize '
-        '(all IPA characters were outside the symbol table).',
+        'MatchaTextFrontend: no symbols mapped for "$text" — cannot '
+        'synthesize (all IPA characters were outside the symbol table).',
       );
     }
 
     final realLen = 2 * pids.length + 1;
     if (realLen > maxText) {
       throw StateError(
-        'TtsTextFrontend: chunk needs $realLen slots > MAX_TEXT $maxText '
+        'MatchaTextFrontend: chunk needs $realLen slots > MAX_TEXT $maxText '
         '(chunk before encode). Text: "$text".',
       );
     }

--- a/packages/flutter_gemma_speech/lib/src/tts/neural_g2p_decode.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/neural_g2p_decode.dart
@@ -21,8 +21,14 @@ Float32List encodeG2pInput(
     }
   }
   ids.add(end);
+  if (ids.length > maxT) {
+    throw StateError(
+      'neural G2P encode: word "$word" frames to ${ids.length} ids '
+      '> maxT $maxT',
+    );
+  }
   final out = Float32List(maxT);
-  for (var i = 0; i < ids.length && i < maxT; i++) {
+  for (var i = 0; i < ids.length; i++) {
     out[i] = ids[i].toDouble();
   }
   return out;
@@ -42,7 +48,13 @@ String decodeG2pOutput(
   for (var i = 0; i < stop; i++) {
     final id = argmax[i];
     if (id != prev) {
-      final ph = idx2ph[id] ?? '';
+      final ph = idx2ph[id];
+      if (ph == null) {
+        throw StateError(
+          'neural G2P decode: argmax id $id has no idx2ph entry '
+          '(n_phonemes/idx2ph mismatch in g2p_meta.json)',
+        );
+      }
       if (!specials.contains(ph) && ph != '_' && !lossy.contains(ph)) {
         sb.write(ph);
       }

--- a/packages/flutter_gemma_speech/lib/src/tts/neural_g2p_decode.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/neural_g2p_decode.dart
@@ -1,0 +1,53 @@
+library;
+
+import 'dart:typed_data';
+
+Float32List encodeG2pInput(
+  String word,
+  Map<String, int> char2idx, {
+  int charRepeats = 3,
+  int start = 1,
+  int end = 2,
+  int maxT = 96,
+}) {
+  final ids = <int>[start];
+  for (final ch in word.split('')) {
+    final id = char2idx[ch];
+    if (id == null) {
+      throw StateError('neural G2P: char "$ch" not in char2idx (word "$word")');
+    }
+    for (var r = 0; r < charRepeats; r++) {
+      ids.add(id);
+    }
+  }
+  ids.add(end);
+  final out = Float32List(maxT);
+  for (var i = 0; i < ids.length && i < maxT; i++) {
+    out[i] = ids[i].toDouble();
+  }
+  return out;
+}
+
+String decodeG2pOutput(
+  List<int> argmax,
+  Map<int, String> idx2ph, {
+  int end = 2,
+  Set<String> specials = const {'_', '<en_us>', '<end>', '<start>'},
+  Set<String> lossy = const {'̃', '̍', '̥', '̯', '͡'},
+}) {
+  var stop = argmax.indexOf(end);
+  if (stop < 0) stop = argmax.length;
+  final sb = StringBuffer();
+  int? prev;
+  for (var i = 0; i < stop; i++) {
+    final id = argmax[i];
+    if (id != prev) {
+      final ph = idx2ph[id] ?? '';
+      if (!specials.contains(ph) && ph != '_' && !lossy.contains(ph)) {
+        sb.write(ph);
+      }
+    }
+    prev = id;
+  }
+  return sb.toString();
+}

--- a/packages/flutter_gemma_speech/lib/src/tts/tts_frontend_input.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/tts_frontend_input.dart
@@ -1,0 +1,23 @@
+library;
+
+import 'dart:typed_data';
+
+/// Model-agnostic carrier for a text-encoder input. Sealed — each pipeline
+/// kind has its own variant (avoids nullable-per-model fields).
+sealed class TtsFrontendInput {
+  const TtsFrontendInput();
+}
+
+/// Matcha's text-encoder input: host-gathered symbol embeddings + mask.
+class MatchaFrontendInput extends TtsFrontendInput {
+  const MatchaFrontendInput(this.symbolEmbeddings, this.textMask, this.realLen);
+
+  /// Row-major [MAX_TEXT * n_channels] symbol embeddings (host-gathered from emb.bin).
+  final Float32List symbolEmbeddings;
+
+  /// [MAX_TEXT] text mask (1.0 for t < realLen else 0.0).
+  final Float32List textMask;
+
+  /// 2 * (#phoneme symbols) + 1 — the real blank-interspersed length.
+  final int realLen;
+}

--- a/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
@@ -9,8 +9,8 @@ import 'matcha_text_frontend.dart';
 import 'tts_frontend_input.dart';
 
 /// Resolves an out-of-dictionary word to its IPA transcription via a neural
-/// G2P model (`TtsCore.neuralG2p`, Task 7). Wired into the worker in Task 11
-/// — until then frontends built without a resolver still throw on OOV.
+/// G2P model (`TtsCore.neuralG2p`, Task 7), wired in by the worker (Task 11).
+/// A frontend built without a resolver still throws on OOV.
 typedef NeuralG2pResolver = String Function(String word);
 
 /// text -> `TtsCore`-ready frontend input, dispatched by

--- a/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
@@ -14,22 +14,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
 
-/// Output of the text frontend — exactly what the Matcha text-encoder graph
-/// consumes.
-class TtsFrontendInput {
-  TtsFrontendInput(this.symbolEmbeddings, this.textMask, this.realLen);
-
-  /// Row-major [maxText * nChannels] symbol embeddings (host-gathered from
-  /// emb.bin), feeds the encoder's `args_0` reshaped to [1, maxText,
-  /// nChannels].
-  final Float32List symbolEmbeddings;
-
-  /// [maxText] text mask (1.0 for t < realLen else 0.0), feeds `args_1`.
-  final Float32List textMask;
-
-  /// 2 * (#phoneme symbols) + 1 — the real (blank-interspersed) length.
-  final int realLen;
-}
+import 'tts_frontend_input.dart';
 
 /// Pure-Dart Matcha-TTS text frontend: dictionary G2P + blank-intersperse +
 /// host-side embedding gather. No neural fallback — OOV words throw.
@@ -105,7 +90,7 @@ class TtsTextFrontend {
   /// text -> frontend input. Throws [StateError] on an OOV word (this
   /// frontend is dictionary-only; the neural `dp_g2p` fallback needs FFI and
   /// belongs to `TtsCore`).
-  TtsFrontendInput encode(String text) {
+  MatchaFrontendInput encode(String text) {
     // --- G2P: text -> IPA (dictionary path only) ---
     final hasTrailingPeriod = text.endsWith('.');
     final core = hasTrailingPeriod ? text.substring(0, text.length - 1) : text;
@@ -163,6 +148,6 @@ class TtsTextFrontend {
       }
     }
 
-    return TtsFrontendInput(symbolEmbeddings, textMask, realLen);
+    return MatchaFrontendInput(symbolEmbeddings, textMask, realLen);
   }
 }

--- a/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
@@ -12,8 +12,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter_gemma/core/utils/gemma_log.dart';
-
 import 'tts_frontend_input.dart';
 
 /// Pure-Dart Matcha-TTS text frontend: dictionary G2P + blank-intersperse +
@@ -116,7 +114,10 @@ class TtsTextFrontend {
       if (id != null) {
         pids.add(id);
       } else {
-        gemmaLog('⚠️  TtsTextFrontend: dropping unmapped IPA symbol "$ch"');
+        throw StateError(
+          'TtsTextFrontend: IPA symbol "$ch" (U+${rune.toRadixString(16)}) '
+          'is not in the 178-symbol table — cannot synthesize "$text".',
+        );
       }
     }
     if (pids.isEmpty) {
@@ -126,13 +127,20 @@ class TtsTextFrontend {
       );
     }
 
+    final realLen = 2 * pids.length + 1;
+    if (realLen > maxText) {
+      throw StateError(
+        'TtsTextFrontend: chunk needs $realLen slots > MAX_TEXT $maxText '
+        '(chunk before encode). Text: "$text".',
+      );
+    }
+
     // --- blank-interspersed ids[maxText] + tmask[maxText] ---
     final ids = List<int>.filled(maxText, 0);
     for (var i = 0; i < pids.length; i++) {
       final pos = 1 + 2 * i;
-      if (pos < maxText) ids[pos] = pids[i];
+      ids[pos] = pids[i];
     }
-    final realLen = 2 * pids.length + 1;
     final textMask = Float32List(maxText);
     for (var t = 0; t < maxText; t++) {
       textMask[t] = t < realLen ? 1.0 : 0.0;

--- a/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/tts_text_frontend.dart
@@ -1,161 +1,36 @@
-/// Matcha-TTS text frontend — `text -> IPA (dictionary G2P) -> symbol ids ->
-/// blank-interspersed ids + text mask -> host-side emb.bin gather -> symbol
-/// embeddings`. Pure Dart, no FFI. The analog of STT's `HfTokenizer`: this is
-/// the input `TtsCore` (Task 2.3) feeds to the Matcha text-encoder graph.
-///
-/// The algorithm is transcribed verbatim from the verified reconstruction
-/// script `matcha_synth.dart` (`main()`, config/dict/emb parsing + G2P +
-/// blank-intersperse + gather).
+/// Text-frontend seam: resolves the pipeline-specific frontend (currently
+/// only Matcha-CFM's `MatchaTextFrontend`) from a [TtsModelProfile]. The
+/// analog of STT's tokenizer seam — `TtsCore` (Task 2.3) only ever talks to
+/// this interface, never to a concrete frontend class.
 library;
 
-import 'dart:convert';
-import 'dart:io';
-import 'dart:typed_data';
-
+import '../model/tts_model_profile.dart';
+import 'matcha_text_frontend.dart';
 import 'tts_frontend_input.dart';
 
-/// Pure-Dart Matcha-TTS text frontend: dictionary G2P + blank-intersperse +
-/// host-side embedding gather. No neural fallback — OOV words throw.
-class TtsTextFrontend {
-  /// Pure constructor from already-parsed data (unit-testable, no file I/O).
-  TtsTextFrontend({
-    required this.symbolToId,
-    required this.dictionary,
-    required this.embeddingTable,
-    required this.nChannels,
-    required this.maxText,
-  });
+/// Resolves an out-of-dictionary word to its IPA transcription via a neural
+/// G2P model (`TtsCore.neuralG2p`, Task 7). Wired into the worker in Task 11
+/// — until then frontends built without a resolver still throw on OOV.
+typedef NeuralG2pResolver = String Function(String word);
 
-  /// IPA char -> symbol id (178-symbol table for the real Matcha bundle).
-  final Map<String, int> symbolToId;
+/// text -> `TtsCore`-ready frontend input, dispatched by
+/// [TtsModelProfile.pipeline]. No FFI, pure Dart.
+abstract class TtsTextFrontend {
+  /// text -> frontend input (symbol embeddings + mask + real length).
+  MatchaFrontendInput encode(String chunk);
 
-  /// Lowercase word -> IPA string (274,927 entries for the real bundle).
-  final Map<String, String> dictionary;
-
-  /// [nSymbols * nChannels] row-major phoneme embedding table.
-  final Float32List embeddingTable;
-
-  /// Embedding width (192 for the real Matcha bundle).
-  final int nChannels;
-
-  /// Max text length in symbol slots (256 for the real Matcha bundle).
-  final int maxText;
-
-  /// Parse the real Matcha bundle files: `config.json` (symbols +
-  /// n_channels + MAX_TEXT), `g2p_dict.txt.gz` (gzipped word -> IPA
-  /// dictionary), `emb.bin` (little-endian f32 phoneme embedding table).
-  static Future<TtsTextFrontend> load({
-    required String configPath,
-    required String dictPath,
-    required String embeddingPath,
-  }) async {
-    final config =
-        jsonDecode(await File(configPath).readAsString())
-            as Map<String, dynamic>;
-    final symbols = (config['symbols'] as List).cast<String>();
-    final symbolToId = <String, int>{
-      // last-wins on duplicates, matches Python dict comprehension.
-      for (var i = 0; i < symbols.length; i++) symbols[i]: i,
-    };
-    final nChannels = (config['n_channels'] as num).toInt();
-    final maxText = (config['MAX_TEXT'] as num).toInt();
-
-    final gzBytes = await File(dictPath).readAsBytes();
-    final dictText = utf8.decode(gzip.decode(gzBytes));
-    final dictionary = <String, String>{};
-    for (final line in const LineSplitter().convert(dictText)) {
-      final tab = line.indexOf('\t');
-      if (tab < 0) continue;
-      dictionary[line.substring(0, tab)] = line.substring(tab + 1);
-    }
-
-    final embBytes = await File(embeddingPath).readAsBytes();
-    final embBd = ByteData.sublistView(embBytes);
-    final embeddingTable = Float32List(embBytes.length ~/ 4);
-    for (var i = 0; i < embeddingTable.length; i++) {
-      embeddingTable[i] = embBd.getFloat32(i * 4, Endian.little);
-    }
-
-    return TtsTextFrontend(
-      symbolToId: symbolToId,
-      dictionary: dictionary,
-      embeddingTable: embeddingTable,
-      nChannels: nChannels,
-      maxText: maxText,
-    );
-  }
-
-  /// text -> frontend input. Throws [StateError] on an OOV word (this
-  /// frontend is dictionary-only; the neural `dp_g2p` fallback needs FFI and
-  /// belongs to `TtsCore`).
-  MatchaFrontendInput encode(String text) {
-    // --- G2P: text -> IPA (dictionary path only) ---
-    final hasTrailingPeriod = text.endsWith('.');
-    final core = hasTrailingPeriod ? text.substring(0, text.length - 1) : text;
-    final words = core.trim().split(RegExp(r'\s+'));
-    final ipaParts = <String>[];
-    for (final w in words) {
-      final wordIpa = dictionary[w.toLowerCase()];
-      if (wordIpa == null) {
-        throw StateError(
-          'OOV word "$w" — neural dp_g2p fallback not yet wired '
-          '(dictionary-only frontend)',
-        );
-      }
-      ipaParts.add(wordIpa);
-    }
-    final ipa = ipaParts.join(' ') + (hasTrailingPeriod ? '.' : '');
-
-    // --- IPA chars -> symbol ids ---
-    final pids = <int>[];
-    for (final rune in ipa.runes) {
-      final ch = String.fromCharCode(rune);
-      final id = symbolToId[ch];
-      if (id != null) {
-        pids.add(id);
-      } else {
-        throw StateError(
-          'TtsTextFrontend: IPA symbol "$ch" (U+${rune.toRadixString(16)}) '
-          'is not in the 178-symbol table — cannot synthesize "$text".',
-        );
-      }
-    }
-    if (pids.isEmpty) {
-      throw StateError(
-        'TtsTextFrontend: no symbols mapped for "$text" — cannot synthesize '
-        '(all IPA characters were outside the symbol table).',
-      );
-    }
-
-    final realLen = 2 * pids.length + 1;
-    if (realLen > maxText) {
-      throw StateError(
-        'TtsTextFrontend: chunk needs $realLen slots > MAX_TEXT $maxText '
-        '(chunk before encode). Text: "$text".',
-      );
-    }
-
-    // --- blank-interspersed ids[maxText] + tmask[maxText] ---
-    final ids = List<int>.filled(maxText, 0);
-    for (var i = 0; i < pids.length; i++) {
-      final pos = 1 + 2 * i;
-      ids[pos] = pids[i];
-    }
-    final textMask = Float32List(maxText);
-    for (var t = 0; t < maxText; t++) {
-      textMask[t] = t < realLen ? 1.0 : 0.0;
-    }
-
-    // --- host emb.bin gather -> [maxText * nChannels] ---
-    final symbolEmbeddings = Float32List(maxText * nChannels);
-    for (var t = 0; t < maxText; t++) {
-      final srcBase = ids[t] * nChannels;
-      final dstBase = t * nChannels;
-      for (var c = 0; c < nChannels; c++) {
-        symbolEmbeddings[dstBase + c] = embeddingTable[srcBase + c];
-      }
-    }
-
-    return MatchaFrontendInput(symbolEmbeddings, textMask, realLen);
-  }
+  /// Load the frontend for [profile], resolving artifact paths from
+  /// [paths] (keyed by the profile's file-role names, e.g.
+  /// `paths[profile.configFile]`).
+  static Future<TtsTextFrontend> load(
+    TtsModelProfile profile,
+    Map<String, String> paths, {
+    NeuralG2pResolver? neuralG2p,
+  }) => switch (profile.pipeline) {
+    TtsPipelineKind.matchaCfm => MatchaTextFrontend.load(
+      profile,
+      paths,
+      neuralG2p: neuralG2p,
+    ),
+  };
 }

--- a/packages/flutter_gemma_speech/lib/src/tts/tts_text_normalizer.dart
+++ b/packages/flutter_gemma_speech/lib/src/tts/tts_text_normalizer.dart
@@ -1,0 +1,31 @@
+library;
+
+import 'english_text_normalizer.dart';
+
+sealed class NormToken {
+  const NormToken();
+}
+
+class WordToken extends NormToken {
+  const WordToken(this.word);
+  final String word;
+}
+
+class SymbolToken extends NormToken {
+  const SymbolToken(this.symbol);
+  final String symbol;
+}
+
+/// Language-agnostic normalizer contract. Punctuation/number/acronym POLICY is
+/// per-locale, so this is a seam (like TtsTextFrontend) — English is impl #1.
+abstract class TtsTextNormalizer {
+  List<NormToken> normalize(String text);
+  List<String> splitClauses(String text);
+  static TtsTextNormalizer forLocale(String locale, Set<String> symbols) =>
+      switch (locale) {
+        'en_us' || 'en' => EnglishTextNormalizer(symbols),
+        _ => throw UnimplementedError(
+          'No TtsTextNormalizer for locale "$locale"',
+        ),
+      };
+}

--- a/packages/flutter_gemma_speech/pubspec.yaml
+++ b/packages/flutter_gemma_speech/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_speech
 description: "On-device speech (STT + TTS) for flutter_gemma via the LiteRT C API + dart:ffi. Opt-in Stt/TtsBackendProvider."
-version: 0.2.0
+version: 0.3.0
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_speech
 topics: [speech, stt, gemma, litert, on-device]

--- a/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
+++ b/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_gemma_speech/src/tts/english_text_normalizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final n = EnglishTextNormalizer({' ', '.', ',', '?'}); // subset for the test
+  test('Hello world. -> [Word(hello) Sym( ) Word(world) Sym(.)]', () {
+    final t = n.normalize('Hello world.');
+    expect(
+      t
+          .map(
+            (x) => x is WordToken
+                ? 'W:${x.word}'
+                : 'S:${(x as SymbolToken).symbol}',
+          )
+          .toList(),
+      ['W:hello', 'S: ', 'W:world', 'S:.'],
+    );
+  });
+  test('comma becomes a SymbolToken, not stripped', () {
+    final t = n.normalize('Sure, ok');
+    expect(t.whereType<SymbolToken>().map((s) => s.symbol), contains(','));
+  });
+  test('splitClauses splits on sentence + clause boundaries', () {
+    expect(n.splitClauses('One, two. Three'), ['One,', 'two.', 'Three']);
+  });
+}

--- a/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
+++ b/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
@@ -66,4 +66,16 @@ void main() {
         .join(' ');
     expect(w, 'two zero zero zero zero zero zero users');
   });
+  test('backtick-wrapped content is kept, not deleted', () {
+    final w = EnglishTextNormalizer({' '})
+        .normalize('the `answer` is `42`')
+        .whereType<WordToken>()
+        .map((x) => x.word)
+        .toList();
+    // Inner content survives: "answer" stays a word, and "42" expands to
+    // its number words instead of vanishing.
+    expect(w, contains('answer'));
+    expect(w, isNot(contains('')));
+    expect(w, ['the', 'answer', 'is', 'forty', 'two']);
+  });
 }

--- a/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
+++ b/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
@@ -23,4 +23,26 @@ void main() {
   test('splitClauses splits on sentence + clause boundaries', () {
     expect(n.splitClauses('One, two. Three'), ['One,', 'two.', 'Three']);
   });
+  test('integer expands to words', () {
+    final t = EnglishTextNormalizer({' '}).normalize('3 cats');
+    expect((t.first as WordToken).word, 'three');
+  });
+  test('year expands', () {
+    final w = EnglishTextNormalizer({
+      ' ',
+    }).normalize('2023').whereType<WordToken>().map((x) => x.word).join(' ');
+    expect(w, 'twenty twenty three');
+  });
+  test('acronym GPU spells out', () {
+    final w = EnglishTextNormalizer({
+      ' ',
+    }).normalize('GPU').whereType<WordToken>().map((x) => x.word).join(' ');
+    expect(w, 'g p u');
+  });
+  test('markdown bold stripped to inner word', () {
+    final w = EnglishTextNormalizer({
+      ' ',
+    }).normalize('**Save**').whereType<WordToken>().map((x) => x.word).join();
+    expect(w, 'save');
+  });
 }

--- a/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
+++ b/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
@@ -45,4 +45,12 @@ void main() {
     }).normalize('**Save**').whereType<WordToken>().map((x) => x.word).join();
     expect(w, 'save');
   });
+  test('large number (>=1M) is digit-spelled, not a RangeError crash', () {
+    final w = EnglishTextNormalizer({' '})
+        .normalize('2,000,000 users')
+        .whereType<WordToken>()
+        .map((x) => x.word)
+        .join(' ');
+    expect(w, 'two zero zero zero zero zero zero users');
+  });
 }

--- a/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
+++ b/packages/flutter_gemma_speech/test/english_text_normalizer_test.dart
@@ -33,6 +33,19 @@ void main() {
     }).normalize('2023').whereType<WordToken>().map((x) => x.word).join(' ');
     expect(w, 'twenty twenty three');
   });
+  test('year 2005 keeps the "oh" (not "twenty five")', () {
+    final w = EnglishTextNormalizer({
+      ' ',
+    }).normalize('2005').whereType<WordToken>().map((x) => x.word).join(' ');
+    expect(w, contains('oh'));
+    expect(w, 'twenty oh five');
+  });
+  test('year 2000 reads as a plain number, not "twenty zero"', () {
+    final w = EnglishTextNormalizer({
+      ' ',
+    }).normalize('2000').whereType<WordToken>().map((x) => x.word).join(' ');
+    expect(w, 'two thousand');
+  });
   test('acronym GPU spells out', () {
     final w = EnglishTextNormalizer({
       ' ',

--- a/packages/flutter_gemma_speech/test/matcha_text_frontend_test.dart
+++ b/packages/flutter_gemma_speech/test/matcha_text_frontend_test.dart
@@ -1,0 +1,46 @@
+import 'dart:typed_data';
+
+import 'package:flutter_gemma_speech/src/tts/matcha_text_frontend.dart';
+import 'package:flutter_gemma_speech/src/tts/tts_frontend_input.dart';
+import 'package:flutter_gemma_speech/src/tts/tts_text_frontend.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Tiny table WITH a space symbol (unlike the fixture in
+  // tts_text_frontend_test.dart) so a multi-word chunk round-trips through
+  // the normalizer's SymbolToken(' ') without hitting the fail-loud
+  // unmapped-symbol throw.
+  MatchaTextFrontend fe({NeuralG2pResolver? g2p}) => MatchaTextFrontend(
+    symbolToId: {'_': 0, ' ': 1, '.': 2, 'a': 3, 'b': 4},
+    dictionary: {'ab': 'ab'},
+    embeddingTable: Float32List(5 * 2),
+    nChannels: 2,
+    maxText: 16,
+    neuralG2p: g2p,
+  );
+
+  test('known word + trailing period recompose (symbols kept)', () {
+    // normalize('ab.') -> [WordToken(ab), SymbolToken(.)] -> dict['ab']
+    // + '.' recomposed as "ab." -> IPA runes [a,b,.] -> pids [3,4,2] ->
+    // realLen = 2*3 + 1 = 7.
+    final o = fe().encode('ab.');
+    expect(o, isA<MatchaFrontendInput>());
+    expect(o.realLen, 7);
+  });
+
+  test('OOV word routes through neural resolver', () {
+    var called = '';
+    final o = fe(
+      g2p: (w) {
+        called = w;
+        return 'ab';
+      },
+    ).encode('zz');
+    expect(called, 'zz');
+    expect(o.realLen, greaterThan(0));
+  });
+
+  test('OOV word with no resolver throws', () {
+    expect(() => fe().encode('zz'), throwsA(isA<StateError>()));
+  });
+}

--- a/packages/flutter_gemma_speech/test/matcha_text_frontend_test.dart
+++ b/packages/flutter_gemma_speech/test/matcha_text_frontend_test.dart
@@ -43,4 +43,20 @@ void main() {
   test('OOV word with no resolver throws', () {
     expect(() => fe().encode('zz'), throwsA(isA<StateError>()));
   });
+
+  test(
+    'non-speech chunk (no symbols mapped) returns empty input, not a throw',
+    () {
+      // '👍' is not a letter, not whitespace, and not in the tiny symbol
+      // table, so the normalizer drops it entirely -> zero tokens -> zero
+      // pids. encode() must return a defined empty MatchaFrontendInput
+      // (realLen 0) instead of throwing, so the worker's `realLen <= 1`
+      // guard can skip this clause without erroring the whole request.
+      final o = fe().encode('👍');
+      expect(o, isA<MatchaFrontendInput>());
+      expect(o.realLen, 0);
+      expect(o.symbolEmbeddings, isEmpty);
+      expect(o.textMask, isEmpty);
+    },
+  );
 }

--- a/packages/flutter_gemma_speech/test/neural_g2p_decode_test.dart
+++ b/packages/flutter_gemma_speech/test/neural_g2p_decode_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_gemma_speech/src/tts/neural_g2p_decode.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final char2idx = {'<en_us>': 1, '<end>': 2, 'h': 10, 'i': 11};
+  test('encode frames char_repeats=3 + start/end, pads to 96, float', () {
+    final x = encodeG2pInput('hi', char2idx);
+    expect(x.length, 96);
+    expect(x.sublist(0, 8), [
+      1,
+      10,
+      10,
+      10,
+      11,
+      11,
+      11,
+      2,
+    ]); // <en_us> h h h i i i <end>
+    expect(x.sublist(8).every((v) => v == 0.0), isTrue);
+  });
+  test(
+    'decode truncates at first <end>, collapses, drops specials + lossy',
+    () {
+      // raw idx: <en_us> h h h ˈ _ ɛ l l <end> [garbage...]
+      final idx2ph = {
+        1: '<en_us>',
+        2: '<end>',
+        10: 'h',
+        51: 'ˈ',
+        0: '_',
+        37: 'ɛ',
+        13: 'l',
+        59: '͡',
+      };
+      final argmax = [
+        1,
+        10,
+        10,
+        10,
+        51,
+        0,
+        37,
+        13,
+        13,
+        2,
+        46,
+        46,
+        46,
+      ]; // tail after <end> ignored
+      expect(decodeG2pOutput(argmax, idx2ph), 'hˈɛl');
+    },
+  );
+  test('lossy tie-bar U+0361 is dropped', () {
+    final idx2ph = {2: '<end>', 20: 't', 59: '͡', 45: 'ʃ'};
+    expect(decodeG2pOutput([20, 59, 45, 2], idx2ph), 'tʃ');
+  });
+}

--- a/packages/flutter_gemma_speech/test/neural_g2p_decode_test.dart
+++ b/packages/flutter_gemma_speech/test/neural_g2p_decode_test.dart
@@ -54,4 +54,19 @@ void main() {
     final idx2ph = {2: '<end>', 20: 't', 59: '͡', 45: 'ʃ'};
     expect(decodeG2pOutput([20, 59, 45, 2], idx2ph), 'tʃ');
   });
+  test('decode throws StateError on argmax id missing from idx2ph (fail-loud, '
+      'not a silent blank)', () {
+    // idx2ph is missing an entry for id 99, which appears in argmax.
+    final idx2ph = {1: '<en_us>', 2: '<end>', 10: 'h'};
+    final argmax = [1, 10, 99, 2];
+    expect(() => decodeG2pOutput(argmax, idx2ph), throwsA(isA<StateError>()));
+  });
+  test('encode throws StateError when framed ids exceed maxT', () {
+    // charRepeats=3 default: 1 (start) + 3*len(word) + 1 (end) must be <=
+    // maxT. Use a tiny maxT so a short word already overflows it.
+    expect(
+      () => encodeG2pInput('hi', char2idx, maxT: 4),
+      throwsA(isA<StateError>()),
+    );
+  });
 }

--- a/packages/flutter_gemma_speech/test/tts_chunk_concat_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_chunk_concat_test.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+import 'package:flutter_gemma_speech/src/litert/tts_chunk.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('concatPcmWithSilence joins segments with a silence gap', () {
+    final a = Uint8List.fromList([1, 2]);
+    final b = Uint8List.fromList([3, 4]);
+    final out = concatPcmWithSilence([
+      a,
+      b,
+    ], silenceSamples: 1); // 1 sample = 2 bytes
+    expect(out, Uint8List.fromList([1, 2, 0, 0, 3, 4]));
+  });
+
+  test('a single segment is returned with no gap inserted', () {
+    final a = Uint8List.fromList([9, 8, 7, 6]);
+    final out = concatPcmWithSilence([a], silenceSamples: 5);
+    expect(out, Uint8List.fromList([9, 8, 7, 6]));
+  });
+
+  test('an empty segment list produces empty output', () {
+    final out = concatPcmWithSilence(<Uint8List>[], silenceSamples: 3);
+    expect(out, isEmpty);
+  });
+
+  test('zero silenceSamples concatenates with no gap', () {
+    final a = Uint8List.fromList([1, 2]);
+    final b = Uint8List.fromList([3, 4]);
+    final c = Uint8List.fromList([5, 6]);
+    final out = concatPcmWithSilence([a, b, c], silenceSamples: 0);
+    expect(out, Uint8List.fromList([1, 2, 3, 4, 5, 6]));
+  });
+
+  test('three segments insert a gap BETWEEN each, not around the ends', () {
+    final a = Uint8List.fromList([1, 1]);
+    final b = Uint8List.fromList([2, 2]);
+    final c = Uint8List.fromList([3, 3]);
+    final out = concatPcmWithSilence([a, b, c], silenceSamples: 1);
+    expect(out, Uint8List.fromList([1, 1, 0, 0, 2, 2, 0, 0, 3, 3]));
+  });
+}

--- a/packages/flutter_gemma_speech/test/tts_fail_loud_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_fail_loud_test.dart
@@ -1,0 +1,18 @@
+import 'dart:typed_data';
+
+import 'package:flutter_gemma_speech/src/tts/tts_text_frontend.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final fe = TtsTextFrontend(
+    symbolToId: {'_': 0, 'a': 1},
+    dictionary: {'x': 'aq'}, // 'q' not in table
+    embeddingTable: Float32List.fromList([0, 0, 10, 11]),
+    nChannels: 2,
+    maxText: 8,
+  );
+
+  test('unmapped IPA symbol is fail-loud, not silently dropped', () {
+    expect(() => fe.encode('x'), throwsA(isA<StateError>()));
+  });
+}

--- a/packages/flutter_gemma_speech/test/tts_fail_loud_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_fail_loud_test.dart
@@ -1,10 +1,10 @@
 import 'dart:typed_data';
 
-import 'package:flutter_gemma_speech/src/tts/tts_text_frontend.dart';
+import 'package:flutter_gemma_speech/src/tts/matcha_text_frontend.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  final fe = TtsTextFrontend(
+  final fe = MatchaTextFrontend(
     symbolToId: {'_': 0, 'a': 1},
     dictionary: {'x': 'aq'}, // 'q' not in table
     embeddingTable: Float32List.fromList([0, 0, 10, 11]),

--- a/packages/flutter_gemma_speech/test/tts_frontend_input_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_frontend_input_test.dart
@@ -1,0 +1,13 @@
+import 'dart:typed_data';
+import 'package:flutter_gemma_speech/src/tts/tts_frontend_input.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('MatchaFrontendInput is a TtsFrontendInput carrying the 3 fields', () {
+    final i = MatchaFrontendInput(_f, _f, 7);
+    expect(i, isA<TtsFrontendInput>());
+    expect(i.realLen, 7);
+  });
+}
+
+final _f = Float32List(0);

--- a/packages/flutter_gemma_speech/test/tts_model_profile_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_model_profile_test.dart
@@ -26,4 +26,14 @@ void main() {
       );
     }
   });
+
+  test(
+    'matcha profile declares phonemeSymbols + dictionaryPlusNeural + en_us',
+    () {
+      const p = TtsModelProfile.matcha();
+      expect(p.representation, TextRepresentation.phonemeSymbols);
+      expect(p.g2p, G2pStrategy.dictionaryPlusNeural);
+      expect(p.locale, 'en_us');
+    },
+  );
 }

--- a/packages/flutter_gemma_speech/test/tts_text_frontend_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_text_frontend_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter_gemma_speech/src/tts/tts_frontend_input.dart';
 import 'package:flutter_gemma_speech/src/tts/tts_text_frontend.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -20,6 +21,7 @@ void main() {
 
   test('encode blank-intersperses ids, builds mask + gathered embeddings', () {
     final out = frontend.encode('ab.'); // "ab" + trailing '.'
+    expect(out, isA<MatchaFrontendInput>());
     // IPA = "ab." -> symbol ids [1,2,3]; realLen = 2*3+1 = 7
     expect(out.realLen, 7);
     // ids: [0,1,0,2,0,3,0,0] (blank-interspersed, positions 1,3,5)

--- a/packages/flutter_gemma_speech/test/tts_text_frontend_test.dart
+++ b/packages/flutter_gemma_speech/test/tts_text_frontend_test.dart
@@ -1,12 +1,12 @@
 import 'dart:typed_data';
 
+import 'package:flutter_gemma_speech/src/tts/matcha_text_frontend.dart';
 import 'package:flutter_gemma_speech/src/tts/tts_frontend_input.dart';
-import 'package:flutter_gemma_speech/src/tts/tts_text_frontend.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   // Tiny 4-symbol table: '_'(0 blank/pad), 'a'(1), 'b'(2), '.'(3); 2 channels.
-  final frontend = TtsTextFrontend(
+  final frontend = MatchaTextFrontend(
     symbolToId: {'_': 0, 'a': 1, 'b': 2, '.': 3},
     dictionary: {'ab': 'ab'}, // word "ab" -> IPA "ab"
     embeddingTable: Float32List.fromList([
@@ -32,6 +32,10 @@ void main() {
     expect(out.symbolEmbeddings.sublist(2, 4), [10, 11]);
     expect(out.symbolEmbeddings.sublist(6, 8), [20, 21]);
     expect(out.symbolEmbeddings.sublist(0, 2), [0, 0]); // blank row
+  });
+
+  test('TtsTextFrontend.encode returns MatchaFrontendInput', () {
+    expect(frontend.encode('ab.'), isA<MatchaFrontendInput>());
   });
 
   test('OOV word throws (dictionary-only)', () {


### PR DESCRIPTION
Makes the on-device TTS text frontend survive real LLM text instead of only dictionary words. Fixes a latent bug in the shipped 0.2.0: `synthesize()` throws on punctuation / numbers / out-of-vocabulary words and silently truncates long text — so anything beyond `"Hello world."` fails today.

`flutter_gemma_speech` **0.2.0 → 0.3.0**. No public API change (the class restructuring stays under `lib/src/`; the barrel still exports only `LiteRtSttBackend` / `LiteRtTtsBackend`), no new dependencies, core (`flutter_gemma`) and `native-v0.14.0` untouched.

### What it delivers
- **Model-agnostic seam**: `TtsTextFrontend` resolved by pipeline + sealed `TtsFrontendInput` + a `TtsTextNormalizer` seam (`EnglishTextNormalizer` as impl #1), so Kokoro / Qwen3-TTS plug in later non-breakingly. Two capability axes (`TextRepresentation`, `G2pStrategy`) + `locale` on the profile.
- **Punctuation preserved as prosody symbols** (not stripped), plus number/acronym expansion and markdown/URL handling.
- **Clause chunking** in the worker (per-chunk CFM seed) for long replies.
- **Fail-loud** on `MAX_TEXT` / `MAX_MEL` overflow and unmapped symbols — no more silent truncation.
- **Neural `dp_g2p` OOV fallback** wired in `TtsCore` and injected as a `NeuralG2pResolver`, using a recipe verified against the real model.

### Verification
- Unit: 62/62; `flutter analyze` clean.
- On-device (macOS): **golden byte-exact** (`38912 == 38912` — the 12-task refactor moves the clean-text output zero bytes), and robustness **5/5** — punctuation (`"Sure, I can help with that."` — the case that crashed in 0.2.0), number, OOV via the real `dp_g2p` FFI graph, clause chunking, and a non-speech-clause case (`"Sounds good! 👍"` — the emoji clause is skipped, the rest still speaks).

Built and reviewed task-by-task; the final whole-branch review caught one cross-task integration bug (a non-speech clause errored the whole request) which is fixed here.

Prerequisite for the on-device voice loop (`VoiceSession`), which builds on this and ships next. Publish is a separate step.
