### PR TITLE
fix: persist STT/TTS/embedding type so getInstalledModels can list them

### DIFF
--- a/packages/flutter_gemma/lib/core/api/embedding_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/embedding_installation_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/model_management/model_specs.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart' as repo;
 import 'package:flutter_gemma/core/utils/file_name_utils.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 
@@ -192,6 +193,7 @@ class EmbeddingInstallationBuilder {
             _modelSource!,
             cancelToken: _cancelToken,
             targetFilename: modelFilename,
+            type: repo.ModelType.embedding,
           )) {
             _onModelProgress!(progress);
           }
@@ -200,6 +202,7 @@ class EmbeddingInstallationBuilder {
             _modelSource!,
             cancelToken: _cancelToken,
             targetFilename: modelFilename,
+            type: repo.ModelType.embedding,
           );
         }
       } else {
@@ -217,6 +220,7 @@ class EmbeddingInstallationBuilder {
             effectiveTokenizerSource,
             cancelToken: _cancelToken,
             targetFilename: tokenizerFilename,
+            type: repo.ModelType.embedding,
           )) {
             _onTokenizerProgress!(progress);
           }
@@ -225,6 +229,7 @@ class EmbeddingInstallationBuilder {
             effectiveTokenizerSource,
             cancelToken: _cancelToken,
             targetFilename: tokenizerFilename,
+            type: repo.ModelType.embedding,
           );
         }
       } else {

--- a/packages/flutter_gemma/lib/core/api/stt_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/stt_installation_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/model_management/model_specs.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart' as repo;
 import 'package:flutter_gemma/core/utils/file_name_utils.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
 
@@ -196,6 +197,7 @@ class SttInstallationBuilder {
             _modelSource!,
             cancelToken: _cancelToken,
             targetFilename: modelFilename,
+            type: repo.ModelType.stt,
           )) {
             _onModelProgress!(progress);
           }
@@ -204,6 +206,7 @@ class SttInstallationBuilder {
             _modelSource!,
             cancelToken: _cancelToken,
             targetFilename: modelFilename,
+            type: repo.ModelType.stt,
           );
         }
       } else {
@@ -220,6 +223,7 @@ class SttInstallationBuilder {
             effectiveTokenizerSource,
             cancelToken: _cancelToken,
             targetFilename: tokenizerFilename,
+            type: repo.ModelType.stt,
           )) {
             _onTokenizerProgress!(progress);
           }
@@ -228,6 +232,7 @@ class SttInstallationBuilder {
             effectiveTokenizerSource,
             cancelToken: _cancelToken,
             targetFilename: tokenizerFilename,
+            type: repo.ModelType.stt,
           );
         }
       } else {

--- a/packages/flutter_gemma/lib/core/api/tts_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/tts_installation_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
 import 'package:flutter_gemma/core/di/service_registry.dart';
 import 'package:flutter_gemma/core/model_management/model_specs.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart' as repo;
 import 'package:flutter_gemma/flutter_gemma.dart';
 
 /// Fluent builder for TTS (text-to-speech) model installation.
@@ -137,6 +138,7 @@ class TtsInstallationBuilder {
           file.source,
           cancelToken: _cancelToken,
           targetFilename: file.filename,
+          type: repo.ModelType.tts,
         );
       }
       done++;

