### PR TITLE
refactor(example): standard list-screen model selection for TTS + Voice Loop

### DIFF
--- a/packages/flutter_gemma/example/lib/home_screen.dart
+++ b/packages/flutter_gemma/example/lib/home_screen.dart
@@ -6,7 +6,7 @@ import 'package:flutter_gemma_example/embedding_models_screen.dart';
 import 'package:flutter_gemma_example/model_selection_screen.dart';
 import 'package:flutter_gemma_example/stt_models_screen.dart';
 import 'package:flutter_gemma_example/translate_models_screen.dart';
-import 'package:flutter_gemma_example/tts_screen.dart';
+import 'package:flutter_gemma_example/tts_models_screen.dart';
 import 'package:flutter_gemma_example/utils/installed_model_lookup.dart';
 import 'package:flutter_gemma_example/voice_screen.dart';
 
@@ -137,10 +137,10 @@ class _HomeScreenState extends State<HomeScreen> {
             const SizedBox(height: 16),
             _NavigationCard(
               title: 'Text-to-Speech',
-              subtitle: 'On-device speech synthesis with Matcha-TTS',
+              subtitle: 'On-device speech synthesis with Matcha & Qwen3',
               icon: Icons.volume_up,
               color: Colors.deepPurple,
-              onTap: () => _push(const TtsScreen()),
+              onTap: () => _push(const TtsModelsScreen()),
             ),
             const SizedBox(height: 16),
             _NavigationCard(

--- a/packages/flutter_gemma/example/lib/tts_models_screen.dart
+++ b/packages/flutter_gemma/example/lib/tts_models_screen.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gemma_example/models/tts_model.dart';
+import 'package:flutter_gemma_example/tts_screen.dart';
+
+/// TTS model selection screen — mirrors [SttModelsScreen]. Lists the
+/// [TtsModel] catalog; picking a supported entry pushes [TtsScreen], which
+/// installs it (idempotent) and sets it active. Unsupported entries (need
+/// their own `TtsModelProfile`, see [TtsModel.unsupportedReason]) are shown
+/// but disabled. Model selection lives here — the standard list screen —
+/// not in an in-screen dropdown, so TTS matches STT / Inference / Translate.
+class TtsModelsScreen extends StatelessWidget {
+  const TtsModelsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0b2351),
+      appBar: AppBar(
+        title: const Text('Text-to-Speech Models'),
+        backgroundColor: const Color(0xFF0b2351),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            const Text(
+              'On-device Text-to-Speech',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Download a model and synthesize speech from text',
+              style: TextStyle(fontSize: 16, color: Colors.white70),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            Expanded(
+              child: ListView.builder(
+                itemCount: TtsModel.values.length,
+                itemBuilder: (context, index) {
+                  final model = TtsModel.values[index];
+                  return _TtsModelCard(model: model);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TtsModelCard extends StatelessWidget {
+  final TtsModel model;
+
+  const _TtsModelCard({required this.model});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: const Color(0xFF1a3a5c),
+      margin: const EdgeInsets.only(bottom: 12.0),
+      child: ListTile(
+        contentPadding: const EdgeInsets.all(16.0),
+        enabled: model.isSupported,
+        title: Text(
+          model.displayName,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 16.0,
+            color: model.isSupported ? Colors.white : Colors.white38,
+          ),
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8.0,
+                      vertical: 4.0,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.blue.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(12.0),
+                    ),
+                    child: Text(
+                      model.size,
+                      style: TextStyle(
+                        color: Colors.blue[200],
+                        fontWeight: FontWeight.bold,
+                        fontSize: 12.0,
+                      ),
+                    ),
+                  ),
+                  if (!model.isSupported) ...[
+                    const SizedBox(width: 8.0),
+                    Expanded(
+                      child: Text(
+                        model.unsupportedReason ?? 'Not supported yet',
+                        style: const TextStyle(
+                          color: Colors.orangeAccent,
+                          fontSize: 12.0,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              // Performance/hardware caveat for supported models (e.g. qwen3's
+              // CPU-only / RTF≈3 / 6 GB-RAM note) — mirrors the caveat the
+              // [TtsScreen] model-info card shows once selected.
+              if (model.isSupported && model.notes != null) ...[
+                const SizedBox(height: 8.0),
+                Text(
+                  model.notes!,
+                  style: const TextStyle(
+                    color: Colors.orangeAccent,
+                    fontSize: 12.0,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        trailing: model.isSupported
+            ? Icon(Icons.arrow_forward_ios, color: Colors.grey[400])
+            : const Icon(Icons.lock_outline, color: Colors.white24),
+        onTap: model.isSupported
+            ? () => Navigator.push(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (context) => TtsScreen(model: model),
+                ),
+              )
+            : null,
+      ),
+    );
+  }
+}

--- a/packages/flutter_gemma/example/lib/tts_screen.dart
+++ b/packages/flutter_gemma/example/lib/tts_screen.dart
@@ -12,8 +12,8 @@ import 'package:path_provider/path_provider.dart';
 /// TTS synthesize screen — mirrors [SttScreen]'s install-in-initState /
 /// `mounted`-after-await / reentrancy discipline, but the flow is simpler:
 /// no recording, just a text field → synthesize → play. Installs
-/// (idempotent) and activates the selected [TtsModel] (defaults to
-/// [TtsModel.matcha]) then lets the user type text and hear it spoken via
+/// (idempotent) and activates [widget.model] (chosen upstream in
+/// [TtsModelsScreen]) then lets the user type text and hear it spoken via
 /// [SpeechSynthesizer.synthesize] + `just_audio` playback of the
 /// WAV-wrapped PCM (`AudioConverter.pcmToWav`).
 ///
@@ -23,20 +23,22 @@ import 'package:path_provider/path_provider.dart';
 /// exactly one voice, no voice picker). Language is a create-time param
 /// (`FlutterGemma.getActiveTts(language: ...)`) — changing it re-creates the
 /// synthesizer (closes the old one, installs/activates again), reloading
-/// the ~1.9 GB model. Switching the model dropdown does the same.
+/// the ~1.9 GB model.
 ///
 /// `createFile` (not raw `dart:io`) is used to write the WAV to a temp file
 /// so this screen still compiles for web, where `flutter_gemma_speech` has
 /// no TTS arm (the init call surfaces that as [_initError] instead).
 class TtsScreen extends StatefulWidget {
-  const TtsScreen({super.key});
+  final TtsModel model;
+
+  const TtsScreen({super.key, required this.model});
 
   @override
   State<TtsScreen> createState() => _TtsScreenState();
 }
 
 class _TtsScreenState extends State<TtsScreen> {
-  TtsModel _model = TtsModel.matcha;
+  late final TtsModel _model = widget.model;
   String _language = 'english';
 
   SpeechSynthesizer? _synth;
@@ -114,14 +116,6 @@ class _TtsScreenState extends State<TtsScreen> {
     }
   }
 
-  /// Switch the active catalog entry and reinitialize. No-op if [model] is
-  /// already selected or a (re)initialization is already in flight.
-  void _selectModel(TtsModel model) {
-    if (model == _model || _isInitializing) return;
-    setState(() => _model = model);
-    _initializeTtsModel();
-  }
-
   /// Switch the qwen3 language and reinitialize (see [_initializeTtsModel]'s
   /// doc for why this must close+recreate rather than just updating state).
   void _selectLanguage(String language) {
@@ -187,7 +181,6 @@ class _TtsScreenState extends State<TtsScreen> {
   }
 
   Widget _buildModelInfoCard() {
-    final supported = TtsModel.values.where((m) => m.isSupported).toList();
     return Card(
       color: const Color(0xFF1a3a5c),
       child: Padding(
@@ -204,18 +197,7 @@ class _TtsScreenState extends State<TtsScreen> {
               ),
             ),
             const SizedBox(height: 12),
-            _buildDropdownRow<TtsModel>(
-              label: 'Model:',
-              value: _model,
-              items: [
-                for (final m in supported)
-                  DropdownMenuItem(value: m, child: Text(m.displayName)),
-              ],
-              onChanged: (m) {
-                if (m != null) _selectModel(m);
-              },
-            ),
-            const SizedBox(height: 8),
+            _buildInfoRow('Model:', _model.displayName),
             _buildInfoRow('Size:', _model.size),
             _buildInfoRow('Type:', 'Text-to-Speech'),
             if (_isQwen3) ...[

--- a/packages/flutter_gemma/example/lib/tts_screen.dart
+++ b/packages/flutter_gemma/example/lib/tts_screen.dart
@@ -231,8 +231,8 @@ class _TtsScreenState extends State<TtsScreen> {
   }
 
   /// A label + [DropdownButton] row, disabled while [_isInitializing] (a
-  /// model/language switch is already in flight — reentrancy guard mirrors
-  /// [_selectModel]/[_selectLanguage]'s own check).
+  /// language switch is already in flight — reentrancy guard mirrors
+  /// [_selectLanguage]'s own check).
   Widget _buildDropdownRow<T>({
     required String label,
     required T value,


### PR DESCRIPTION
## What

Model selection in the example app was inconsistent: most modalities (Inference, STT, Translate, Embedding) pick a model via a dedicated "<X> Models" list screen, but **TTS** hid it in a bespoke in-screen dropdown, and the **Voice Loop** hardcoded its three models with no choice at all.

This makes both consistent with the rest — model selection always lives in a standard list screen, never an in-screen dropdown.

### TTS

- **`tts_models_screen.dart`** (new) — `TtsModelsScreen`, a mirror of `SttModelsScreen`: lists the `TtsModel` catalog as cards; tapping a supported entry pushes `TtsScreen`; unsupported entries (kokoro / supertonic) are shown disabled with their reason.
- **`tts_screen.dart`** — now takes `required this.model` (like `SttScreen`); the in-screen model dropdown is gone (static `Model:` row). The qwen3 `language` dropdown stays — that's a runtime param of the chosen model, not model selection.
- **`home_screen.dart`** — the Text-to-Speech card routes to `TtsModelsScreen`.

### Voice Loop

- **`SttModelsScreen` / `TtsModelsScreen` / `ModelSelectionScreen`** — gain an optional `onSelected` callback: in "pick" mode, tapping an entry returns it and pops instead of navigating into the working screen.
- **`voice_setup_screen.dart`** (new) — `VoiceSetupScreen`: three tappable rows (STT / LLM / TTS), each opening the matching list in selection mode, plus a **Start Voice Loop** button. Defaults reproduce the previous trio (Moonshine Tiny / Gemma 3 1B IT / Matcha-TTS), so behaviour is unchanged until a step is swapped.
- **`voice_screen.dart`** — `VoiceScreen` now takes `required sttModel / llmModel / ttsModel` (drops the hardcoded statics).
- **`home_screen.dart`** — the Voice Loop card routes to `VoiceSetupScreen`.

Example-only; no package or public-API changes.
