### PR TITLE
docs(website): bring fluttergemma.dev in line with 1.5.0

### DIFF
--- a/website/content/docs/embeddings-and-rag.md
+++ b/website/content/docs/embeddings-and-rag.md
@@ -53,7 +53,7 @@ await FlutterGemma.installEmbedder()
 ### Generate embeddings
 
 ```dart
-final embedder = FlutterGemmaPlugin.instance.initializedEmbeddingModel!;
+final embedder = await FlutterGemma.getActiveEmbedder();
 final embeddings = await embedder.generateEmbeddings(
   docs.map((d) => d.content).toList(),
   taskType: TaskType.retrievalDocument,
@@ -69,17 +69,22 @@ doesn't block the UI thread.
 
 ## On-device RAG / vector store
 
+All RAG operations live on the `FlutterGemma.rag` namespace — the canonical
+entry point. (The store is opt-in: register a `vectorStore:` in
+`FlutterGemma.initialize(...)`, or every `rag` call throws a clear "add a RAG
+package" error.)
+
 ```dart
 import 'package:flutter_gemma/flutter_gemma.dart';
 
 // 1. Install an embedding model (any of Gecko / EmbeddingGemma) — see above.
 
 // 2. Initialize the vector store (one shard per database path)
-await FlutterGemmaPlugin.instance.initializeVectorStore('rag_store');
+await FlutterGemma.rag.initialize('rag_store');
 
