### PR TITLE
chore(website): docs → flutter_gemma 1.5.7

### DIFF
--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.5.6
+  flutter_gemma: ^1.5.7
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.3.1   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,7 +29,7 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.5.6                 # core — always required
+  flutter_gemma: ^1.5.7                 # core — always required
   flutter_gemma_litertlm: ^1.3.1        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.4      # add if you compute embeddings

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -30,7 +30,7 @@ inference.
 
 ```
 dependencies:
-  flutter_gemma: ^1.5.6
+  flutter_gemma: ^1.5.7
   flutter_gemma_speech: ^0.4.3
 ```
 


### PR DESCRIPTION
Bumps the `flutter_gemma: ^X.Y.Z` version pins in the docs to the just-published **1.5.7** (genkit.md, migration.md, speech.md). Site builds locally (`jaspr build`); auto-deploys on merge.