--- a/packages/flutter_gemma/lib/core/handlers/asset_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/asset_source_handler.dart
@@ -35,6 +35,7 @@ class AssetSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     if (source is! AssetSource) {
       throw ArgumentError('AssetSourceHandler only supports AssetSource');
@@ -77,7 +78,7 @@ class AssetSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 
@@ -89,6 +90,7 @@ class AssetSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     if (source is! AssetSource) {
       throw ArgumentError('AssetSourceHandler only supports AssetSource');
@@ -126,7 +128,7 @@ class AssetSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 

--- a/packages/flutter_gemma/lib/core/handlers/bundled_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/bundled_source_handler.dart
@@ -36,6 +36,7 @@ class BundledSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     // Bundled resources are instant, no cancellation needed
     if (source is! BundledSource) {
@@ -57,7 +58,7 @@ class BundledSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 
@@ -69,6 +70,7 @@ class BundledSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     // Same as above - bundled resources are instant
     if (source is! BundledSource) {
@@ -92,7 +94,7 @@ class BundledSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 

--- a/packages/flutter_gemma/lib/core/handlers/file_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/file_source_handler.dart
@@ -33,6 +33,7 @@ class FileSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     // File sources are instant (just registration), no cancellation needed
     if (source is! FileSource) {
@@ -67,7 +68,7 @@ class FileSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 
@@ -79,6 +80,7 @@ class FileSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     // Same as above - file registration is instant
     if (source is! FileSource) {
@@ -116,7 +118,7 @@ class FileSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 

--- a/packages/flutter_gemma/lib/core/handlers/network_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/network_source_handler.dart
@@ -36,6 +36,7 @@ class NetworkSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     if (source is! NetworkSource) {
       throw ArgumentError('NetworkSourceHandler only supports NetworkSource');
@@ -71,7 +72,7 @@ class NetworkSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 
@@ -83,6 +84,7 @@ class NetworkSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     if (source is! NetworkSource) {
       throw ArgumentError('NetworkSourceHandler only supports NetworkSource');
@@ -122,7 +124,7 @@ class NetworkSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: sizeBytes,
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 

--- a/packages/flutter_gemma/lib/core/handlers/source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/source_handler.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart';
 
 /// Base interface for handling different model source types
 /// Each source type (Network, Asset, Bundled, File) has its own handler implementation
@@ -39,6 +40,9 @@ abstract interface class SourceHandler {
   ///   `*InstallationBuilder`s so a companion file's on-disk identity can be
   ///   namespaced by its owning model (see
   ///   `docs/superpowers/specs/2026-08-02-install-identity-namespacing-design.md`).
+  /// - [type]: Repository tag written to [ModelInfo.type]. Defaults to
+  ///   [ModelType.inference]. STT/TTS/embedding builders must pass their
+  ///   own type so [ModelFileManager.getInstalledModels] can list them.
   ///
   /// Throws:
   /// - [UnsupportedError] if this handler doesn't support the source type
@@ -49,6 +53,7 @@ abstract interface class SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   });
 
   /// Installs the model with progress tracking
@@ -89,6 +94,7 @@ abstract interface class SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   });
 
   /// Checks if this source supports resume after interruption

--- a/packages/flutter_gemma/lib/core/handlers/web_asset_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_asset_source_handler.dart
@@ -45,12 +45,14 @@ class WebAssetSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     // Delegate to installWithProgress, ignore progress events
     await for (final _ in installWithProgress(
       source,
       cancelToken: cancelToken,
       targetFilename: targetFilename,
+      type: type,
     )) {
       // Ignore progress updates
     }
@@ -61,6 +63,7 @@ class WebAssetSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     if (source is! AssetSource) {
       throw ArgumentError('WebAssetSourceHandler only supports AssetSource');
@@ -109,7 +112,7 @@ class WebAssetSourceHandler implements SourceHandler {
         source: source,
         installedAt: DateTime.now(),
         sizeBytes: -1,
-        type: ModelType.inference,
+        type: type,
         hasLoraWeights: false,
       );
 

--- a/packages/flutter_gemma/lib/core/handlers/web_asset_source_handler_stub.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_asset_source_handler_stub.dart
@@ -33,6 +33,7 @@ class WebAssetSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     throw UnsupportedError(
       'WebAssetSourceHandler is only available on web platform',
@@ -44,6 +45,7 @@ class WebAssetSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebAssetSourceHandler is only available on web platform',

--- a/packages/flutter_gemma/lib/core/handlers/web_bundled_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_bundled_source_handler.dart
@@ -47,12 +47,14 @@ class WebBundledSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     // Delegate to installWithProgress, ignore progress events
     await for (final _ in installWithProgress(
       source,
       cancelToken: cancelToken,
       targetFilename: targetFilename,
+      type: type,
     )) {
       // Ignore progress updates
     }
@@ -63,6 +65,7 @@ class WebBundledSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     if (source is! BundledSource) {
       throw ArgumentError(
@@ -113,7 +116,7 @@ class WebBundledSourceHandler implements SourceHandler {
         source: source,
         installedAt: DateTime.now(),
         sizeBytes: -1,
-        type: ModelType.inference,
+        type: type,
         hasLoraWeights: false,
       );
 

--- a/packages/flutter_gemma/lib/core/handlers/web_bundled_source_handler_stub.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_bundled_source_handler_stub.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/core/handlers/source_handler.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart';
 
 /// Stub implementation for non-web platforms
 class WebBundledSourceHandler implements SourceHandler {
@@ -23,6 +24,7 @@ class WebBundledSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebBundledSourceHandler is only available on web platform',
@@ -34,6 +36,7 @@ class WebBundledSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebBundledSourceHandler is only available on web platform',

--- a/packages/flutter_gemma/lib/core/handlers/web_file_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_file_source_handler.dart
@@ -41,6 +41,7 @@ class WebFileSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     // Web file registration is instant, no cancellation needed
     if (source is! FileSource) {
@@ -64,7 +65,7 @@ class WebFileSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: -1, // Unknown for web external files
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 
@@ -76,6 +77,7 @@ class WebFileSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     // Same as above - web file registration is instant
     if (source is! FileSource) {
@@ -105,7 +107,7 @@ class WebFileSourceHandler implements SourceHandler {
       source: source,
       installedAt: DateTime.now(),
       sizeBytes: -1, // Unknown for web external files
-      type: ModelType.inference,
+      type: type,
       hasLoraWeights: false,
     );
 

--- a/packages/flutter_gemma/lib/core/handlers/web_file_source_handler_stub.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_file_source_handler_stub.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/core/handlers/source_handler.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart';
 
 /// Stub implementation for non-web platforms
 class WebFileSourceHandler implements SourceHandler {
@@ -21,6 +22,7 @@ class WebFileSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebFileSourceHandler is only available on web platform',
@@ -32,6 +34,7 @@ class WebFileSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebFileSourceHandler is only available on web platform',

--- a/packages/flutter_gemma/lib/core/handlers/web_network_source_handler.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_network_source_handler.dart
@@ -48,12 +48,14 @@ class WebNetworkSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async {
     // Delegate to installWithProgress, ignore progress events
     await for (final _ in installWithProgress(
       source,
       cancelToken: cancelToken,
       targetFilename: targetFilename,
+      type: type,
     )) {
       // Ignore progress updates
     }
@@ -64,6 +66,7 @@ class WebNetworkSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) async* {
     if (source is! NetworkSource) {
       throw ArgumentError(
@@ -104,7 +107,7 @@ class WebNetworkSourceHandler implements SourceHandler {
         source: source,
         installedAt: DateTime.now(),
         sizeBytes: -1, // Web doesn't track size (blob URL)
-        type: ModelType.inference,
+        type: type,
         hasLoraWeights: false,
       );
 

--- a/packages/flutter_gemma/lib/core/handlers/web_network_source_handler_stub.dart
+++ b/packages/flutter_gemma/lib/core/handlers/web_network_source_handler_stub.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/core/handlers/source_handler.dart';
 import 'package:flutter_gemma/core/domain/model_source.dart';
 import 'package:flutter_gemma/core/model_management/cancel_token.dart';
+import 'package:flutter_gemma/core/services/model_repository.dart';
 
 /// Stub implementation for non-web platforms
 class WebNetworkSourceHandler implements SourceHandler {
@@ -23,6 +24,7 @@ class WebNetworkSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebNetworkSourceHandler is only available on web platform',
@@ -34,6 +36,7 @@ class WebNetworkSourceHandler implements SourceHandler {
     ModelSource source, {
     CancelToken? cancelToken,
     String? targetFilename,
+    ModelType type = ModelType.inference,
   }) {
     throw UnsupportedError(
       'WebNetworkSourceHandler is only available on web platform',

--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -478,7 +478,7 @@ class MobileModelManager extends ModelFileManager {
           );
         }
 
-        await handler.install(file.source);
+        await handler.install(file.source, type: _toRepoType(spec.type));
         gemmaLog(
           '✅ File installed: ${file.filename} via Modern handler: ${file.source.runtimeType}',
         );
@@ -667,6 +667,7 @@ class MobileModelManager extends ModelFileManager {
           source: file.source,
           targetPath: filePath,
           token: token,
+          type: _toRepoType(spec.type),
         )) {
           yield DownloadProgress(
             currentFileIndex: i,
@@ -719,6 +720,7 @@ class MobileModelManager extends ModelFileManager {
     required ModelSource source,
     required String targetPath,
     String? token,
+    repo.ModelType type = repo.ModelType.inference,
   }) async* {
     // Delegate to ServiceRegistry handler
     if (source is! NetworkSource) {
@@ -738,7 +740,10 @@ class MobileModelManager extends ModelFileManager {
     final handler = registry.networkHandler;
 
     // Use handler's progress stream
-    await for (final progress in handler.installWithProgress(networkSource)) {
+    await for (final progress in handler.installWithProgress(
+      networkSource,
+      type: type,
+    )) {
       yield progress;
     }
   }
@@ -827,6 +832,13 @@ class MobileModelManager extends ModelFileManager {
     }
   }
 
+  repo.ModelType _toRepoType(ModelManagementType type) => switch (type) {
+    ModelManagementType.inference => repo.ModelType.inference,
+    ModelManagementType.embedding => repo.ModelType.embedding,
+    ModelManagementType.stt => repo.ModelType.stt,
+    ModelManagementType.tts => repo.ModelType.tts,
+  };
+
   /// Gets all installed models for a specific type
   @override
   Future<List<String>> getInstalledModels(ModelManagementType type) async {
@@ -836,15 +848,7 @@ class MobileModelManager extends ModelFileManager {
       final registry = ServiceRegistry.instance;
       final repository = registry.modelRepository;
 
-      // Convert ModelManagementType to repo.ModelType (exhaustive — a new
-      // ModelManagementType value must be mapped here, not silently bucketed
-      // into embedding).
-      final modelType = switch (type) {
-        ModelManagementType.inference => repo.ModelType.inference,
-        ModelManagementType.embedding => repo.ModelType.embedding,
-        ModelManagementType.stt => repo.ModelType.stt,
-        ModelManagementType.tts => repo.ModelType.tts,
-      };
+      final modelType = _toRepoType(type);
 
       // Get all installed models and filter by type
       final allModels = await repository.listInstalled();

--- a/packages/flutter_gemma/lib/core/model_management/managers/web_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/web_model_manager.dart
@@ -388,6 +388,7 @@ class WebModelManager extends ModelFileManager {
       // true progress will emit 100% immediately)
       await for (final progress in handler.installWithProgress(
         sourceToInstall,
+        type: _toRepoType(spec.type),
       )) {
         yield DownloadProgress(
           currentFileIndex: i,
@@ -441,6 +442,13 @@ class WebModelManager extends ModelFileManager {
     gemmaLog('WebModelManager: Model ${spec.name} deleted');
   }
 
+  repo.ModelType _toRepoType(ModelManagementType type) => switch (type) {
+    ModelManagementType.inference => repo.ModelType.inference,
+    ModelManagementType.embedding => repo.ModelType.embedding,
+    ModelManagementType.stt => repo.ModelType.stt,
+    ModelManagementType.tts => repo.ModelType.tts,
+  };
+
   /// Gets list of installed model filenames
   ///
   /// Phase 5.5: Delegates to Modern API (ModelRepository) instead of
@@ -456,15 +464,9 @@ class WebModelManager extends ModelFileManager {
     // Get all installed models from repository
     final allInstalled = await repository.listInstalled();
 
-    // Filter by type (exhaustive — a new ModelManagementType value must be
-    // mapped here, not silently bucketed into embedding).
-    final wantType = switch (type) {
-      ModelManagementType.inference => repo.ModelType.inference,
-      ModelManagementType.embedding => repo.ModelType.embedding,
-      ModelManagementType.stt => repo.ModelType.stt,
-      ModelManagementType.tts => repo.ModelType.tts,
-    };
-    final filtered = allInstalled.where((m) => m.type == wantType).toList();
+    final filtered = allInstalled
+        .where((m) => m.type == _toRepoType(type))
+        .toList();
 
     // Return filenames
     return filtered.map((m) => m.id).toList();
@@ -592,7 +594,10 @@ class WebModelManager extends ModelFileManager {
             file.source,
           );
           if (handler != null) {
-            await handler.install(file.source);
+            await handler.install(
+              file.source,
+              type: _toRepoType(spec.type),
+            );
             url = fileSystem.getUrl(file.filename);
           }
         }
@@ -679,7 +684,7 @@ class WebModelManager extends ModelFileManager {
             'ensureModelReadyFromSpec',
           );
         }
-        await handler.install(file.source);
+        await handler.install(file.source, type: _toRepoType(spec.type));
       }
     }
 

--- a/packages/flutter_gemma/test/core/handlers/source_handler_test.dart
+++ b/packages/flutter_gemma/test/core/handlers/source_handler_test.dart
@@ -120,6 +120,34 @@ void main() {
       verify(() => mockRepository.saveModel(any())).called(1);
     });
 
+    test('install persists the requested ModelType tag', () async {
+      final source = NetworkSource('https://example.com/tts.bin');
+      const targetPath = '/data/tts.bin';
+
+      when(
+        () => mockFileSystem.getWriteTargetPath(any()),
+      ).thenAnswer((_) async => targetPath);
+      when(
+        () => mockDownloadService.download(
+          any(),
+          any(),
+          token: any(named: 'token'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockFileSystem.getFileSize(any()),
+      ).thenAnswer((_) async => 1024);
+      when(() => mockRepository.saveModel(any())).thenAnswer((_) async {});
+
+      await handler.install(source, type: ModelType.tts);
+
+      final captured = verify(
+        () => mockRepository.saveModel(captureAny()),
+      ).captured.single as ModelInfo;
+      expect(captured.type, ModelType.tts);
+      expect(captured.id, 'tts.bin');
+    });
+
     test(
       'install honors targetFilename override for write path and ModelInfo.id',
       () async {


### PR DESCRIPTION
## Summary
- Thread `ModelType` through `SourceHandler.install` / `installWithProgress` instead of hardcoding `inference` on every save.
- STT, TTS, and embedding builders (and both model managers) now write the matching repository tag.
- `getInstalledModels(stt/tts)` was empty after a successful install because every row was tagged `inference`. Fixes #391.

## Test plan
- [x] `flutter test test/core/handlers/source_handler_test.dart` (44 passed), including a new case that `install(..., type: ModelType.tts)` persists `tts`.
- [x] Install an STT or TTS model and confirm `getInstalledModels(ModelManagementType.stt/tts)` returns the files.