### PR TITLE
docs: the per-session sampler claim was false — correct it, add a reverse probe

### DIFF
--- a/packages/flutter_gemma/DESKTOP_SUPPORT.md
+++ b/packages/flutter_gemma/DESKTOP_SUPPORT.md
@@ -325,21 +325,37 @@ Why this is the case:
 Once upstream lands the missing exports / a wgpu reset API, the plugin will
 re-enable GPU sampling on the affected platforms.
 
-### `randomSeed` / `temperature` / `topK` / `topP` honoring
+### `randomSeed` / `temperature` / `topK` / `topP` — only the first session's values apply
 
-As of litertlm 1.2.0 (LiteRT-LM **v0.14.0**), per-session sampler params
-(seed / temperature / topK / topP) are honored **natively** by the upstream
-runtime through its opaque session config — no downstream patch. Each session
-carries its own sampler params, so two sessions with different seeds produce
-independent, seed-reproducible output. Verified on CPU and GPU across macOS,
-iOS, Linux, Windows (CPU/NPU), and Android.
+**Only the first generation on an engine sets the sampler.** Every later session
+on that same engine keeps those values, whatever it asks for. This is an
+upstream defect ([LiteRT-LM #2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080),
+open) and it reproduces on every version we have measured — v0.14.0, v0.15.0 and
+v0.16.0, on CPU as well as GPU.
 
-> Earlier releases (≤ litertlm 1.1.0) needed a build-time downstream patch
+`topK` defaults to `1`, which is greedy. So the common shape is: an app loads a
+model, runs one generation with defaults, and from then on the engine is locked
+greedy — a later `temperature: 1.5` changes nothing, with no error and no
+warning. It also runs the other way: an engine whose first session is stochastic
+keeps sampling, and a later `topK: 1` will not give you argmax.
+
+The seed is not re-applied either. The sampler keeps its RNG state across
+sessions, so two byte-identical requests on one engine produce different text.
+
+**Workaround:** close and recreate the engine when you need different sampler
+settings. `model.close()` followed by `FlutterGemma.getActiveModel(...)` gives a
+fresh engine that honors its first session, at the cost of a model reload. If
+your app uses one fixed configuration throughout — as most chat apps do — this
+never surfaces, because the first session already set the values you wanted.
+
+> Before litertlm 1.2.0 we carried a build-time patch
 > (`native/litert_lm/patch_c_api.sh`, offered upstream as
-> [#2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080) /
-> [PR #2081](https://github.com/google-ai-edge/LiteRT-LM/pull/2081)) because the
-> stock executor hardcoded sampler params on the GPU/NPU path. v0.14.0 lands the
-> native session-config sampler, so that patch is no longer applied.
+> [PR #2081](https://github.com/google-ai-edge/LiteRT-LM/pull/2081)) that fixed
+> this downstream. v0.14.0 added a native session-config sampler API, so the
+> patch was dropped — but the underlying baking was not fixed, which is how this
+> section came to claim otherwise between 2026-07-23 and now. The repros live in
+> `example/integration_test/sampler_baking_2080_test.dart` and
+> `sampler_reverse_probe_test.dart`.
 
 Reproducer: `flutter test integration_test/regression_bugs_test.dart` on any
 platform — `randomSeed=42` vs `randomSeed=99` at `temperature=1.0`.

--- a/packages/flutter_gemma/example/integration_test/sampler_reverse_probe_test.dart
+++ b/packages/flutter_gemma/example/integration_test/sampler_reverse_probe_test.dart
@@ -1,0 +1,154 @@
+/// Falsification probe for the #2080 diagnosis — NOT a regression test.
+///
+/// sampler_baking_2080_test.dart concludes "the engine bakes whatever its first
+/// generation used". That conclusion makes a prediction that has nothing to do
+/// with greedy being a special case, and this file tests it:
+///
+///   Engine D, FIRST session STOCHASTIC (topK 64, temp 1.5, seed 7)  -> S
+///   Engine D, LATER session GREEDY     (topK 1,  temp 0.8, seed 1)  -> Gd
+///
+///   baking real      : Gd == S   (locked to the stochastic first generation)
+///   baking not real  : Gd == G   (the greedy text a fresh greedy engine gives)
+///
+/// The two outcomes are mutually exclusive and both are observable, so this
+/// cannot come back "inconclusive" the way a single-direction test can. If Gd
+/// comes out equal to the known greedy text, the baking diagnosis is wrong and
+/// the docs' "honored natively" claim is right.
+///
+/// Run: cd example && flutter test integration_test/sampler_reverse_probe_test.dart -d macos
+library;
+
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'inference_test_helpers.dart' show registerTestEngines;
+
+String get _macosDir =>
+    '${Platform.environment['HOME']}/Library/Containers/dev.flutterberlin.flutterGemmaExample55/Data/Documents';
+String get _model => '$_macosDir/gemma-4-E2B-it.litertlm';
+
+const _prompt =
+    'Invent a name for a cosy coffee shop. Answer with the name only.';
+
+Future<String> _gen(
+  InferenceModel model, {
+  required int topK,
+  required double temperature,
+  required int randomSeed,
+}) async {
+  final session = await model.createSession(
+    temperature: temperature,
+    topK: topK,
+    randomSeed: randomSeed,
+  );
+  try {
+    await session.addQueryChunk(const Message(text: _prompt, isUser: true));
+    return (await session.getResponse()).trim();
+  } finally {
+    await session.close();
+  }
+}
+
+Future<InferenceModel> _engine() => FlutterGemma.getActiveModel(
+  maxTokens: 1024,
+  preferredBackend: PreferredBackend.cpu,
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await registerTestEngines();
+    expect(
+      File(_model).existsSync(),
+      isTrue,
+      reason: 'model missing at $_model',
+    );
+    await FlutterGemma.installModel(
+      modelType: ModelType.gemmaIt,
+      fileType: ModelFileType.litertlm,
+    ).fromFile(_model).install();
+  });
+
+  testWidgets(
+    'reverse probe — does a stochastic-first engine bake stochastic?',
+    (_) async {
+      final String g, s, gd;
+
+      // Reference: what greedy looks like on an engine that starts greedy.
+      final refEngine = await _engine();
+      try {
+        g = await _gen(refEngine, topK: 1, temperature: 0.8, randomSeed: 1);
+      } finally {
+        await refEngine.close();
+      }
+
+      // The probe: stochastic FIRST, greedy SECOND, same engine.
+      //
+      // Both sessions use seed 7 deliberately. The first run of this probe
+      // varied topK/temperature AND the seed together, and produced a third
+      // value that matched neither hypothesis — because under baked stochastic
+      // params a different seed still gives different text. Holding the seed
+      // fixed makes the two outcomes exactly comparable: if the later greedy
+      // session returns S verbatim, topK/temperature were baked.
+      final engineD = await _engine();
+      String s2;
+      try {
+        s = await _gen(engineD, topK: 64, temperature: 1.5, randomSeed: 7);
+        // Identical request to S. If params were re-applied per session the
+        // seed would be re-seeded and this must equal S; if the engine baked
+        // them and simply keeps drawing, the RNG stream has advanced and it
+        // will differ. Either way it separates "re-applied" from "baked".
+        s2 = await _gen(engineD, topK: 64, temperature: 1.5, randomSeed: 7);
+        gd = await _gen(engineD, topK: 1, temperature: 0.8, randomSeed: 7);
+      } finally {
+        await engineD.close();
+      }
+      // ignore: avoid_print
+      print('[probe] S2 (identical request to S)         ="$s2"');
+
+      // ignore: avoid_print
+      print(
+        '[probe] G  (greedy on a greedy-first engine) ="$g"\n'
+        '[probe] S  (stochastic, engine D first)      ="$s"\n'
+        '[probe] Gd (greedy, engine D second)         ="$gd"\n'
+        '[probe] verdict: ${gd == g ? "BAKING DISPROVED — the greedy request was honoured" : "BAKING CONFIRMED — engine D never returned to greedy; it kept "
+                  "sampling from what its first generation baked"}',
+      );
+
+      // Control: if stochastic and greedy coincide on this prompt, nothing
+      // below can be told apart.
+      expect(
+        s,
+        isNot(equals(g)),
+        reason:
+            'INCONCLUSIVE: stochastic and greedy produced the same text on a '
+            'fresh engine, so the two outcomes are indistinguishable here',
+      );
+
+      // 1. An identical repeat request must reproduce, if the seed is applied
+      //    per session. It does not — the RNG stream simply carries on.
+      expect(
+        s2,
+        isNot(equals(s)),
+        reason:
+            'the second identical stochastic request reproduced "$s2", which '
+            'would mean seeds ARE re-applied per session — that contradicts '
+            'the baking diagnosis and this probe should be rewritten',
+      );
+
+      // 2. The decisive one. Greedy (topK 1) is argmax: deterministic, seed
+      //    independent. A session that asks for greedy and does not get the
+      //    greedy answer did not get its parameters.
+      expect(
+        gd,
+        isNot(equals(g)),
+        reason:
+            'the greedy request on engine D returned the greedy answer, so '
+            'later sessions DO honour their params — #2080 would be fixed',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+}

--- a/website/content/docs/desktop.md
+++ b/website/content/docs/desktop.md
@@ -363,17 +363,33 @@ on `getActiveModel(...)`.
 - **macOS, Windows** — upstream `libLiteRtTopKMetalSampler` / `libLiteRtTopKWebGpuSampler` ship with incomplete C ABI exports (3 of 7 functions); the factory falls back to the CPU chain. ([#1990](https://github.com/google-ai-edge/LiteRT-LM/issues/1990), [#2073](https://github.com/google-ai-edge/LiteRT-LM/issues/2073))
 - **Linux** — the prebuilt sampler `.so` holds a process-static `wgpu::Instance` that any second `engine_create` rejects. Since runtime model swap matters more than the few ms saved, the plugin doesn't preload it and lets the factory fall back to CPU.
 
-### `randomSeed` / `temperature` / `topK` / `topP`
+### `randomSeed` / `temperature` / `topK` / `topP` — only the first session's values apply
 
-As of litertlm 1.2.0 (LiteRT-LM **v0.14.0**), per-session sampler params
-(seed / temperature / topK / topP) are honored **natively** by the upstream
-runtime through its opaque session config — no downstream patch. Each session
-carries its own sampler params, so two sessions with different seeds produce
-independent, seed-reproducible output. Verified on CPU and GPU across macOS,
-iOS, Linux, Windows (CPU/NPU), and Android. (Earlier releases needed a build-time
-patch offered upstream as [#2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080) /
-[PR #2081](https://github.com/google-ai-edge/LiteRT-LM/pull/2081); v0.14.0 lands the native
-session-config sampler, so that patch is no longer applied.)
+<Warning>
+**Only the first generation on an engine sets the sampler.** Every later session
+on that same engine keeps those values, whatever it asks for. Upstream defect
+([LiteRT-LM #2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080),
+open), reproducing on v0.14.0, v0.15.0 and v0.16.0, on CPU as well as GPU.
+</Warning>
+
+`topK` defaults to `1`, which is greedy — so the common shape is: an app loads a
+model, runs one generation with defaults, and from then on the engine is locked
+greedy. A later `temperature: 1.5` changes nothing, with no error and no warning.
+It runs the other way too: an engine whose first session is stochastic keeps
+sampling, and a later `topK: 1` will not give you argmax. The seed is not
+re-applied either — the sampler keeps its RNG state across sessions, so two
+identical requests on one engine produce different text.
+
+**Workaround:** close and recreate the engine when you need different sampler
+settings — `model.close()` then `FlutterGemma.getActiveModel(...)` — at the cost
+of a model reload. If your app uses one fixed configuration throughout, as most
+chat apps do, this never surfaces: the first session already set the values you
+wanted.
+
+Before litertlm 1.2.0 we carried a build-time patch that fixed this downstream
+(offered upstream as [PR #2081](https://github.com/google-ai-edge/LiteRT-LM/pull/2081)).
+v0.14.0 added a native session-config sampler API and the patch was dropped, but
+the underlying baking was never fixed.
 
 ### Audio modality requires LiteRT-LM models
 


### PR DESCRIPTION
`DESKTOP_SUPPORT.md` and the desktop docs page both stated that per-session sampler params are "honored **natively**" since litertlm 1.2.0, and that this was "Verified on CPU and GPU across macOS, iOS, Linux, Windows and Android".

That is not true, and has not been since it was written. The claim went in on 2026-07-23 with the v0.14.0 migration, on the expectation that the new native session-config sampler API fixed upstream [#2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080). Five days later we measured and it had not — the API landed, the baking did not go away. The docs were never corrected, so for three weeks they described the opposite of the measured behaviour.

## What actually happens

Only the first generation on an engine sets the sampler. Every later session keeps those values, whatever it asks for. Re-measured on v0.16.0 today; unchanged from v0.14.0 and v0.15.0.

`topK` defaults to `1`, i.e. greedy — so "first session is greedy" is the default path rather than an edge case. An app that loads a model, runs one generation with defaults, then exposes a temperature control ships a control that silently does nothing.

## The new probe

`sampler_baking_2080_test.dart` only ran the experiment one way: greedy first, stochastic later. That leaves "maybe greedy is special, maybe the prompt just converges" open.

`sampler_reverse_probe_test.dart` runs it the other way and closes that:

```
G   greedy     (topK=1,  temp=0.8, seed=7) on a fresh engine   = "The Snug Mug"
S   stochastic (topK=64, temp=1.5, seed=7) on engine D, 1st    = "The Snug Nook"
S2  stochastic (identical request to S)    on engine D, 2nd    = "The Nook"
Gd  greedy     (topK=1,  temp=0.8, seed=7) on engine D, 3rd    = "The Nook & Cranny"
```

`Gd != G` — greedy is argmax, deterministic and seed-independent. A session that asks for `topK: 1` and gets a sampled value did not receive its parameters.

`S2 != S` for a byte-identical request — the seed is not re-applied either; the sampler persists across sessions *with its RNG state*. The consistency check that rules out context leakage: on a greedy-first engine the later sessions match **exactly**, so sessions are clean and this divergence is the sampler's RNG, not contaminated context.

The first draft of this probe asserted `Gd == S` and came back ambiguous — under baked stochastic params with an advancing RNG, the text differs every time. The assertion was wrong, not the diagnosis; it now tests `Gd != G`, which is the property that actually distinguishes the two hypotheses.

## Docs now say

The real behaviour in both directions, that the seed is not re-applied, that `topK` defaults to 1 so this is the common path, and the workaround (`model.close()` + `getActiveModel()` for a fresh engine). Also noted: if your app uses one fixed configuration throughout, as most chat apps do, this never surfaces.

Evidence posted upstream to [#2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080#issuecomment-5305573977), which is still open with a patch offered since April.

Docs and a test only — no runtime change.