-// 3. Add documents — let the plugin compute embeddings for you
+// 3. Add documents — let flutter_gemma compute embeddings for you
 for (final doc in docs) {
-  await FlutterGemmaPlugin.instance.addDocument(
+  await FlutterGemma.rag.addDocument(
     id: doc.id,
     content: doc.content,
     metadata: '{"category":"science","lang":"en"}',
@@ -88,13 +93,13 @@ for (final doc in docs) {
 
 // 3b. Or batch-embed yourself and feed pre-computed vectors via
 //     addDocumentWithEmbedding(...) for higher throughput.
-final embedder = FlutterGemmaPlugin.instance.initializedEmbeddingModel!;
+final embedder = await FlutterGemma.getActiveEmbedder();
 final embeddings = await embedder.generateEmbeddings(
   docs.map((d) => d.content).toList(),
   taskType: TaskType.retrievalDocument,
 );
 for (var i = 0; i < docs.length; i++) {
-  await FlutterGemmaPlugin.instance.addDocumentWithEmbedding(
+  await FlutterGemma.rag.addDocumentWithEmbedding(
     id: docs[i].id,
     content: docs[i].content,
     embedding: embeddings[i],
@@ -103,7 +108,7 @@ for (var i = 0; i < docs.length; i++) {
 }
 
 // 4. Semantic search, with optional payload-aware Filter
-final results = await FlutterGemmaPlugin.instance.searchSimilar(
+final results = await FlutterGemma.rag.searchSimilar(
   query: 'quantum entanglement',
   topK: 10,
   threshold: 0.0,
@@ -112,6 +117,12 @@ final results = await FlutterGemmaPlugin.instance.searchSimilar(
     mustNot: [FieldEquals(key: 'lang', value: 'fr')],
   ),
 );
+
+// 5. Maintain the store: remove one document (no-op if the id is absent),
+//    read stats, or clear everything.
+await FlutterGemma.rag.removeDocument(id: 'doc-42');
+final stats = await FlutterGemma.rag.stats();
+await FlutterGemma.rag.clear();
 ```
 
 ## The Filter API

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.4.1
+  flutter_gemma: ^1.5.0
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.3.1   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -33,6 +33,11 @@ SmolLM and more — see [Models](/docs/models) for the full list.
 - **Text Embeddings & RAG:** Generate vector embeddings (EmbeddingGemma, Gecko) and run on-device RAG. See [Embeddings & RAG](/docs/embeddings-and-rag).
 - **Web Persistent Caching:** Models persist across browser restarts using the Cache API (Web only).
 
+## What's new in 1.5
+
+- **genai_primitives support** — drive an on-device chat with the Flutter team's standard `ChatMessage` types via `package:flutter_gemma/genai.dart` (`sendMessage`/`generateContent` + streams, covering text, vision, audio, thinking, and tool calls). See [genai_primitives](/docs/genai).
+- **`FlutterGemma` is the one canonical entry point.** RAG moved onto the `FlutterGemma.rag.*` namespace (`initialize`/`addDocument`/`addDocumentWithEmbedding`/`searchSimilar`/`removeDocument`/`stats`/`clear`), and the facade gained model introspection (`activeModelSpec`/`activeEmbedderSpec`/`activeSttSpec`/`activeTtsSpec`, `getModelPath`), storage helpers (`getStorageInfo`/`getOrphanedFiles`/`cleanupStorage`/`performCleanup`), and per-modality uninstallers (`uninstallEmbedder`/`uninstallStt`/`uninstallTts`). `FlutterGemmaPlugin.instance` is now a documented low-level SPI tier — app code shouldn't need it.
+
 ## What's new in 1.0
 
 - **Modular package split** — the monolith is now a small **core** (`flutter_gemma`) plus **opt-in** packages, so your app ships only the native weight it uses: `flutter_gemma_litertlm` (.litertlm), `flutter_gemma_mediapipe` (.task/.bin), `flutter_gemma_embeddings`, `flutter_gemma_rag_qdrant`, `flutter_gemma_rag_sqlite`. See [Packages](/docs/packages).
@@ -176,9 +181,20 @@ If you only ever have one conversation at a time, stick with the simpler
 
 ## Managing Installed Models
 
-Use `uninstallModel()` to delete a model's files and metadata. When you remove
-the model that is currently **active**, also clear its persisted identity so it
-isn't auto-restored on the next app launch:
+### Uninstalling
+
+For the **active** embedder / STT / TTS model, one call deletes every file it
+owns (e.g. an embedder's model *and* tokenizer) and clears its persisted
+identity so it isn't auto-restored on the next launch:
+
+```dart
+await FlutterGemma.uninstallEmbedder(); // deletes model + tokenizer, clears identity
+await FlutterGemma.uninstallStt();
+await FlutterGemma.uninstallTts();
+```
+
+To delete an inference model, or any model by filename, use `uninstallModel()`
+and clear the active inference identity if you removed the active one:
 
 ```dart
 // Free in-memory handles first if the model is loaded.
@@ -189,17 +205,41 @@ await FlutterGemma.uninstallModel('Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.lit
 
 // Clear the persisted "active model" identity so it isn't auto-restored.
 await FlutterGemma.clearActiveInferenceIdentity();
-
-// For an embedder, pair uninstallModel() with:
-await FlutterGemma.clearActiveEmbeddingIdentity();
 ```
 
 <Info>
-`clearActiveInferenceIdentity()` / `clearActiveEmbeddingIdentity()` wipe both the
-in-memory active spec and the persisted preference. Pair them with
-`uninstallModel()` only when the deleted model was the active one — otherwise it
-would be restored as active on the next launch.
+`clearActiveInferenceIdentity()` wipes both the in-memory active spec and the
+persisted preference. Pair it with `uninstallModel()` only when the deleted model
+was the active one. The `uninstallEmbedder/Stt/Tts` helpers already clear the
+identity for you.
 </Info>
+
+### Inspecting what's active
+
+Cheap, synchronous getters return the active model's **identity** (its spec)
+without loading the engine — use these to render UI, not `getActiveModel()`
+(which loads the runtime). Each is typed to its modality:
+
+```dart
+final InferenceModelSpec? model = FlutterGemma.activeModelSpec;
+final EmbeddingModelSpec? embedder = FlutterGemma.activeEmbedderSpec;
+final SttModelSpec? stt = FlutterGemma.activeSttSpec;
+final TtsModelSpec? tts = FlutterGemma.activeTtsSpec;
+
+// Absolute on-device path of an installed file (a URL/OPFS handle on web):
+final path = await FlutterGemma.getModelPath('Gemma3-1B-IT_..._ekv4096.litertlm');
+```
+
+### Storage & cleanup
+
+Inspect on-device usage and reclaim space left by interrupted downloads:
+
+```dart
+final info = await FlutterGemma.getStorageInfo();      // StorageStats: files + bytes
+final orphans = await FlutterGemma.getOrphanedFiles();  // fragments with no metadata
+final removed = await FlutterGemma.cleanupStorage();    // delete orphans, returns count
+await FlutterGemma.performCleanup();                    // cancel stale tasks + sweep
+```
 
 ## Message Types
 

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,7 +29,7 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.4.1                 # core — always required
+  flutter_gemma: ^1.5.0                 # core — always required
   flutter_gemma_litertlm: ^1.3.1        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.4      # add if you compute embeddings
@@ -116,8 +116,9 @@ await FlutterGemma.installEmbedder()
     .modelFromNetwork(modelUrl, token: token)
     .tokenizerFromNetwork(tokenizerUrl, token: token)
     .install();
-await FlutterGemmaPlugin.instance.addDocument(/* ... */);
-final hits = await FlutterGemmaPlugin.instance.searchSimilar(query, topK: 5);
+await FlutterGemma.rag.initialize('rag_store');
+await FlutterGemma.rag.addDocument(/* ... */);
+final hits = await FlutterGemma.rag.searchSimilar(query: query, topK: 5);
 ```
 
 ## What you'll see if you forget step 2

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -30,7 +30,7 @@ inference.
 
 ```
 dependencies:
-  flutter_gemma: ^1.4.1
+  flutter_gemma: ^1.5.0
   flutter_gemma_speech: ^0.3.0
 ```
 


### PR DESCRIPTION
Brings fluttergemma.dev in line with the 1.5.0 API surface (audited every doc for coverage).

## Changes
- **RAG on the canonical facade** — `embeddings-and-rag.md` and the `migration.md` quick-example now use `FlutterGemma.rag.*` (`initialize`/`addDocument`/`addDocumentWithEmbedding`/`searchSimilar`/`removeDocument`/`stats`/`clear`) and `getActiveEmbedder()`, instead of the low-level `FlutterGemmaPlugin.instance.*` path (now SPI/legacy).
- **New facade APIs documented** — `getting-started.md` "Managing Installed Models" now covers the per-modality uninstallers (`uninstallEmbedder`/`uninstallStt`/`uninstallTts`), the typed identity getters (`activeModelSpec`/`activeEmbedderSpec`/`activeSttSpec`/`activeTtsSpec`) + `getModelPath`, and the storage helpers (`getStorageInfo`/`getOrphanedFiles`/`cleanupStorage`/`performCleanup`).
- **What's new in 1.5** section — summarizes genai_primitives + the facade-as-canonical-entry-point work.
- **Version pins** — core `flutter_gemma` `^1.4.1` → `^1.5.0` (genkit / migration / speech). Satellites unchanged.

genai_primitives already has its own `genai.md` (shipped in #363).

## Verification
`jaspr build` completes all 16 routes, no `[ERROR]`; all code fences are `dart`/plain (SSG-safe).

## Merge timing
Merge **after** `flutter_gemma 1.5.0` is published to pub.dev — the site auto-deploys on merge to `main`, and the bumped pins must not advertise a version that isn't live yet.
