### PR TITLE
fix(litertlm): detect stream-callback ABI at runtime (LiteRT-LM v0.15.0)

### DIFF
--- a/.claude/skills/build-native/SKILL.md
+++ b/.claude/skills/build-native/SKILL.md
@@ -16,53 +16,160 @@ This skill exists because we shipped 0.14.0 and 0.14.1 with native dylibs that b
 
 ### Required upstream commit
 
-iOS dylib **must** be built from upstream LiteRT-LM commit **`5e0d86b`** ("Update dependencies of litert_lm"). It is the first commit that ships `libLiteRtMetalAccelerator.dylib` for iOS. The `v0.10.2` tag predates this — building against it produces a `libLiteRtLm.dylib` whose Metal accelerator vtable doesn't match the prebuilt framework, and you get `EXC_BAD_ACCESS` inside `litert_lm_engine_create` on iPhone. `build_ios.sh` already defaults to `5e0d86b`. Do not pass `v0.10.2`.
+**Pin the exact tag commit SHA on every platform, and pass it explicitly.** Upstream has retagged releases in place before, so a tag *name* is not a stable reference. Get the SHA with:
 
-macOS, Linux, Windows, Android: latest tag (currently `v0.10.2`) works — the Metal accelerator constraint is iOS-only.
+```bash
+gh api repos/google-ai-edge/LiteRT-LM/git/ref/tags/<tag> --jq '.object.sha'
+```
+
+The scripts' `DEFAULT_REF` lags whatever release you are migrating to, so never rely on it — `build_ios.sh` still defaulted to the v0.14.0-era `80f301ff` during the v0.15.0 migration.
+
+**The historical iOS `5e0d86b` pin is obsolete.** It existed because `5e0d86b` was the first commit shipping `libLiteRtMetalAccelerator.dylib` for iOS, and older tags produced a `libLiteRtLm.dylib` whose Metal-accelerator vtable didn't match the prebuilt framework → `EXC_BAD_ACCESS` inside `litert_lm_engine_create` on device. Modern tags ship their own `prebuilt/ios_arm64/`, so building iOS from the tag is now the *safer* option.
+
+The real invariant is: **source and accelerator prebuilts must come from the same tree.** Mixing them is the hazard — not the choice of tag. Verify before building:
+
+```bash
+gh api "repos/google-ai-edge/LiteRT-LM/contents/prebuilt/ios_arm64?ref=<tag>" --jq '.[].name'
+# needs libLiteRtMetalAccelerator.dylib + libLiteRtTopKMetalSampler.dylib
+```
+
+### The LiteRT pin is a second ABI surface — check it every time
+
+A LiteRT-LM bump silently moves `LITERT_REF` in `WORKSPACE` (line ~6), and that is a **different upstream repo** with its own C API. This matters because the packages consume two different APIs:
+
+- `flutter_gemma_litertlm` → LiteRT-LM C API (`c/engine.h`)
+- `flutter_gemma_embeddings`, `flutter_gemma_speech` → **LiteRT** C API directly, via hand-written bindings in `lib/src/litert/`
+
+So a green litertlm smoke run proves nothing about embeddings. In the v0.14.0 migration the pin moved, `LiteRtCreateModelFromFile` gained a third parameter (`LiteRtEnvironment` first), and embeddings silently returned `status=500` — a full day lost before the cause was found.
+
+```bash
+for t in <old-tag> <new-tag>; do
+  gh api "repos/google-ai-edge/LiteRT-LM/contents/WORKSPACE?ref=$t" --jq '.content' | base64 -d | grep '^LITERT_REF'
+done
+```
+
+If it moved, diff the headers the bindings use (`litert/c/litert_{model,environment,options,tensor_buffer,compiled_model}.h`) at both refs. Symbol list:
+`grep -ohE "LiteRt[A-Za-z_]+" packages/flutter_gemma_embeddings/lib/src/litert/*.dart | sort -u`
+
+Known: v0.14.0 (`622f1f3c`) **breaking**; v0.15.0 (`3cb830ad`) safe — four headers byte-identical, `litert_compiled_model.h` only gains `LiteRtGetCompiledModelEnvironment()`.
 
 ### Required linker flags
 
 | Platform | Flag | Why |
 |---|---|---|
 | **macOS / iOS** | `-Wl,-headerpad_max_install_names` | Native Assets re-runs `install_name_tool -id @rpath/...` on every `pub get`. Without headerpad, the rewrite fails with "larger updated load commands do not fit" and `pub get` aborts. |
