### PR TITLE
docs(website): vision/audio per-encoder backend (1.5.9 / litertlm 1.4.2)

### DIFF
--- a/website/content/docs/desktop.md
+++ b/website/content/docs/desktop.md
@@ -53,7 +53,7 @@ models.
 
 | Platform | Architecture | GPU backend | Vision | Audio | Notes |
 |---|---|---|---|---|---|
-| macOS | arm64 (Apple Silicon) | Metal | ✅ | ✅ | Vision verified on Gemma 4 + Gemma 3n via Metal |
+| macOS | arm64 (Apple Silicon) | Metal | ✅ | ✅ | Vision verified on Gemma 4 + Gemma 3n (text decoder on Metal, vision encoder on CPU) |
 | macOS | x86_64 | — | — | — | Not supported (Apple Silicon only) |
 | Windows | x86_64 | DirectX 12 (via Dawn/WebGPU) | ✅ | ✅ | Requires VS 2019+ runtime (`vcredist`) for DXC |
 | Windows | arm64 | — | — | — | Not supported |
@@ -355,7 +355,10 @@ Windows CPU/NPU were never affected.
 When `preferredBackend: PreferredBackend.gpu`, the **forward pass** (prefill +
 decode) runs on the GPU accelerator (Metal, DX12, Vulkan). The **per-token
 sampler** (top-k / top-p / argmax) runs on CPU — roughly 1–5 ms per token vs. the
