### PR TITLE
docs(changelog): credit @o-mid for the concurrent #391 fix (#421)

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.5.7
-- fix: getInstalledModels(stt/tts/embedding) returns installed models — were mistagged inference (#391).
+- fix: getInstalledModels(stt/tts/embedding) returns installed models — were mistagged inference (#391; concurrent fix by @o-mid in #421).
 
 ## 1.5.6
 - fix: Gemma 4 streaming no longer leaks raw tool-call JSON into the text channel.


### PR DESCRIPTION
@o-mid independently submitted the same #391 fix in #421, opened before #422 landed. 1.5.7 is already published (pub.dev is immutable), but this credits them in the repo CHANGELOG for the record. The v1.5.7 GitHub Release notes were also updated with the same credit.