+| **macOS** | `-mmacosx-version-min=11.0` | Without it clang stamps `LC_BUILD_VERSION` with the **build host's** OS, so the bundle's floor silently tracks whichever Mac produced it. |
+| **Android** | `aarch64-linux-android24-clang` (target triple carries the API level) | Same reason, stated explicitly rather than inherited. |
 | Linux | `-Wl,--dynamic-list=...` (already in patch_c_api.sh §1) | Exports LiteRt* / litert_lm_* symbols for the WebGPU accelerator's `dlsym(RTLD_DEFAULT)` |
 | Windows | `/DEF:windows_exports.def` (already in patch_c_api.sh §1) | Bazel native attribute |
 | All | `-fvisibility=hidden` is **WRONG** for our use case — needs default visibility on the listed export sets |
 
 The `headerpad_max_install_names` flag is **not optional on Apple platforms**. Verify in the post-build checklist below.
 
+**Deployment target must be stated, never inherited.** This bites only the libraries *we* compile — the upstream prebuilt companions arrive with their own sane values (11.0 / 14.0), so a single odd number in the middle of an otherwise healthy bundle is the signature. `native-v0.14.0` shipped `libStreamProxy.dylib` with `minos 26.0` for exactly this reason: `build_macos.sh` compiled it with a bare `clang -shared` on a macOS 26 host, while `example/macos/Podfile` advertises `platform :osx, '10.15'`. `build_ios.sh` never had the bug because its step 8b force-normalizes every companion to 13.0 with `vtool -set-build-version`. Check every self-built binary:
+
+```bash
+for f in prebuilt/macos_arm64/*.dylib; do
+  printf "%-46s minos=%s\n" "$(basename $f)" "$(vtool -show-build "$f" | awk '/minos/{print $2; exit}')"
+done
+```
+
+Anything at or near the current macOS release means the flag was dropped. Rebuilding one dylib is a two-second `clang` call — no Bazel involved — so there is never a reason to ship it wrong.
+
 ### Patches we apply
 