-full LLM generation, which is dominated by the forward pass.
+full LLM generation, which is dominated by the forward pass. The **vision
+encoder** likewise runs on CPU by default (the GPU delegate can't prepare its
+ops); override per-encoder with `preferredVisionBackend:` / `preferredAudioBackend:`
+on `getActiveModel(...)`.
 
 - **macOS, Windows** — upstream `libLiteRtTopKMetalSampler` / `libLiteRtTopKWebGpuSampler` ship with incomplete C ABI exports (3 of 7 functions); the factory falls back to the CPU chain. ([#1990](https://github.com/google-ai-edge/LiteRT-LM/issues/1990), [#2073](https://github.com/google-ai-edge/LiteRT-LM/issues/2073))
 - **Linux** — the prebuilt sampler `.so` holds a process-static `wgpu::Instance` that any second `engine_create` rejects. Since runtime model swap matters more than the few ms saved, the plugin doesn't preload it and lets the factory fall back to CPU.

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,9 +21,9 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.4.3
-  flutter_gemma: ^1.5.8
+  flutter_gemma: ^1.5.9
   # Add the inference engine(s) you need:
-  flutter_gemma_litertlm: ^1.4.1   # .litertlm models (mobile + desktop)
+  flutter_gemma_litertlm: ^1.4.2   # .litertlm models (mobile + desktop)
   flutter_gemma_mediapipe: ^1.0.4  # .task / .bin models (mobile + web)
   # Optional — for embeddings:
   flutter_gemma_embeddings: ^1.0.4

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,8 +29,8 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.5.8                 # core — always required
-  flutter_gemma_litertlm: ^1.4.1        # add if you run .litertlm models
+  flutter_gemma: ^1.5.9                 # core — always required
+  flutter_gemma_litertlm: ^1.4.2        # add if you run .litertlm models
   flutter_gemma_mediapipe: ^1.0.4       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^1.0.4      # add if you compute embeddings
   flutter_gemma_rag_qdrant: ^1.1.0      # add for native on-device RAG (qdrant)

--- a/website/content/docs/multimodal.md
+++ b/website/content/docs/multimodal.md
@@ -13,8 +13,11 @@ devices with 8GB+ RAM.
 Vision is supported by **Gemma 4 E2B/E4B**, **Gemma3n E2B/E4B**, **FastVLM 0.5B**
 (desktop), and the community models **Qwen2-VL 2B**, **SmolVLM2 500M**, and
 **LLaVA-OneVision 0.5B** (Android, iOS, Desktop). Gemma 4 / Gemma3n vision runs on
-all four platforms (Android, iOS, Web, Desktop) — verified on macOS Metal and
-Linux Vulkan.
+all four platforms (Android, iOS, Web, Desktop). On the `.litertlm` engine the
+text decoder runs on your chosen backend (Metal / Vulkan / DX12 on GPU), while
+the **vision encoder always runs on CPU by default** — the Metal/WebGPU delegates
+can't prepare its ops — so image input works on a GPU text backend with no extra
+config.
 
 ### Enabling vision
 
@@ -23,10 +26,17 @@ Set `supportImage: true` when creating the model:
 ```dart
 final model = await FlutterGemma.getActiveModel(
   maxTokens: 4096,
-  preferredBackend: PreferredBackend.gpu,
+  preferredBackend: PreferredBackend.gpu,   // drives the text decoder
   supportImage: true,
 );
 ```
+
+`preferredBackend` selects the text decoder's backend. The vision encoder runs on
+CPU by default regardless (the Metal/WebGPU delegates can't prepare its
+`STABLEHLO_COMPOSITE` ops — routing it to GPU used to hard-fail at model load,
+fixed in `flutter_gemma_litertlm` 1.4.2). To force GPU vision — only for a model
+whose vision section is built to allow it — pass
+`preferredVisionBackend: PreferredBackend.gpu` to `getActiveModel(...)`.
 
 ### Sending an image
 
@@ -53,8 +63,9 @@ if (message.hasImage) {
 
 <Info>
 The plugin automatically handles common image formats (JPEG, PNG, etc.) when
-using `Message.withImages()` or `Message.withImage()`. Use the GPU backend for
-better performance with multimodal models.
+using `Message.withImages()` or `Message.withImage()`. The GPU backend speeds up
+text decoding; image encoding still runs on CPU (audio encoding can be moved to
+GPU — see below).
 </Info>
 
 ## Audio (voice input)
@@ -74,16 +85,19 @@ Enable audio with `supportAudio: true`:
 ```dart
 final model = await FlutterGemma.getActiveModel(
   maxTokens: 4096,
-  preferredBackend: PreferredBackend.gpu,
+  preferredBackend: PreferredBackend.gpu,        // text decoder
   supportImage: true,
   supportAudio: true,
+  preferredAudioBackend: PreferredBackend.gpu,   // move the audio encoder to GPU
 );
 ```
 
 <Warning>
 Audio input only works with `.litertlm` models that include the audio adapter.
-MediaPipe `.task` models on web do not support audio. On macOS, Gemma 3n audio on
-GPU is roughly 2× faster than on CPU.
+MediaPipe `.task` models on web do not support audio. On macOS, Gemma 3n audio
+runs roughly 2× faster on GPU than on CPU — but the audio encoder defaults to
+CPU, so pass `preferredAudioBackend: PreferredBackend.gpu` (as above) to get that
+speedup; `preferredBackend` alone only moves the text decoder.
 </Warning>
 
 ## Web limitations
@@ -100,4 +114,7 @@ matrix.
 - Ensure you're using a multimodal model (Gemma 4, Gemma3n E2B/E4B, FastVLM, Qwen2-VL, SmolVLM2, LLaVA-OneVision).
 - Set `supportImage: true` when creating the model (and `supportAudio: true` for audio).
 - Check device memory — multimodal models require more RAM.
-- Use the GPU backend for better performance.
+- Use the GPU backend for faster text decoding. Image encoding runs on CPU by
+  default; move audio encoding to GPU with `preferredAudioBackend: PreferredBackend.gpu`.
+- If image input fails at model load on a GPU backend on an older release, upgrade
+  to `flutter_gemma_litertlm` 1.4.2 — the vision encoder now defaults to CPU.

--- a/website/content/docs/multimodal.md
+++ b/website/content/docs/multimodal.md
@@ -33,10 +33,11 @@ final model = await FlutterGemma.getActiveModel(
 
 `preferredBackend` selects the text decoder's backend. The vision encoder runs on
 CPU by default regardless (the Metal/WebGPU delegates can't prepare its
-`STABLEHLO_COMPOSITE` ops — routing it to GPU used to hard-fail at model load,
-fixed in `flutter_gemma_litertlm` 1.4.2). To force GPU vision — only for a model
-whose vision section is built to allow it — pass
-`preferredVisionBackend: PreferredBackend.gpu` to `getActiveModel(...)`.
+`STABLEHLO_COMPOSITE` ops — routing it to GPU used to hard-fail at model load;
+`flutter_gemma_litertlm` 1.4.2 fixes this by defaulting the vision encoder to
+CPU). To force GPU vision — only for a model whose vision section is built to
+allow it — pass `preferredVisionBackend: PreferredBackend.gpu` to
+`getActiveModel(...)`.
 
 ### Sending an image
 

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -30,7 +30,7 @@ inference.
 
 ```
 dependencies:
-  flutter_gemma: ^1.5.8
+  flutter_gemma: ^1.5.9
   flutter_gemma_speech: ^0.4.3
 ```
 

--- a/website/content/docs/troubleshooting.md
+++ b/website/content/docs/troubleshooting.md
@@ -155,7 +155,15 @@ if you hit it.
 - Ensure you're using a multimodal model (Gemma 4, Gemma3n E2B/E4B, FastVLM).
 - Set `supportImage: true` (and `supportAudio: true` for audio) when creating the model.
 - Check device memory — multimodal models require more RAM.
-- Use the GPU backend for better performance. See [Multimodal](/docs/multimodal).
+- **Image input crashes at model load on a GPU text backend (older releases).**
+  On Metal (iOS/macOS) and WebGPU (Windows/Linux) the vision encoder's ops can't
+  be prepared by the GPU delegate. Fixed in **`flutter_gemma_litertlm` 1.4.2 /
+  core 1.5.9** — the vision encoder now defaults to CPU while the text decoder
+  keeps the GPU. Upgrade if you hit it.
+- Use the GPU backend for faster text decoding. Image encoding runs on CPU by
+  default; move audio encoding to GPU with `preferredAudioBackend: PreferredBackend.gpu`.
+  To force GPU vision (only for a model built to allow it), pass
+  `preferredVisionBackend: PreferredBackend.gpu`. See [Multimodal](/docs/multimodal).
 
 ## Function calling
 


### PR DESCRIPTION
Docs for the just-published **flutter_gemma 1.5.9 + flutter_gemma_litertlm 1.4.2** (#429).

- Bump version pins ^1.5.8→^1.5.9, ^1.4.1→^1.4.2 (genkit/migration/speech).
- **multimodal.md**: the vision encoder runs on CPU by default (Metal/WebGPU can't prepare its ops; text decoder uses the chosen backend); document `preferredVisionBackend`. Fix the audio "2× on GPU" claim — audio now defaults to CPU, so `preferredAudioBackend: PreferredBackend.gpu` is required for that speedup.
- **troubleshooting.md**: note the fixed GPU-vision model-load crash + the per-encoder overrides.
- **desktop.md**: macOS table + "per-token sampler runs on CPU" section note the CPU vision encoder.

`jaspr build` clean; all fences are `dart`. Auto-deploys on merge.