### PR TITLE
refactor(core): adopt @o-mid's _toRepoType helper + thread type through manager internal installs (#421)

### DIFF
--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -478,7 +478,7 @@ class MobileModelManager extends ModelFileManager {
           );
         }
 
-        await handler.install(file.source);
+        await handler.install(file.source, modelType: _toRepoType(spec.type));
         gemmaLog(
           '✅ File installed: ${file.filename} via Modern handler: ${file.source.runtimeType}',
         );
@@ -667,6 +667,7 @@ class MobileModelManager extends ModelFileManager {
           source: file.source,
           targetPath: filePath,
           token: token,
+          modelType: _toRepoType(spec.type),
         )) {
           yield DownloadProgress(
             currentFileIndex: i,
@@ -719,6 +720,7 @@ class MobileModelManager extends ModelFileManager {
     required ModelSource source,
     required String targetPath,
     String? token,
+    repo.ModelType modelType = repo.ModelType.inference,
   }) async* {
     // Delegate to ServiceRegistry handler
     if (source is! NetworkSource) {
@@ -738,7 +740,10 @@ class MobileModelManager extends ModelFileManager {
     final handler = registry.networkHandler;
 
     // Use handler's progress stream
-    await for (final progress in handler.installWithProgress(networkSource)) {
+    await for (final progress in handler.installWithProgress(
+      networkSource,
+      modelType: modelType,
+    )) {
       yield progress;
     }
   }
@@ -827,6 +832,13 @@ class MobileModelManager extends ModelFileManager {
     }
   }
 
+  repo.ModelType _toRepoType(ModelManagementType type) => switch (type) {
+    ModelManagementType.inference => repo.ModelType.inference,
+    ModelManagementType.embedding => repo.ModelType.embedding,
+    ModelManagementType.stt => repo.ModelType.stt,
+    ModelManagementType.tts => repo.ModelType.tts,
+  };
+
   /// Gets all installed models for a specific type
   @override
   Future<List<String>> getInstalledModels(ModelManagementType type) async {
@@ -836,15 +848,7 @@ class MobileModelManager extends ModelFileManager {
       final registry = ServiceRegistry.instance;
       final repository = registry.modelRepository;
 
-      // Convert ModelManagementType to repo.ModelType (exhaustive — a new
-      // ModelManagementType value must be mapped here, not silently bucketed
-      // into embedding).
-      final modelType = switch (type) {
-        ModelManagementType.inference => repo.ModelType.inference,
-        ModelManagementType.embedding => repo.ModelType.embedding,
-        ModelManagementType.stt => repo.ModelType.stt,
-        ModelManagementType.tts => repo.ModelType.tts,
-      };
+      final modelType = _toRepoType(type);
 
       // Get all installed models and filter by type
       final allModels = await repository.listInstalled();

--- a/packages/flutter_gemma/lib/core/model_management/managers/web_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/web_model_manager.dart
@@ -388,6 +388,7 @@ class WebModelManager extends ModelFileManager {
       // true progress will emit 100% immediately)
       await for (final progress in handler.installWithProgress(
         sourceToInstall,
+        modelType: _toRepoType(spec.type),
       )) {
         yield DownloadProgress(
           currentFileIndex: i,
@@ -441,6 +442,13 @@ class WebModelManager extends ModelFileManager {
     gemmaLog('WebModelManager: Model ${spec.name} deleted');
   }
 
+  repo.ModelType _toRepoType(ModelManagementType type) => switch (type) {
+    ModelManagementType.inference => repo.ModelType.inference,
+    ModelManagementType.embedding => repo.ModelType.embedding,
+    ModelManagementType.stt => repo.ModelType.stt,
+    ModelManagementType.tts => repo.ModelType.tts,
+  };
+
   /// Gets list of installed model filenames
   ///
   /// Phase 5.5: Delegates to Modern API (ModelRepository) instead of
@@ -456,15 +464,9 @@ class WebModelManager extends ModelFileManager {
     // Get all installed models from repository
     final allInstalled = await repository.listInstalled();
 
-    // Filter by type (exhaustive — a new ModelManagementType value must be
-    // mapped here, not silently bucketed into embedding).
-    final wantType = switch (type) {
-      ModelManagementType.inference => repo.ModelType.inference,
-      ModelManagementType.embedding => repo.ModelType.embedding,
-      ModelManagementType.stt => repo.ModelType.stt,
-      ModelManagementType.tts => repo.ModelType.tts,
-    };
-    final filtered = allInstalled.where((m) => m.type == wantType).toList();
+    final filtered = allInstalled
+        .where((m) => m.type == _toRepoType(type))
+        .toList();
 
     // Return filenames
     return filtered.map((m) => m.id).toList();
@@ -485,13 +487,7 @@ class WebModelManager extends ModelFileManager {
     // Get all installed models from repository
     final allInstalled = await repository.listInstalled();
 
-    final wantType = switch (type) {
-      ModelManagementType.inference => repo.ModelType.inference,
-      ModelManagementType.embedding => repo.ModelType.embedding,
-      ModelManagementType.stt => repo.ModelType.stt,
-      ModelManagementType.tts => repo.ModelType.tts,
-    };
-    return allInstalled.any((m) => m.type == wantType);
+    return allInstalled.any((m) => m.type == _toRepoType(type));
   }
 
   @override
@@ -592,7 +588,10 @@ class WebModelManager extends ModelFileManager {
             file.source,
           );
           if (handler != null) {
-            await handler.install(file.source);
+            await handler.install(
+              file.source,
+              modelType: _toRepoType(spec.type),
+            );
             url = fileSystem.getUrl(file.filename);
           }
         }
@@ -679,7 +678,7 @@ class WebModelManager extends ModelFileManager {
             'ensureModelReadyFromSpec',
           );
         }
-        await handler.install(file.source);
+        await handler.install(file.source, modelType: _toRepoType(spec.type));
       }
     }
 


### PR DESCRIPTION
Incorporates the manager-side improvements from @o-mid's #421. The surface #391 fix (threading the model type through `SourceHandler.install`) landed concurrently in #422 / 1.5.7; this brings the two things that PR added on the manager side:

- a `_toRepoType(ModelManagementType) → repo.ModelType` helper in both model managers, replacing the duplicated inline switches in `getInstalledModels` (+ `isAnyModelInstalled` on web);
- threading `modelType: _toRepoType(spec.type)` into the managers' internal `handler.install`/`installWithProgress` calls — defensive (those paths only carry inference specs today, so it's a no-op now, but future-proofs a non-inference spec routing through them).

No behavior change for the primary stt/tts/embedding installs (they already go through the typed builder path). Param adapted `type`→`modelType` to match main's shipped signature. `flutter analyze` clean, 615 tests pass.

Credited to @o-mid via `Co-authored-by`. Closes #421.