-`native/litert_lm/patch_c_api.sh` sections:
+`native/litert_lm/patch_c_api.sh` — the surviving sections (2–9 were **deleted** at the v0.14.0 migration once upstream implemented them natively; don't go looking for them):
+
 1. `cc_binary(linkshared=True)` target + Linux dynamic-list + Windows .def
-2-3. `set_max_num_images` C API + `set_cache_dir` propagation to vision/audio executors
-4. `set_litert_dispatch_lib_dir` C API
-5. 6-arg `litert_lm_conversation_config_create` overload
-6-9. `SetPendingSamplerParams` virtual + executor override + `SessionBasic` push (matches our PR #2081 — drop these once it merges)
-10b. **App Store ITMS-90432 fix** — rewrite `gpu_registry.cc` dlopen to `@executable_path/...framework/<X>` path on Apple. **iOS-critical** — without it App Store rejects 0.14.0 builds.
+4b. `set_use_hw_masking_for_npu` (Intel LunarLake/PantherLake — default `true` crashes their NPU)
+4c. GPU smooth-UI knobs — `gpu_context_low_priority` + `kernel_batch_size` (#364)
+10b. **App Store ITMS-90432 fix** — rewrite `gpu_registry.cc` dlopen to `@executable_path/...framework/<X>` on Apple. **iOS-critical.**
+11. minizip/zlib mirrored off the flaky zlib.net
 
 §10a (sampler_factory.cc) is **deliberately NOT patched** — `libLiteRtTopKMetalSampler.dylib` has 3-of-7 broken exports on Apple (#2073). Patching it surfaces a NULL-vtable crash. Leave the basename dlopen so `sampler_factory.cc` falls back to CPU sampler. Revisit when Google fixes #2073.
+
+Dry-run the patcher against the new tag before building anything — every section must print `OK`, never `WARN`:
+
+```bash
+bash native/litert_lm/patch_c_api.sh /tmp/LiteRT-LM
+```
+
+On Windows/git-bash, `python3` resolves to the Microsoft Store stub, which prints "Python was not found" **and still exits 0** — so sections 10b and 11 silently no-op. Shim it first:
+`printf '#!/bin/sh\nexec "<path>/python.exe" "$@"\n' > /somewhere/python3 && chmod +x` and prepend that dir to `PATH`.
+
+### Cloning upstream without fighting the network
+
+The repo carries large LFS binaries; a full clone repeatedly dies mid-transfer on anything but a rock-solid link, and the failure restarts from zero. Clone the tag shallow with LFS deferred, then pull only the platforms you're building:
+
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git -c http.version=HTTP/1.1 -c http.postBuffer=524288000 \
+  clone --depth 1 --branch <tag> https://github.com/google-ai-edge/LiteRT-LM /tmp/LiteRT-LM
+cd /tmp/LiteRT-LM
+git lfs pull --include="prebuilt/macos_arm64/*,prebuilt/ios_arm64/*,prebuilt/ios_sim_arm64/*,prebuilt/android_arm64/*"
+```
+
+**Then point `origin` at a local bare mirror.** `build_*.sh` run `git fetch --tags --force origin` whenever the clone dir already exists — cheap on a full clone, near-endless on a shallow one, because every other tag's objects have to be fetched. Redirecting origin makes that fetch local and instant (measured: 0.03 s), and removes the network from the build loop entirely:
+
+```bash
+git clone --bare /tmp/LiteRT-LM /tmp/LiteRT-LM-mirror.git
+cd /tmp/LiteRT-LM && git remote set-url origin /tmp/LiteRT-LM-mirror.git
+```
+
+Verify the LFS pull produced real binaries, not pointers — `head -c 20 <file>` starting with `version https` means it's still a pointer.
+
+### ⚠️ NPU stacks are NOT produced by the build — carry them forward
+
+Both NPU dispatch stacks live in the previous release, not in the compiler output. A fresh build always yields **zero** of them; treat that as the default, not as a failure to investigate. Confirmed at v0.14.0 ("2 critical NPU drops") and again at v0.15.0.
+
+| Bundle | Files to restore | Pattern |
+|---|---|---|
+| `windows_x86_64` | **12** — Intel NPU dispatch | `LiteRtDispatch.dll`, `openvino*.dll`, `tbb*.dll` |
+| `android_arm64` | **11** — Qualcomm QNN | `libQnn*.so`, `libLiteRtDispatch_Qualcomm.so` |
+
+```bash
+gh release download native-v<prev> --repo DenisovAV/flutter_gemma \
+  -p "litertlm-windows_x86_64.tar.gz" -D /tmp/prev --clobber
+mkdir -p /tmp/prev/x && tar xzf /tmp/prev/litertlm-windows_x86_64.tar.gz -C /tmp/prev/x
+find /tmp/prev/x -maxdepth 1 -type f \( -name 'LiteRtDispatch*' -o -name 'openvino*' -o -name 'tbb*' \) \
+  -exec cp -p {} <windows-bundle-dir>/ \;
+```
+
+Then assert both the count **and** byte-identity against the previous release (sha256 per file). Shipping without them doesn't fail any build — it fails silently for every user on `PreferredBackend.npu`.
 
 ---
 
 ## Build commands
 
+Always pass the pinned SHA explicitly — the scripts' `DEFAULT_REF` lags the release you're migrating to.
+
 ```bash
-# macOS arm64 (run on a Mac)
-./native/litert_lm/build_macos.sh             # latest tag is fine
+REF=<tag-commit-sha>
+export ANDROID_NDK_HOME="$HOME/Library/Android/sdk/ndk/29.0.14206865"   # r29 mandatory
 
-# iOS device + simulator (run on a Mac)
-./native/litert_lm/build_ios.sh               # defaults to 5e0d86b — DO NOT override
-
-# Android arm64 (cross-compile from macOS)
-./native/litert_lm/build_android.sh
-
-# Linux x86_64  → flutter-gemma-linux GCloud VM
-# Windows x86_64 → flutter-gemma-gpu GCloud VM (long-running, use Scheduled Task)
-# See project_gcloud_vm_workflow memory.
+./native/litert_lm/build_macos.sh   "$REF"    # macOS arm64
+./native/litert_lm/build_ios.sh     "$REF"    # iOS device + simulator
+./native/litert_lm/build_android.sh "$REF"    # Android arm64, cross-compiled
 ```
 
-**`bazelisk clean --expunge` before rebuild only if WORKSPACE patch_cmds changed** (otherwise incremental is fine and ~5× faster).
+`ANDROID_NDK_HOME` must be **exported explicitly**: `build_android.sh` auto-detects the newest NDK *only when the variable is unset*, so a stale value in your shell silently selects the wrong toolchain (r26 fails on a C++20 concept in the minijinja chat template).
+
+**Linux x86_64/arm64 and Windows x86_64 build in CI**, not on a VM: dispatch `build-litertlm-native.yml` with `-f litertlm_version=<SHA>`. Use `--ref <branch>` if the migration carries source changes — the workflow compiles `stream_proxy.c` from the checked-out tree, so dispatching from `main` would silently ship a stale shim.
+
+**`bazelisk clean --expunge` before rebuild only if WORKSPACE patch_cmds changed** (otherwise incremental is fine and ~5× faster — a warm cache can finish a platform in 2–5 min, which is normal and not a sign that nothing was built).
+
+### Never trust a build's exit code — verify artifacts
+
+Wrapper scripts have reported success while producing nothing (a failed `git clone` inside the script, an `echo` after the build masking its status, `gh` printing a network error and still exiting 0). Confirm each platform by **artifact**, not by status line:
+
+```bash
+f=prebuilt/<dir>/libLiteRtLm.dylib      # or .so
+printf "exists=%s mtime=%s newversion_symbol=%s\n" \
+  "$([ -f "$f" ] && echo yes || echo NO)" \
+  "$(stat -f '%Sm' -t '%H:%M' "$f" 2>/dev/null)" \
+  "$([ -f "$f" ] && nm -gU "$f" 2>/dev/null | grep -c '<symbol-new-in-this-version>')"
+```
+
+Print `exists` **next to** the symbol count. `nm` on a missing file emits nothing and `grep -c` turns that into a perfectly innocent `0` — "feature absent" and "check never ran" must not look identical. The same applies to shell globs: in zsh an unmatched `*.so` aborts the whole `ls`, so use `find … \( -name '*.dylib' -o -name '*.so' \)` in verification loops.
 
 ---
 
@@ -83,20 +190,19 @@ otool -hv native/litert_lm/prebuilt/<dir>/libLiteRtLm.dylib | tail -2
 # → cputype 16777228 (arm64), filetype 6 (DYLIB)
 ```
 
-### 2. Header padding (macOS / iOS) — **the one I missed**
+### 2. Header padding (macOS / iOS) — measure it with check #4, not with `sizeofcmds`
 
-```bash
-otool -h native/litert_lm/prebuilt/<dir>/libLiteRtLm.dylib | tail -1 | awk '{print $7}'
-# → sizeofcmds. Need >= 4096 to safely rewrite install_name later.
-```
-
-If `sizeofcmds < 4096`, the dylib was built without `-headerpad_max_install_names`. Native Assets will fail every `pub get` on macOS with:
+Native Assets re-runs `install_name_tool -id @rpath/...` on every `pub get`. Without enough header padding the rewrite fails with:
 
 > `install_name_tool: changing install names or rpaths can't be redone for: ... larger updated load commands do not fit`
 
-**This is what bit users in 0.14.1 #247.** No way to retroactively add headerpad to an already-linked binary — you must rebuild.
+**This is what bit users in 0.14.1 (#247).** Padding cannot be added to an already-linked binary — you must rebuild with `-Wl,-headerpad_max_install_names`.
 
-For dylibs we don't build ourselves (upstream prebuilts like `libGemmaModelConstraintProvider.dylib`, `libLiteRtMetalAccelerator.dylib`, `libLiteRtTopKMetalSampler.dylib`): file an upstream bug, then either rebuild from source with the flag, or use `optool` / `ld -r` to relink with bigger headerpad.
+**Do not test this by comparing `sizeofcmds` against a threshold.** An earlier version of this skill said "need `sizeofcmds >= 4096`", which is wrong: `sizeofcmds` is the *current* size of the load commands, while `-headerpad_max_install_names` enlarges the *free space* after them. A small library legitimately has small load commands — `libStreamProxy.dylib` reports ~1136 and rewrites perfectly. At the v0.15.0 migration that threshold flagged 8 healthy dylibs, including three upstream ones, and would have blocked the release for nothing.
+
+**Check #4 below is the only authoritative test** — it performs the exact operation Native Assets performs. Run it over every dylib in the directory and trust its result.
+
+For dylibs we don't build ourselves (upstream prebuilts like `libGemmaModelConstraintProvider.dylib`, `libLiteRtMetalAccelerator.dylib`, `libLiteRtTopKMetalSampler.dylib`) that genuinely fail check #4: file an upstream bug, then either rebuild from source with the flag, or relink with `optool` / `ld -r` for bigger headerpad.
 
 ### 3. install_name + rpath
 
@@ -187,8 +293,17 @@ If anything other than `.framework/` is in there, App Store will reject with ITM
 | 4 | `libGemmaModelConstraintProvider.dylib` headerpad too small | Check #2 + #4 + #7 | **0.14.1** |
 | 5 | `lipo` "same architectures (arm64)" — Native Assets called twice for iOS | hook/build.dart `_prebuiltDirName` returns null for iOS x64 | dev session |
 | 6 | upstream `libLiteRt.dylib` was x86_64 macOS binary in `prebuilt/ios_arm64/` (#2072) | Check #1 (`file`) | 5e0d86b commit (upstream bug, but we should detect on copy) |
+| 7 | NPU dispatch stacks dropped from the tarballs — build never emits them | Count + sha256 vs previous release | **caught pre-publish** at v0.14.0 *and* v0.15.0 |
+| 8 | LiteRT pin moved, `LiteRtCreateModelFromFile` 2→3 args → embeddings `status=500` | Header diff at both `LITERT_REF`s | v0.14.0 dev cycle, ~1 day lost |
+| 9 | `RTLD_DEFAULT` undeclared on glibc — needs `_GNU_SOURCE` before every include | CI Linux job (macOS compiles it happily) | **caught in CI** at v0.15.0 |
+| 10 | v0.15.0 changed `LiteRtLmStreamCallback` 4-arg → 2-arg, no compat overload | ACCESS_VIOLATION (Windows) / malformed UTF-8 (macOS) at first token | **caught pre-publish** at v0.15.0 |
 
 Every one of those would have been caught by checks 1-8 before commit. **Run them all every time.**
+
+Two of these deserve emphasis because nothing in the build output hints at them:
+
+- **#7 is silent.** The tarball packs, the checksums verify, every smoke test on CPU/GPU passes. Only a user with `PreferredBackend.npu` finds out.
+- **#8 and #10 are ABI drift, not code changes on our side.** C linkage means a stale call shape still links; you get register garbage instead of a compiler error. When a bump touches any callback or C-API signature, verify the shape at both refs rather than assuming source that compiles is source that's correct.
 
 ---
 

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -42,6 +42,25 @@ typedef _ProxyCreateDart =
 typedef _ProxyFreeStringNative = Void Function(Pointer<Char> str);
 typedef _ProxyFreeStringDart = void Function(Pointer<Char> str);
 
+/// Decode a NUL-terminated native string without throwing on malformed bytes.
+///
+/// `Utf8Pointer.toDartString` throws [FormatException] the moment the buffer
+/// isn't valid UTF-8, which is the worst possible behaviour on the error path:
+/// a native failure then surfaces as a complaint about character encoding, and
+/// the actual message — the only thing that would explain the failure — is
+/// lost. That misdirection cost real debugging time when LiteRT-LM v0.15.0
+/// changed the stream-callback ABI and this path started receiving register
+/// garbage. Decoding leniently keeps whatever the native layer did send
+/// readable, with U+FFFD standing in for the unreadable bytes.
+String _decodeNativeString(Pointer<Char> ptr, {int maxBytes = 64 * 1024}) {
+  final bytes = ptr.cast<Uint8>();
+  var length = 0;
+  while (length < maxBytes && bytes[length] != 0) {
+    length++;
+  }
+  return utf8.decode(bytes.asTypedList(length), allowMalformed: true);
+}
+
 /// Per-conversation operations a session needs from the FFI layer.
 ///
 /// [LiteRtLmConversationHandle] is the real implementation backed by a
@@ -1493,7 +1512,7 @@ class LiteRtLmFfiClient {
       Pointer<Char> errorMsg,
     ) {
       if (errorMsg != nullptr && errorMsg.address != 0) {
-        final error = errorMsg.cast<Utf8>().toDartString();
+        final error = _decodeNativeString(errorMsg);
         _proxyFreeString!(errorMsg); // free strdup'd string
         // stopGeneration() (and any other caller-initiated cancel) surfaces
         // here as a CANCELLED error from native. That's not an error from

--- a/packages/flutter_gemma_litertlm/native/litert_lm/stream_proxy.c
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/stream_proxy.c
@@ -1,9 +1,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#ifndef _WIN32
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
 #include <fcntl.h>
+#include <dlfcn.h>
 #endif
 
 #ifdef _WIN32
@@ -12,9 +15,68 @@
 #define STREAM_PROXY_EXPORT __attribute__((visibility("default")))
 #endif
 
-// Callback type matching LiteRtLmStreamCallback
+// Callback type matching LiteRtLmStreamCallback up to and including v0.14.0.
+// This is also the shape our Dart NativeCallable expects, in both ABI modes —
+// adapting the newer upstream shape to it is exactly this file's job.
 typedef void (*LiteRtLmStreamCallback)(void* callback_data, const char* chunk,
                                        _Bool is_final, const char* error_msg);
+
+// ── v0.15.0 streaming ABI ────────────────────────────────────────────────
+// LiteRT-LM v0.15.0 replaced the 4-arg stream callback with a 2-arg one that
+// hands over an opaque chunk object read through accessors:
+//
+//   v0.13.1 / v0.14.0: void(void*, const char* chunk, bool final, const char* err)
+//   v0.15.0:           void(void*, const LiteRtLmStreamChunk* chunk)
+//
+// Upstream kept no compatibility overload, and the C API carries no version
+// symbol, so a build-time switch would pin us to one native release. Probe the
+// loaded libLiteRtLm at runtime instead and hand LiteRT-LM whichever callback
+// it actually calls — that keeps one binary working against both.
+//
+// Registering the wrong shape is not a graceful failure: args 3 and 4 come from
+// whatever the registers happen to hold, and strdup() on that garbage pointer
+// faults outright on Windows and yields malformed text on macOS.
+typedef void (*StreamCallbackV15)(void* callback_data, const void* chunk);
+typedef const char* (*ChunkGetTextFn)(const void* chunk);
+typedef const char* (*ChunkGetErrorFn)(const void* chunk);
+typedef _Bool (*ChunkIsFinalFn)(const void* chunk);
+
+static ChunkGetTextFn stream_chunk_get_text = NULL;
+static ChunkGetErrorFn stream_chunk_get_error = NULL;
+static ChunkIsFinalFn stream_chunk_is_final = NULL;
+static int stream_abi_probed = 0;
+
+static void* stream_proxy_resolve(const char* name) {
+#ifdef _WIN32
+  // The bundle ships the lib under both names depending on platform packaging.
+  static const char* modules[] = {"LiteRtLm.dll", "libLiteRtLm.dll", NULL};
+  for (int i = 0; modules[i] != NULL; i++) {
+    HMODULE mod = GetModuleHandleA(modules[i]);
+    if (mod != NULL) {
+      FARPROC sym = GetProcAddress(mod, name);
+      if (sym != NULL) return (void*)sym;
+    }
+  }
+  return NULL;
+#else
+  // Dart preloads libLiteRtLm with RTLD_GLOBAL (stream_proxy_load_global), so
+  // its exports are reachable from the default search scope.
+  return dlsym(RTLD_DEFAULT, name);
+#endif
+}
+
+// Resolve the v0.15.0 chunk accessors once. Their presence *is* the version
+// probe: they simply do not exist in v0.14.0 and earlier.
+static void stream_proxy_probe_abi(void) {
+  if (stream_abi_probed) return;
+  stream_abi_probed = 1;
+  stream_chunk_get_text =
+      (ChunkGetTextFn)stream_proxy_resolve("litert_lm_stream_chunk_get_text");
+  stream_chunk_get_error =
+      (ChunkGetErrorFn)stream_proxy_resolve("litert_lm_stream_chunk_get_error");
+  stream_chunk_is_final =
+      (ChunkIsFinalFn)stream_proxy_resolve("litert_lm_stream_chunk_is_final");
+}
 
 // Proxy callback data: holds the Dart callback and memory to free
 typedef struct {
@@ -41,6 +103,30 @@ static void stream_proxy_callback(void* callback_data, const char* chunk,
   }
 }
 
+// v0.15.0 callback: unpack the chunk object and forward in the 4-arg shape
+// Dart already understands.
+static void stream_proxy_callback_v15(void* callback_data, const void* chunk) {
+  ProxyData* proxy = (ProxyData*)callback_data;
+
+  const char* text =
+      stream_chunk_get_text ? stream_chunk_get_text(chunk) : NULL;
+  const char* error_msg =
+      stream_chunk_get_error ? stream_chunk_get_error(chunk) : NULL;
+  _Bool is_final = stream_chunk_is_final ? stream_chunk_is_final(chunk) : 0;
+
+  char* chunk_copy = text ? strdup(text) : NULL;
+  // v0.15.0 signals "no error" with an EMPTY string rather than NULL. Dart
+  // treats any non-NULL error pointer as a failed stream, so forwarding "" here
+  // would abort the stream on every ordinary token.
+  char* error_copy = (error_msg && error_msg[0]) ? strdup(error_msg) : NULL;
+
+  proxy->dart_callback(proxy->dart_data, chunk_copy, is_final, error_copy);
+
+  if (is_final) {
+    free(proxy);
+  }
+}
+
 // Create a proxy that wraps a Dart callback.
 // Returns: proxy callback function pointer (to pass to LiteRT-LM)
 // Out: proxy_data (to pass as callback_data to LiteRT-LM)
@@ -51,7 +137,14 @@ void* stream_proxy_create(LiteRtLmStreamCallback dart_callback,
   ProxyData* proxy = (ProxyData*)malloc(sizeof(ProxyData));
   proxy->dart_callback = dart_callback;
   proxy->dart_data = dart_data;
-  *out_proxy_fn = stream_proxy_callback;
+
+  stream_proxy_probe_abi();
+  // The out-param is typed as the 4-arg callback because that is what the Dart
+  // binding declares; LiteRT-LM only ever consumes the address, so handing back
+  // the 2-arg entry point through the same slot is safe.
+  *out_proxy_fn = stream_chunk_get_text
+                      ? (LiteRtLmStreamCallback)(void*)stream_proxy_callback_v15
+                      : stream_proxy_callback;
   return proxy;
 }
 

--- a/packages/flutter_gemma_litertlm/native/litert_lm/stream_proxy.c
+++ b/packages/flutter_gemma_litertlm/native/litert_lm/stream_proxy.c
@@ -1,3 +1,11 @@
+// _GNU_SOURCE must precede every include: on glibc, RTLD_DEFAULT (used by the
+// ABI probe below) is a GNU extension that <dlfcn.h> only exposes under it.
+// Apple's libc declares RTLD_DEFAULT unconditionally, so a macOS build compiles
+// happily without this and Linux fails with "RTLD_DEFAULT undeclared".
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
LiteRT-LM v0.15.0 changed `LiteRtLmStreamCallback` from

```c
void (*)(void* data, const char* chunk, bool is_final, const char* error_msg)
```

to

```c
void (*)(void* data, const LiteRtLmStreamChunk* chunk)
```

with no compatibility overload, and the C API exposes no version symbol to detect it. A shim built for the old shape keeps linking and starts reading arguments 3 and 4 out of whatever the registers happen to hold — `strdup()` then runs on a garbage pointer. That surfaced as an ACCESS_VIOLATION in `StreamProxy.dll` on Windows and a `FormatException: Missing extension byte` on macOS, neither of which points anywhere near the real cause.

## What this does

`stream_proxy.c` now probes the loaded `libLiteRtLm` for `litert_lm_stream_chunk_get_text` — a symbol that simply does not exist before v0.15.0 — and registers the matching callback shape. One binary works against both ABIs, which keeps the upcoming native bump revertible instead of one-way.

Two details worth flagging for review:

- v0.15.0 reports "no error" as an **empty string**, not `NULL`. Dart treats any non-NULL error pointer as a failed stream, so the adapter forwards `NULL` unless `error_msg[0]` is set — without that, every ordinary token would abort the stream.
- The accessors are resolved lazily via `dlsym`/`GetProcAddress` rather than linked, so the shim still builds and runs against v0.14.0.

`litert_lm_client.dart` also decodes native strings leniently now. `Utf8Pointer.toDartString` throws on malformed bytes, so on the error path a native failure was being replaced by a complaint about character encoding, losing the only message that explained it.

## Verification

Same test, same machine, both native versions:

| natives | result |
|---|---|
| `native-v0.14.0` (shipped) | ✅ `All tests passed` |
| v0.15.0 (`2117fc43`) | ✅ `All tests passed` |

The v0.14.0 run is the one that matters: it is the currently published bundle, so this proves no regression for existing users. `flutter analyze` clean, 32 package unit tests pass.

## Not included

This is the adapter only — no native bump, no version changes. The `native-v0.15.0` migration follows separately so that a bisect can distinguish "the adapter broke it" from "the bump broke it".