### PR TITLE
chore(release): guard-release-docs hook + skill HARD RULES / Definition-of-Done

### DIFF
--- a/.claude/hooks/guard-release-docs.py
+++ b/.claude/hooks/guard-release-docs.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Block `dart pub publish` of a package whose code changed but whose docs did not.
+
+Why this exists: twice in one session a package was released with the code shipped
+but the docs skipped — agent 0.2.3 published without its pub.dev README updated
+(had to ship 0.2.4 the same day), and the 1.5.9 vision-backend docs were split off
+into a separate website PR instead of riding the release PR. The `release` skill
+says docs (Step 12: version pins + new-API docs) are MANDATORY ON EVERY RELEASE and
+"commit the website/ changes on your release branch / PR" (one PR, not two). The
+skill was read and the docs were still deferred — which is the argument for a hook
+over more prose: a checklist advises, a hook refuses. (Same lesson as
+guard-publish.py.)
+
+Blocks a real publish (not --dry-run) of package X when, in the commit range that
+introduced X's current `version:` (that commit .. HEAD), X's `lib/` changed but
+NEITHER of these did:
+  * packages/X/README.md   (the pub.dev-facing docs)
+  * website/content/docs/  (the fluttergemma.dev docs)
+
+Override for a genuine code-only release with no doc surface (rare) by putting
+`RELEASE_SKIP_DOCS=<reason>` in the command, e.g.
+  RELEASE_SKIP_DOCS="internal refactor, no public API/behavior change" dart pub publish
+
+Fail-closed: if git can't be consulted, or the package/version can't be resolved,
+BLOCK — an irreversible publish in an unknown state is not a safe one.
+
+Exit 0 allows, exit 2 blocks with the reason on stderr.
+Run `python3 guard-release-docs.py --self-test` to check the matching rules.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Mirror guard-publish.py's command-position matcher (MULTILINE is load-bearing:
+# a `cd\n dart pub publish` block must still match).
+PUBLISH_RE = re.compile(
+    r"(?:^|[;&|(]|&&|\|\|)\s*"
+    r"(?:\w+=\S+\s+)*"
+    r"(?:(?:timeout|nice|env|command|stdbuf)\s+\S+\s+)*"
+    r"(?:dart|flutter)\s+pub\s+publish\b",
+    re.MULTILINE,
+)
+DRY_RUN_RE = re.compile(r"(?<![\w-])--dry-run(?![\w-])")
+SKIP_RE = re.compile(r"(?<![\w-])RELEASE_SKIP_DOCS=")
+# `cd packages/<name>` (the publish is run from the package dir).
+CD_PKG_RE = re.compile(r"cd\s+(?:\S*/)?packages/([A-Za-z0-9_]+)")
+
+
+class GitUnavailable(RuntimeError):
+    """git could not be consulted — treated as a block, never as 'clean'."""
+
+
+def git(*args):
+    try:
+        r = subprocess.run(
+            ["git", "-C", os.environ.get("CLAUDE_PROJECT_DIR", "."), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise GitUnavailable(f"git {' '.join(args)}: {e}") from e
+    if r.returncode != 0:
+        raise GitUnavailable(
+            f"git {' '.join(args)} exited {r.returncode}: {r.stderr.strip()}"
+        )
+    return r.stdout.strip()
+
+
+def _publish_is_exempt(cmd):
+    """True only if every publish invocation on the line carries --dry-run."""
+    for m in PUBLISH_RE.finditer(cmd):
+        tail = re.split(r"[;&|\n]", cmd[m.end() :], maxsplit=1)[0]
+        if not DRY_RUN_RE.search(tail):
+            return False
+    return True
+
+
+def _package_from(cmd):
+    """Which packages/<name> is being published. None if undeterminable."""
+    m = CD_PKG_RE.search(cmd)
+    return m.group(1) if m else None
+
+
+def _current_version(pkg):
+    root = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    path = os.path.join(root, "packages", pkg, "pubspec.yaml")
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            m = re.match(r"version:\s*(\S+)", line)
+            if m:
+                return m.group(1)
+    raise GitUnavailable(f"no version: in packages/{pkg}/pubspec.yaml")
+
+
+def _doc_problem(pkg):
+    """Return a block-reason string, or None if the release's docs are fine."""
+    version = _current_version(pkg)
+    # The commit that set the CURRENT version is the release boundary. -S finds
+    # where the exact `version: V` string entered pubspec.yaml.
+    boundary = git(
+        "log", "-1", "--format=%H", "-S", f"version: {version}",
+        "--", f"packages/{pkg}/pubspec.yaml",
+    )
+    if not boundary:
+        raise GitUnavailable(
+            f"cannot locate the commit that set version {version} for {pkg}"
+        )
+    # Files changed in boundary..HEAD, plus the boundary commit itself.
+    changed = set(
+        git("diff", "--name-only", f"{boundary}~1", "HEAD").splitlines()
+    )
+    lib_prefix = f"packages/{pkg}/lib/"
+    code_changed = any(f.startswith(lib_prefix) for f in changed)
+    if not code_changed:
+        return None  # docs-only / no public code change → nothing to enforce
+
+    readme = f"packages/{pkg}/README.md"
+    docs_touched = readme in changed or any(
+        f.startswith("website/content/docs/") for f in changed
+    )
+    if docs_touched:
+        return None
+
+    return (
+        f"packages/{pkg}/lib changed since v{version} was set ({boundary[:10]}) "
+        f"but neither {readme} nor website/content/docs/ was updated.\n"
+        "  The release skill (Step 12) requires docs in the SAME release: bump the\n"
+        "  version pins + document the new/changed API before publishing.\n"
+        "  If this release genuinely has no doc surface, re-run with\n"
+        '  RELEASE_SKIP_DOCS="<reason>" in the command.'
+    )
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+        cmd = (payload.get("tool_input") or {}).get("command") or ""
+    except Exception as e:
+        sys.stderr.write(
+            f"BLOCKED: guard-release-docs could not read the hook payload ({e!r}).\n"
+        )
+        return 2
+
+    if not PUBLISH_RE.search(cmd):
+        return 0
+    if _publish_is_exempt(cmd):
+        return 0
+    if SKIP_RE.search(cmd):
+        return 0  # explicit, reasoned opt-out
+
+    pkg = _package_from(cmd)
+    if pkg is None:
+        sys.stderr.write(
+            "BLOCKED: guard-release-docs can't tell which package is being "
+            "published (no `cd packages/<name>` in the command).\n"
+            "Run the publish from the package dir, or add "
+            'RELEASE_SKIP_DOCS="<reason>" if intentional.\n'
+        )
+        return 2
+
+    try:
+        problem = _doc_problem(pkg)
+    except (GitUnavailable, OSError) as e:
+        sys.stderr.write(
+            f"BLOCKED: cannot verify docs shipped with this release — {e}\n"
+            "A publish is irreversible; an unverifiable state is not a safe one.\n"
+        )
+        return 2
+
+    if problem is None:
+        return 0
+
+    sys.stderr.write(
+        "BLOCKED: release is missing its docs.\n  - "
+        + problem
+        + "\n(guard: .claude/hooks/guard-release-docs.py)\n"
+    )
+    return 2
+
+
+# (command, matches_publish, is_exempt) — matching-rule cases only; the git-based
+# doc check is exercised on the live repo, not here.
+_TESTS = [
+    ("dart pub publish --force", True, False),
+    ("cd packages/flutter_gemma_agent && dart pub publish", True, False),
+    ("dart pub publish --dry-run", True, True),
+    ("dart pub publish --dry-run && dart pub publish", True, False),
+    ('RELEASE_SKIP_DOCS="x" dart pub publish', True, False),  # skip handled in main, not exempt
+    ("git push origin main", False, False),
+    ('grep -r "dart pub publish" docs/', False, False),
+]
+
+
+def _self_test():
+    bad = 0
+    for cmd, want_match, want_exempt in _TESTS:
+        got_match = bool(PUBLISH_RE.search(cmd))
+        got_exempt = got_match and _publish_is_exempt(cmd)
+        if got_match != want_match or got_exempt != want_exempt:
+            bad += 1
+            print(
+                f"  FAIL {cmd!r}: match={got_match}(want {want_match}) "
+                f"exempt={got_exempt}(want {want_exempt})"
+            )
+    # package + skip parsing
+    assert _package_from("cd packages/flutter_gemma_agent && dart pub publish") == (
+        "flutter_gemma_agent"
+    ), "package parse"
+    assert _package_from("dart pub publish") is None, "no-cd parse"
+    assert SKIP_RE.search('RELEASE_SKIP_DOCS="reason" dart pub publish'), "skip parse"
+    print(f"  {len(_TESTS) - bad}/{len(_TESTS)} match-rule cases pass; parse asserts ok")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        sys.exit(_self_test())
+    sys.exit(main())

--- a/.claude/hooks/guard-release-docs.py
+++ b/.claude/hooks/guard-release-docs.py
@@ -13,11 +13,19 @@ guard-publish.py.)
 
 Blocks a real publish (not --dry-run) of package X when, in the commit range that
 introduced X's current `version:` (that commit .. HEAD), X's `lib/` changed but
-NEITHER of these did:
-  * packages/X/README.md   (the pub.dev-facing docs)
-  * website/content/docs/  (the fluttergemma.dev docs)
+its own pub.dev-facing `packages/X/README.md` did NOT. The README specifically —
+a `website/content/docs/` edit is deliberately NOT accepted as a substitute:
+website docs aren't package-scoped, so a sibling package's website change (batch
+release) or a website-only-but-README-skipped change (the agent 0.2.3 miss this
+hook was built for) would otherwise pass. website/README both belong in the
+release, but only README is enforceable per-package here; the Step-12b website
+docs are enforced by review + the DoD checklist.
 
-Override for a genuine code-only release with no doc surface (rare) by putting
+This range/boundary logic is only exact when HEAD == the release commit — which is
+always true when this PreToolUse hook actually fires (at `dart pub publish` time).
+It is NOT a general retroactive audit.
+
+Override for a genuine code-only release with no README surface (rare) by putting
 `RELEASE_SKIP_DOCS=<reason>` in the command, e.g.
   RELEASE_SKIP_DOCS="internal refactor, no public API/behavior change" dart pub publish
 
@@ -43,9 +51,16 @@ PUBLISH_RE = re.compile(
     re.MULTILINE,
 )
 DRY_RUN_RE = re.compile(r"(?<![\w-])--dry-run(?![\w-])")
-SKIP_RE = re.compile(r"(?<![\w-])RELEASE_SKIP_DOCS=")
-# `cd packages/<name>` (the publish is run from the package dir).
-CD_PKG_RE = re.compile(r"cd\s+(?:\S*/)?packages/([A-Za-z0-9_]+)")
+# RELEASE_SKIP_DOCS must sit in command position (an env assignment prefix),
+# not merely appear in an echo/grep of the string.
+SKIP_RE = re.compile(
+    r"(?:^|[;&|(]|&&|\|\|)\s*(?:\w+=\S+\s+)*RELEASE_SKIP_DOCS=", re.MULTILINE
+)
+# `packages/<name>` as a path segment — used for both `cd packages/<name>` in the
+# command AND the hook payload's cwd (a bare `dart pub publish` run from the
+# package dir carries no `cd`, so cwd is the fallback).
+PKG_SEG_RE = re.compile(r"(?:^|/)packages/([A-Za-z0-9_]+)(?:/|$)")
+CD_PKG_RE = re.compile(r"cd\s+(\S*packages/[A-Za-z0-9_]+)")
 
 
 class GitUnavailable(RuntimeError):
@@ -79,10 +94,26 @@ def _publish_is_exempt(cmd):
     return True
 
 
-def _package_from(cmd):
-    """Which packages/<name> is being published. None if undeterminable."""
-    m = CD_PKG_RE.search(cmd)
-    return m.group(1) if m else None
+def _package_from(cmd, cwd):
+    """Which packages/<name> is being published. None if undeterminable.
+
+    Prefer the LAST `cd .../packages/<name>` on the command (it reflects the
+    effective cwd of the publish); fall back to the payload cwd, which is where a
+    bare `dart pub publish` (no `cd`) actually runs — that is the shape the
+    release skill's Step 10 documents, so it must resolve, not block.
+    """
+    last = None
+    for m in CD_PKG_RE.finditer(cmd):
+        last = m.group(1)
+    if last:
+        seg = PKG_SEG_RE.search(last)
+        if seg:
+            return seg.group(1)
+    if cwd:
+        seg = PKG_SEG_RE.search(cwd)
+        if seg:
+            return seg.group(1)
+    return None
 
 
 def _current_version(pkg):
@@ -118,20 +149,23 @@ def _doc_problem(pkg):
     if not code_changed:
         return None  # docs-only / no public code change → nothing to enforce
 
+    # Require the package's OWN README (the pub.dev landing page). A global
+    # website/content/docs/ edit is NOT a substitute: the motivating miss (agent
+    # 0.2.3) updated website/agent.md but skipped the README and had to re-ship as
+    # 0.2.4. Accepting any website edit would also let a co-released package in a
+    # batch (e.g. "core + speech") mask another package whose README was skipped.
+    # README is package-scoped, so it can't be borrowed from a sibling.
     readme = f"packages/{pkg}/README.md"
-    docs_touched = readme in changed or any(
-        f.startswith("website/content/docs/") for f in changed
-    )
-    if docs_touched:
+    if readme in changed:
         return None
 
     return (
         f"packages/{pkg}/lib changed since v{version} was set ({boundary[:10]}) "
-        f"but neither {readme} nor website/content/docs/ was updated.\n"
-        "  The release skill (Step 12) requires docs in the SAME release: bump the\n"
-        "  version pins + document the new/changed API before publishing.\n"
-        "  If this release genuinely has no doc surface, re-run with\n"
-        '  RELEASE_SKIP_DOCS="<reason>" in the command.'
+        f"but {readme} was not updated.\n"
+        "  The release skill (Step 12) requires the pub.dev-facing README to ship\n"
+        "  the new/changed API in the SAME release (website/content/docs is not a\n"
+        "  substitute — it's not package-scoped). If this release genuinely has no\n"
+        '  README surface, re-run with RELEASE_SKIP_DOCS="<reason>" in the command.'
     )
 
 
@@ -139,6 +173,7 @@ def main():
     try:
         payload = json.load(sys.stdin)
         cmd = (payload.get("tool_input") or {}).get("command") or ""
+        cwd = payload.get("cwd") or ""
     except Exception as e:
         sys.stderr.write(
             f"BLOCKED: guard-release-docs could not read the hook payload ({e!r}).\n"
@@ -152,11 +187,11 @@ def main():
     if SKIP_RE.search(cmd):
         return 0  # explicit, reasoned opt-out
 
-    pkg = _package_from(cmd)
+    pkg = _package_from(cmd, cwd)
     if pkg is None:
         sys.stderr.write(
             "BLOCKED: guard-release-docs can't tell which package is being "
-            "published (no `cd packages/<name>` in the command).\n"
+            "published (no `cd .../packages/<name>` and no packages/<name> cwd).\n"
             "Run the publish from the package dir, or add "
             'RELEASE_SKIP_DOCS="<reason>" if intentional.\n'
         )
@@ -187,6 +222,8 @@ def main():
 _TESTS = [
     ("dart pub publish --force", True, False),
     ("cd packages/flutter_gemma_agent && dart pub publish", True, False),
+    ("cd packages/x\ndart pub publish", True, False),  # multiline was a guard-publish bypass
+    ("timeout 900 dart pub publish", True, False),  # wrapper was a bypass
     ("dart pub publish --dry-run", True, True),
     ("dart pub publish --dry-run && dart pub publish", True, False),
     ('RELEASE_SKIP_DOCS="x" dart pub publish', True, False),  # skip handled in main, not exempt
@@ -206,12 +243,22 @@ def _self_test():
                 f"  FAIL {cmd!r}: match={got_match}(want {want_match}) "
                 f"exempt={got_exempt}(want {want_exempt})"
             )
-    # package + skip parsing
-    assert _package_from("cd packages/flutter_gemma_agent && dart pub publish") == (
+    # package resolution: cd-in-command, cwd-fallback (bare publish), last-cd-wins
+    assert _package_from("cd packages/flutter_gemma_agent && dart pub publish", "") == (
         "flutter_gemma_agent"
-    ), "package parse"
-    assert _package_from("dart pub publish") is None, "no-cd parse"
+    ), "cd parse"
+    assert _package_from("dart pub publish", "/repo/packages/flutter_gemma") == (
+        "flutter_gemma"
+    ), "bare publish resolves via cwd (Step 10 shape)"
+    assert _package_from("dart pub publish", "") is None, "no cd, no cwd -> None"
+    assert _package_from(
+        "cd packages/flutter_gemma && cd packages/flutter_gemma_agent && dart pub publish", ""
+    ) == "flutter_gemma_agent", "last cd wins"
+    # skip must be in command position, not inside an echo/grep
     assert SKIP_RE.search('RELEASE_SKIP_DOCS="reason" dart pub publish'), "skip parse"
+    assert not SKIP_RE.search('echo RELEASE_SKIP_DOCS=note && dart pub publish'), (
+        "skip must not fire from an echo of the string"
+    )
     print(f"  {len(_TESTS) - bad}/{len(_TESTS)} match-rule cases pass; parse asserts ok")
     return 1 if bad else 0
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-release-docs.py\"",
+            "error_message": "Release blocked: package lib/ changed but its README/website docs did not (release skill Step 12). Ship docs in the same PR, or override with RELEASE_SKIP_DOCS=\"reason\"."
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -20,8 +20,10 @@ silently do the other thing.
 1. **ONE PR: code + `website/` docs + version bumps ship together.** The Step 12
    doc changes (version pins + new/changed-API docs) go on the SAME release
    branch/PR as the code, merged in one go. A **separate website-only PR is
-   FORBIDDEN** — the only time it is allowed is when the code PR has ALREADY
-   merged before you got to docs, and that is a planning failure to note in the
+   FORBIDDEN** except (a) the code PR has ALREADY merged before you got to docs
+   (a planning failure — do NOT let this become the pattern), or (b) a
+   post-merge deploy-failure hotfix, which 12c requires be a new PR since main is
+   protected. Case (a) is a failure to note in the
    PR, not the pattern to copy. Author the docs BEFORE the release PR merges.
 2. **Docs are part of Done, not a follow-up.** "I'll do the docs later / in a
    follow-up" is the exact failure this skill exists to stop. `README.md`
@@ -33,7 +35,7 @@ silently do the other thing.
    (done / N/A + reason) before you publish. Do not publish off memory of the
    skill — walk it as a literal checklist against the actual repo state.
 
-### Definition of Done (paste + check every line before Step 10 publish)
+### Definition of Done (paste it; check 1a–12b before Step 10 publish; 12c is verified after merge)
 
 ```
 [ ] Pre-flight: git clean · analyze 0 err · flutter test green · build web + one native target
@@ -416,6 +418,11 @@ git push origin <branch> --tags
 ## Step 10: pub.dev publish
 
 ```bash
+# Run from the package dir so the guard-release-docs hook can resolve which
+# package is publishing (bare `dart pub publish` with the cwd already in the
+# package works too — the hook reads the payload cwd — but the explicit `cd` is
+# unambiguous):
+cd packages/<name>
 dart pub publish --dry-run    # verify once more
 dart pub publish              # only after user approval
 ```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -8,6 +8,48 @@ user_invocable: true
 
 Run as `/release <plugin-version>` (e.g. `/release 0.14.1`).
 
+## ⛔ HARD RULES — these are not advice, and not overridable by your judgment
+
+A checklist advises; these refuse. They exist because the steps below were read
+and still skipped — twice in one session (agent 0.2.3 shipped without its README
+→ had to publish 0.2.4; the 1.5.9 docs were split into a separate website PR).
+When a rule here conflicts with what seems "more sensible right now", the rule
+wins. If following one is genuinely impossible, SAY SO out loud and stop — do not
+silently do the other thing.
+
+1. **ONE PR: code + `website/` docs + version bumps ship together.** The Step 12
+   doc changes (version pins + new/changed-API docs) go on the SAME release
+   branch/PR as the code, merged in one go. A **separate website-only PR is
+   FORBIDDEN** — the only time it is allowed is when the code PR has ALREADY
+   merged before you got to docs, and that is a planning failure to note in the
+   PR, not the pattern to copy. Author the docs BEFORE the release PR merges.
+2. **Docs are part of Done, not a follow-up.** "I'll do the docs later / in a
+   follow-up" is the exact failure this skill exists to stop. `README.md`
+   (pub.dev-facing) and `website/content/docs/**` are release deliverables. A
+   `guard-release-docs.py` hook BLOCKS `dart pub publish` when a package's `lib/`
+   changed but neither its README nor website docs did — if it fires, you skipped
+   Step 12, not "hit a false positive".
+3. **Reproduce this Definition-of-Done in your reply and mark every item**
+   (done / N/A + reason) before you publish. Do not publish off memory of the
+   skill — walk it as a literal checklist against the actual repo state.
+
+### Definition of Done (paste + check every line before Step 10 publish)
+
+```
+[ ] Pre-flight: git clean · analyze 0 err · flutter test green · build web + one native target
+[ ] 1a  every package whose lib/ changed is in the publish list (grep, don't guess)
+[ ] 1b/c native: dylibs/build-scripts changed? → rebuild + SHA256 + native release, else N/A
+[ ] 1e  core public API changed? → upgrade-genkit (realign + version), else N/A
+[ ] 1f  shared code duplicated across satellites patched everywhere (grep the pattern)
+[ ] 1g  each changed satellite's flutter_gemma: floor >= the core version it now needs
+[ ] 2   versions bumped: pubspec + podspec (if any) + CLAUDE.md Current-Version line
+[ ] 7   CHANGELOG: one short line per package, every published package
+[ ] 8   dart pub publish --dry-run → 0 warnings, every package
+[ ] 12a website + README version pins bumped to the just-published versions
+[ ] 12b new/changed public API + behavior documented (README + website)  ← SAME PR
+[ ] 12c after merge: firebase-hosting-merge run == success (not just triggered)
+```
+
 ## Architecture context (read this first)
 
 flutter_gemma 0.14.0+ has **no Kotlin/JVM/gRPC server**. Native libs come from one of two sources, decided per-platform by `hook/build.dart` (Native Assets):


### PR DESCRIPTION
Enforces what the release skill already says but that got skipped twice this session (agent 0.2.3 shipped without its README → had to publish 0.2.4; the 1.5.9 vision docs were split into a separate website PR instead of riding the release PR).

## `guard-release-docs.py` (PreToolUse, next to `guard-publish.py`)
Blocks `dart pub publish` of a package whose `lib/` changed since its current `version:` was set, but whose `README.md` / `website/content/docs/` did **not**. Mirrors guard-publish's discipline: command-position matcher, `--dry-run` exempt, fail-closed if git can't be consulted, `--self-test` (7/7). Docs-only releases pass; `RELEASE_SKIP_DOCS="reason"` is the reasoned opt-out.

Verified on the live repo: it would have **blocked** the litertlm 1.4.2 publish (its docs were in a separate PR), and correctly **allows** the agent 0.2.4 docs-only release (README touched, lib not).

## `release/SKILL.md`
- **⛔ HARD RULES** block at the very top: one PR for code+docs+version; docs are Done, not a follow-up; reproduce the Definition-of-Done before publishing — framed as non-overridable-by-judgment, because prose that reads as advice is what got walked past.
- **Definition of Done** paste-and-check list (steps 1a-1g / 2 / 7 / 8 / 12a-c).

'a checklist advises, a hook refuses.'