### PR TITLE
fix(litertlm): drop thinking output from the KV cache on FFI

### DIFF
--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.2
+- Drop thinking output from the KV cache on FFI, as web already does.
+
 ## 1.3.1
 - Clearer engine-create error for GPU-only `.litertlm` models run on CPU (#390).
 

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
@@ -130,6 +130,7 @@ class FfiInferenceModel extends InferenceModel with CloseNotifier {
         topP: topP,
         seed: randomSeed,
         maxOutputTokens: maxOutputTokens,
+        enableThinking: enableThinking,
       );
       gemmaLog(
         '[FfiInferenceModel/perf] createConversation (FFI): ${sessionSw.elapsedMilliseconds - beforeConv}ms',
@@ -658,6 +659,7 @@ class _VirtualConversationHandle implements ConversationHandle {
         seed: seed,
         extraContext: extraContext,
         maxOutputTokens: maxOutputTokens,
+        enableThinking: enableThinking,
       )) {
         final chunkText = LiteRtLmFfiClient.extractTextFromResponse(rawChunk);
         assistantText.write(chunkText);

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -873,6 +873,7 @@ class LiteRtLmFfiClient {
     double? topP,
     int seed = 1,
     int? maxOutputTokens,
+    bool enableThinking = false,
   }) {
     // The handle must be registered before the guard lifts: otherwise shutdown()
     // can clear _handles between the create and the add, leaving a live
@@ -896,6 +897,7 @@ class LiteRtLmFfiClient {
           topP: topP,
           seed: seed,
           maxOutputTokens: maxOutputTokens,
+          enableThinking: enableThinking,
         ),
       );
       gemmaLog('[LiteRtLmFfi] Conversation created');
@@ -921,6 +923,7 @@ class LiteRtLmFfiClient {
     double? topP,
     int seed = 1,
     int? maxOutputTokens,
+    bool enableThinking = false,
   }) async {
     _assertInitialized();
     final b = _bindings!;
@@ -1021,6 +1024,18 @@ class LiteRtLmFfiClient {
         b.litert_lm_conversation_config_set_messages(
           convConfig,
           messagesPtr.cast(),
+        );
+      }
+      // Thinking output is per-turn scratch work. Left in the KV cache it is
+      // re-prefilled on every later turn of the same conversation, so a long
+      // chat pays for reasoning the user never sees and that the model does
+      // not need again. The web path already pairs the two
+      // (`filterChannelContentFromKvCache: enableThinking ? true : null` in
+      // litert_lm_web_inference.dart); this is the FFI half.
+      if (enableThinking) {
+        b.litert_lm_conversation_config_set_filter_channel_content_from_kv_cache(
+          convConfig,
+          true,
         );
       }
     }
@@ -1292,6 +1307,7 @@ class LiteRtLmFfiClient {
     int seed = 1,
     String? extraContext,
     int? maxOutputTokens,
+    bool enableThinking = false,
   }) {
     // StreamController (not async*) so the mutex release is tied to the
     // controller lifecycle — it fires on done, error, AND consumer cancel /
@@ -1358,6 +1374,7 @@ class LiteRtLmFfiClient {
               topP: topP,
               seed: seed,
               maxOutputTokens: maxOutputTokens,
+              enableThinking: enableThinking,
             );
             _virtualConv = conv;
             _virtualActiveToken = conversationToken;

--- a/packages/flutter_gemma_litertlm/pubspec.yaml
+++ b/packages/flutter_gemma_litertlm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_litertlm
 description: "LiteRT-LM (.litertlm) on-device inference engine for flutter_gemma via dart:ffi (5 native platforms) + web. Opt-in InferenceEngineProvider."
-version: 1.3.1
+version: 1.3.2
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_litertlm
 topics: [gemma, llm, litert, on-device, ffi]


### PR DESCRIPTION
## Problem

`litert_lm_conversation_config_set_filter_channel_content_from_kv_cache` is declared in `native/litert_lm/include/engine.h` and bound in `litert_lm_bindings.dart`, but nothing on the FFI path ever calls it.

The web path already pairs the two — `litert_lm_web_inference.dart`:

```dart
filterChannelContentFromKvCache: enableThinking ? true : null,
```

`_createRawConversation` in `litert_lm_client.dart` sets `session_config`, `system_message`, `tools`, `enable_constrained_decoding` and `messages`, but not the channel filter, and it had no `enableThinking` parameter to key it off. So on the five native platforms thinking output stays in the KV cache and is re-prefilled on every later turn of the same conversation, while web does not have that cost.

`enableThinking` is already threaded as far as `_chatOn` / `_chatRawOn`, where it becomes per-message `extra_context` — it just never reached the conversation config.

## Change

Threads `enableThinking` from `createSession` down through `createConversationHandle` and `startVirtualTurn` into `_createRawConversation`, and sets the filter when thinking is on.

Defaults to `false` throughout, so nothing changes for sessions that do not enable thinking.

## Why it matters

Measured on a Galaxy M33 (Exynos 1280, Android 15) with Gemma 4 E2B and tools enabled, over a scripted 10-turn conversation run 3×:

- context grows ~109 tokens/turn, and thinking is retained in the cache across all of it
- a warm turn's time-to-first-token is ~4.4s against a ~14.4s cold turn 1, so prefill is already the cheap part — but it grows with every turn that keeps thought in the cache

Turning thinking off entirely cut a 10-turn conversation from 283s to 211s, which is the same cost from the other direction: reasoning that is paid for repeatedly and never read.

## Notes

- No behaviour change for `enableThinking: false`
- `dart analyze` on the two changed files reports 235 issues both before and after this change (all pre-existing `override_on_non_overriding_member` warnings)
- Version bumped to 1.3.2 with a one-line CHANGELOG entry per the repo convention

## Follow-up, not in this PR

`enableThinking` is a `final` field on the session, so it cannot vary per message even though the native layer accepts `extra_context` per message. For a tool-calling chat turn that means the round which only emits a tool-call envelope pays full chain-of-thought for it. Happy to open a separate issue if that is worth pursuing.
