### PR TITLE
chore(website): docs → flutter_gemma 1.5.6; document VoiceSession streamAudio

### DIFF
--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.5.5
+  flutter_gemma: ^1.5.6
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.3.1   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -23,7 +23,7 @@ SmolLM and more — see [Models](/docs/models) for the full list.
 - **Audio Input:** Record and send audio messages with Gemma 4 and Gemma3n models (Android, iOS device, Desktop).
 - **Function Calling:** Let models call external functions and integrate with other services. See [Function Calling](/docs/function-calling).
 - **Agent Skills:** Give the model a catalog of `SKILL.md` skills it picks and runs itself — text, JS, native intents, or MCP tools. See [Agent Skills](/docs/agent).
-- **Speech & Voice (STT + TTS + voice loop):** Transcribe audio, synthesize speech, and run a full on-device speech-to-speech voice loop (`VoiceSession`) via `flutter_gemma_speech` — moonshine STT + Matcha TTS today. See [Speech](/docs/speech).
+- **Speech & Voice (STT + TTS + voice loop):** Transcribe audio, synthesize speech, and run a full on-device speech-to-speech voice loop (`VoiceSession`) via `flutter_gemma_speech` — STT (moonshine/Whisper/Parakeet) + TTS (Matcha/Qwen3/Inflect) today. See [Speech](/docs/speech).
 - **Thinking Mode:** View the reasoning process of DeepSeek, Gemma 4, and Qwen3 models. See [Thinking Mode](/docs/thinking-mode).
 - **Stop Generation:** Cancel text generation mid-process on Android, iOS, Web, and Desktop.
 - **Backend Switching:** Choose between CPU and GPU backends for each model individually.

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -26,7 +26,7 @@ dependencies:
   flutter_gemma_rag_sqlite: latest_version   # RAG vector store (sqlite-vec / vec0; all platforms, incl. web)
 
   # Optional — on-device speech (STT + TTS):
