### PR TITLE
fix(litertlm): pin the vision encoder to the CPU backend on iOS

### DIFF
--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -642,7 +642,13 @@ class LiteRtLmFfiClient {
     // Create engine settings
     final modelPathPtr = modelPath.toNativeUtf8();
     final backendPtr = backend.toNativeUtf8();
-    final visionBackendPtr = enableVision ? backend.toNativeUtf8() : nullptr;
+    // The vision encoder cannot be prepared by the Metal delegate: it fails with
+    // "Node number 41 (STABLEHLO_COMPOSITE) failed to prepare", which surfaces as
+    // "Failed to create conversation" from vision_litert_compiled_model_executor.cc.
+    // Pin it to CPU, the same way the audio encoder below already is. The .litertlm
+    // file itself ships section_backend_constraint: cpu for vision_adapter and
+    // audio_encoder, so mixed backends are the intended configuration.
+    final visionBackendPtr = enableVision ? 'cpu'.toNativeUtf8() : nullptr;
     final audioBackendPtr = enableAudio ? 'cpu'.toNativeUtf8() : nullptr;
 
     try {


### PR DESCRIPTION
Passing `PreferredBackend.gpu` also routes the vision encoder to Metal, where it cannot be prepared:

    ERROR: Node number 41 (STABLEHLO_COMPOSITE) failed to prepare.
    Failed to create conversation: INTERNAL:
      [runtime/executor/vision_litert_compiled_model_executor.cc:275]

Reproduced on an iPhone 17 Pro Max (iOS 26.6) with gemma-4-E2B-it.litertlm, supportImage: true, maxTokens: 2048. In debug builds the failure is silent and looks like a hang; only a profile build surfaces the error.

The .litertlm file already ships `section_backend_constraint: cpu` for vision_adapter and audio_encoder, so mixed backends are the intended configuration -- the vision encoder is simply missing that constraint. The audio backend here is already hardcoded to CPU for the same reason; this applies the same treatment to vision.

Measured on the same device (profile build, image + Korean prompt), time to first token:

    all CPU                     3799 ms cold / 3727 ms warm
    GPU LLM + CPU vision        6013 ms first ever (Metal shader
                                compile), 3487 ms cold after restart,
                                1499-1636 ms warm

A follow-up could expose `visionBackend` as a parameter instead of hardcoding it, once the Metal delegate gains STABLEHLO_COMPOSITE support.