### PR TITLE
ci: pin jaspr_cli 0.23.1 (0.23.2 build daemon broken)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -28,7 +28,10 @@ jobs:
           cache: true
 
       - name: Install Jaspr CLI
-        run: dart pub global activate jaspr_cli
+        # Pin to 0.23.1 — jaspr_cli 0.23.2 fails with "Failed to start build
+        # daemon, port file is missing" (build-daemon regression). Matches the
+        # `jaspr: ^0.23.1` pin in website/pubspec.yaml. Bump deliberately.
+        run: dart pub global activate jaspr_cli 0.23.1
 
       - name: Build Jaspr site (SSG)
         working-directory: website

--- a/.github/workflows/website-build-check.yml
+++ b/.github/workflows/website-build-check.yml
@@ -25,7 +25,10 @@ jobs:
           cache: true
 
       - name: Install Jaspr CLI
-        run: dart pub global activate jaspr_cli
+        # Pin to 0.23.1 — jaspr_cli 0.23.2 fails with "Failed to start build
+        # daemon, port file is missing" (build-daemon regression). Matches the
+        # `jaspr: ^0.23.1` pin in website/pubspec.yaml. Bump deliberately.
+        run: dart pub global activate jaspr_cli 0.23.1
 
       - name: Build Jaspr site (SSG)
         working-directory: website

--- a/website/pubspec.lock
+++ b/website/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.3"
   build_runner:
     dependency: "direct dev"
     description:
@@ -650,4 +650,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <3.13.0-z"
+  dart: ">=3.11.0 <3.13.0-z"


### PR DESCRIPTION
The website SSG build (`website-build-check.yml` on every PR touching `website/` or `packages/flutter_gemma/example/`, and `firebase-hosting-merge.yml` on deploy) started failing with:

```
[CLI] [CRITICAL] Failed to start build daemon, port file is missing.
```

Root cause: both workflows run `dart pub global activate jaspr_cli` **unpinned**, which now pulls **jaspr_cli 0.23.2**, whose build-daemon startup is broken. `dart run build_runner build` (one-shot) works fine — only jaspr's daemon path fails. Verified locally: `jaspr build` fails on 0.23.2, succeeds on **0.23.1** (`Completed building project to /build/jaspr`).

Fix: pin `dart pub global activate jaspr_cli 0.23.1` in both workflows (matches `website/pubspec.yaml`'s `jaspr: ^0.23.1`). Also refreshed the transitive `build_daemon` lock 4.1.1 → 4.1.3.

This unblocks the website check on PRs #398 (and any future PR touching example/website) and prevents the merge-deploy from silently leaving the live site on the old build.