-  flutter_gemma_speech: latest_version       # transcribe audio + synthesize speech (moonshine + Matcha today; native only) + voice loop
+  flutter_gemma_speech: latest_version       # transcribe audio + synthesize speech (on-device STT + TTS; native only) + voice loop
 ```
 
 **Pick by need:**

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,7 +29,7 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.5.5                 # core — always required
+  flutter_gemma: ^1.5.6                 # core — always required
   flutter_gemma_litertlm: ^1.3.1        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.4      # add if you compute embeddings

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -251,9 +251,10 @@ tokenizer), works on mobile + web, and throws `DownloadCancelledException`.
 
 On-device speech via the opt-in [`flutter_gemma_speech`](/docs/speech) package —
 selectable, profile-driven pipelines (you pick the model with `SttModelType` /
-`TtsModelType`). **moonshine-tiny** (STT) and **Matcha** (TTS) work end-to-end
-today; Whisper / Parakeet STT profiles and kokoro / supertonic TTS voices are
-follow-ons. Native only (no Web). See [Speech](/docs/speech) for usage.
+`TtsModelType`). **moonshine-tiny**, **Whisper**, and **Parakeet** (STT) and
+**Matcha**, **Qwen3-TTS** (multilingual), and **Inflect-Nano-v2** (fast) TTS work
+end-to-end today; kokoro / supertonic TTS voices are follow-ons. Native only (no
+Web). See [Speech](/docs/speech) for usage.
 A `VoiceSession` also chains STT → LLM → TTS into a push-to-talk voice loop —
 see [Speech](/docs/speech).
 
@@ -262,12 +263,16 @@ see [Speech](/docs/speech).
 | Model | Input | Size | Status | Auth |
 |---|---|---|---|---|
 | **[moonshine-tiny](https://huggingface.co/litert-community/moonshine-tiny)** | raw 16 kHz PCM | ~104 MB | ✅ end-to-end | ❌ |
+| **Whisper** (tiny, English) | log-mel | — | ✅ end-to-end | ❌ |
+| **Parakeet** (CTC) | log-mel | — | ✅ end-to-end | ❌ |
 
 **Text-to-speech**
 
 | Model | Output | Size | Status | Auth |
 |---|---|---|---|---|
 | **[Matcha](https://huggingface.co/litert-community/Matcha-TTS)** | 16-bit PCM @ 22050 Hz | ~90 MB | ✅ end-to-end | ❌ |
+| **[Qwen3-TTS](https://huggingface.co/litert-community/Qwen3-TTS-12Hz-0.6B-Base)** (11 langs) | 16-bit PCM | ~1.9 GB | ✅ end-to-end | ❌ |
+| **[Inflect-Nano-v2](https://huggingface.co/sasha-denisov/inflect-nano-v2-litert)** (fast) | 16-bit PCM @ 24 kHz | ~8 MB | ✅ end-to-end | ❌ |
 
 ## Text embedding models
 

--- a/website/content/docs/packages.md
+++ b/website/content/docs/packages.md
@@ -21,7 +21,7 @@ ships only the native weight it actually uses. All packages live in one monorepo
 | **`flutter_gemma_rag_qdrant`** | On-device RAG vector store (qdrant-edge, native Rust FFI). Fastest on native. | Native (no Web) |
 | **`flutter_gemma_rag_sqlite`** | On-device RAG vector store — in-SQLite KNN via the `sqlite-vec` (`vec0`) extension. Exact + portable. | All (incl. Web) |
 | **`flutter_gemma_agent`** | On-device [agent skills](/docs/agent) — SKILL.md catalog + tool-calling loop (text / JS / native-intent / MCP). | All (JS: no Linux) |
-| **`flutter_gemma_speech`** | On-device [speech](/docs/speech) — speech-to-text + text-to-speech + a `VoiceSession` voice loop (moonshine STT + Matcha TTS today) via the LiteRT C API + `dart:ffi`. | Native (no Web) |
+| **`flutter_gemma_speech`** | On-device [speech](/docs/speech) — speech-to-text + text-to-speech + a `VoiceSession` voice loop (moonshine/Whisper/Parakeet STT + Matcha/Qwen3/Inflect TTS) via the LiteRT C API + `dart:ffi`. | Native (no Web) |
 
 ## How it works
 

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -30,7 +30,7 @@ inference.
 
 ```
 dependencies:
-  flutter_gemma: ^1.5.5
+  flutter_gemma: ^1.5.6
   flutter_gemma_speech: ^0.4.3
 ```
 
@@ -186,6 +186,23 @@ itself, same as the STT/TTS sections above. For barge-in, call
 `await session.interrupt()` while a turn is in flight: it stops generation,
 bounded-drains the reply stream, and the turn ends with a
 `VoiceTurnInterruptedEvent` instead of `VoiceTurnCompleteEvent`.
+
+### Streaming audio (lower time-to-first-audio)
+
+By default the reply is synthesized in one shot after the LLM finishes — a single
+`VoiceReplyAudioEvent(isFinal: true)`. Pass `streamAudio: true` to synthesize
+clause-by-clause, overlapped with the LLM stream, so the first audio plays much
+sooner: the turn emits a series of `VoiceReplyAudioEvent(isFinal: false)` chunks
+followed by a zero-byte `isFinal: true` marker. The player must play the chunks
+in order; per-clause synthesis has slightly flatter prosody at the clause joins
+than synthesizing the whole reply at once.
+
+```dart
+final session = VoiceSession.fromChat(
+  recognizer: recognizer, chat: chat, synthesizer: synthesizer,
+  streamAudio: true,
+);
+```
 
 ### Tool calling in the voice loop
 


### PR DESCRIPTION
Bumps the version strings in the docs to the just-published **flutter_gemma 1.5.6** (genkit.md, migration.md, speech.md), and documents the new **`VoiceSession(streamAudio:)`** clause-by-clause TTS API in speech.md.

Site builds locally (`jaspr build` → "Completed building project"); all code fences are `dart`. Auto-deploys to fluttergemma.dev on merge.