### PR TITLE
feat(genkit): text/vision/audio backend options on FlutterGemmaModelOptions (0.4.4)

### DIFF
--- a/packages/genkit_flutter_gemma/CHANGELOG.md
+++ b/packages/genkit_flutter_gemma/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4
+
+- Add preferredBackend / preferredVisionBackend / preferredAudioBackend to FlutterGemmaModelOptions (text decoder + vision/audio encoder backends).
+
 ## 0.4.3
 
 - Fix example: declare `ModelFileType.litertlm` for `.litertlm` models (desktop was declaring `.task`, routing them to MediaPipe). Adds a fileType-consistency test.

--- a/packages/genkit_flutter_gemma/README.md
+++ b/packages/genkit_flutter_gemma/README.md
@@ -138,6 +138,9 @@ final response = await ai.generate(
 | `systemInstruction` | `String?` | null | System-level instruction (overrides system-role messages) |
 | `maxFunctionBufferLength` | `int?` | null | Max token buffer for streaming tool-call arguments (increase for large payloads) |
 | `enableSpeculativeDecoding` | `bool?` | null | MTP speculative decoding for Gemma 4 E2B/E4B (null = model default, true/false = force on/off) |
+| `preferredBackend` | `String?` | null | Text-decoder backend: `'cpu'`, `'gpu'`, `'npu'` (null = engine default) |
+| `preferredVisionBackend` | `String?` | null | Vision-encoder backend: `'cpu'`, `'gpu'`, `'npu'` (null defaults to CPU; ignored by MediaPipe) |
+| `preferredAudioBackend` | `String?` | null | Audio-encoder backend: `'cpu'`, `'gpu'`, `'npu'` (null defaults to CPU; set `'gpu'` for faster audio; ignored by MediaPipe) |
 
 ## Streaming
 

--- a/packages/genkit_flutter_gemma/lib/src/backend_parse.dart
+++ b/packages/genkit_flutter_gemma/lib/src/backend_parse.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_gemma/flutter_gemma.dart' as gemma;
+import 'package:genkit/genkit.dart';
+
+/// Parse a 'cpu'/'gpu'/'npu' string to [gemma.PreferredBackend]; null → null.
+/// An unrecognized value throws [GenkitException] (INVALID_ARGUMENT).
+gemma.PreferredBackend? parsePreferredBackend(
+  String? value, {
+  String field = 'preferredBackend',
+}) {
+  if (value == null) return null;
+  switch (value) {
+    case 'cpu':
+      return gemma.PreferredBackend.cpu;
+    case 'gpu':
+      return gemma.PreferredBackend.gpu;
+    case 'npu':
+      return gemma.PreferredBackend.npu;
+    default:
+      throw GenkitException(
+        'Unknown $field: "$value". Supported values: cpu, gpu, npu.',
+        status: StatusCodes.INVALID_ARGUMENT,
+      );
+  }
+}

--- a/packages/genkit_flutter_gemma/lib/src/flutter_gemma_embedder.dart
+++ b/packages/genkit_flutter_gemma/lib/src/flutter_gemma_embedder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_gemma/flutter_gemma.dart' as gemma;
 import 'package:genkit/plugin.dart';
 
+import 'backend_parse.dart';
 import 'flutter_gemma_options.dart';
 import 'flutter_gemma_runtime.dart';
 
@@ -38,23 +39,7 @@ Embedder<FlutterGemmaEmbedConfig> createFlutterGemmaEmbedder({
       }
 
       // Parse preferredBackend string to enum.
-      gemma.PreferredBackend? backend;
-      if (config?.preferredBackend != null) {
-        switch (config!.preferredBackend) {
-          case 'cpu':
-            backend = gemma.PreferredBackend.cpu;
-          case 'gpu':
-            backend = gemma.PreferredBackend.gpu;
-          case 'npu':
-            backend = gemma.PreferredBackend.npu;
-          default:
-            throw GenkitException(
-              'Unknown preferredBackend: "${config.preferredBackend}". '
-              'Supported values: cpu, gpu, npu.',
-              status: StatusCodes.INVALID_ARGUMENT,
-            );
-        }
-      }
+      final backend = parsePreferredBackend(config?.preferredBackend);
 
       // Get or create embedding model (invalidate on backend change).
       if (cachedEmbedder == null || cachedBackend != backend) {
@@ -74,10 +59,12 @@ Embedder<FlutterGemmaEmbedConfig> createFlutterGemmaEmbedder({
         embeddings: vectors
             .asMap()
             .entries
-            .map((entry) => Embedding(
-                  embedding: entry.value,
-                  metadata: request.input[entry.key].metadata,
-                ))
+            .map(
+              (entry) => Embedding(
+                embedding: entry.value,
+                metadata: request.input[entry.key].metadata,
+              ),
+            )
             .toList(growable: false),
       );
     },

--- a/packages/genkit_flutter_gemma/lib/src/flutter_gemma_model.dart
+++ b/packages/genkit_flutter_gemma/lib/src/flutter_gemma_model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_gemma/flutter_gemma.dart' as gemma;
 import 'package:genkit/plugin.dart';
 
+import 'backend_parse.dart';
 import 'converters/request_converter.dart';
 import 'converters/response_converter.dart';
 import 'converters/tool_converter.dart';
@@ -30,6 +31,9 @@ Model createFlutterGemmaModel({
   bool? cachedSupportImage;
   bool? cachedSupportAudio;
   bool? cachedEnableSpeculativeDecoding;
+  gemma.PreferredBackend? cachedPreferredBackend;
+  gemma.PreferredBackend? cachedPreferredVisionBackend;
+  gemma.PreferredBackend? cachedPreferredAudioBackend;
 
   // Future-chain lock: each caller awaits the previous one, ensuring
   // only one generation runs at a time against the native model.
@@ -62,13 +66,29 @@ Model createFlutterGemmaModel({
           cachedSupportImage: cachedSupportImage,
           cachedSupportAudio: cachedSupportAudio,
           cachedEnableSpeculativeDecoding: cachedEnableSpeculativeDecoding,
-          onModelCached: (model, maxTokens, supportImage, supportAudio, enableSpeculativeDecoding) {
-            cachedModel = model;
-            cachedMaxTokens = maxTokens;
-            cachedSupportImage = supportImage;
-            cachedSupportAudio = supportAudio;
-            cachedEnableSpeculativeDecoding = enableSpeculativeDecoding;
-          },
+          cachedPreferredBackend: cachedPreferredBackend,
+          cachedPreferredVisionBackend: cachedPreferredVisionBackend,
+          cachedPreferredAudioBackend: cachedPreferredAudioBackend,
+          onModelCached:
+              (
+                model,
+                maxTokens,
+                supportImage,
+                supportAudio,
+                enableSpeculativeDecoding,
+                preferredBackend,
+                preferredVisionBackend,
+                preferredAudioBackend,
+              ) {
+                cachedModel = model;
+                cachedMaxTokens = maxTokens;
+                cachedSupportImage = supportImage;
+                cachedSupportAudio = supportAudio;
+                cachedEnableSpeculativeDecoding = enableSpeculativeDecoding;
+                cachedPreferredBackend = preferredBackend;
+                cachedPreferredVisionBackend = preferredVisionBackend;
+                cachedPreferredAudioBackend = preferredAudioBackend;
+              },
         );
       } finally {
         completer.complete();
@@ -88,7 +108,20 @@ Future<ModelResponse> _executeGeneration({
   required bool? cachedSupportImage,
   required bool? cachedSupportAudio,
   required bool? cachedEnableSpeculativeDecoding,
-  required void Function(gemma.InferenceModel, int, bool, bool, bool?) onModelCached,
+  required gemma.PreferredBackend? cachedPreferredBackend,
+  required gemma.PreferredBackend? cachedPreferredVisionBackend,
+  required gemma.PreferredBackend? cachedPreferredAudioBackend,
+  required void Function(
+    gemma.InferenceModel,
+    int,
+    bool,
+    bool,
+    bool?,
+    gemma.PreferredBackend?,
+    gemma.PreferredBackend?,
+    gemma.PreferredBackend?,
+  )
+  onModelCached,
 }) async {
   // Parse config from the untyped Map.
   final configMap = request.config;
@@ -118,16 +151,32 @@ Future<ModelResponse> _executeGeneration({
     'none' => gemma.ToolChoice.none,
     _ => gemma.ToolChoice.auto,
   };
-  final systemInstruction = config?.systemInstruction ??
-      extractSystemInstruction(request.messages);
+  final systemInstruction =
+      config?.systemInstruction ?? extractSystemInstruction(request.messages);
   final maxFunctionBufferLength = config?.maxFunctionBufferLength;
+  final preferredBackend = parsePreferredBackend(
+    config?.preferredBackend,
+    field: 'preferredBackend',
+  );
+  final preferredVisionBackend = parsePreferredBackend(
+    config?.preferredVisionBackend,
+    field: 'preferredVisionBackend',
+  );
+  final preferredAudioBackend = parsePreferredBackend(
+    config?.preferredAudioBackend,
+    field: 'preferredAudioBackend',
+  );
 
   // Get or create InferenceModel (cached if params match).
-  final needsNewModel = cachedModel == null ||
+  final needsNewModel =
+      cachedModel == null ||
       cachedMaxTokens != maxTokens ||
       cachedSupportImage != supportImage ||
       cachedSupportAudio != supportAudio ||
-      cachedEnableSpeculativeDecoding != enableSpeculativeDecoding;
+      cachedEnableSpeculativeDecoding != enableSpeculativeDecoding ||
+      cachedPreferredBackend != preferredBackend ||
+      cachedPreferredVisionBackend != preferredVisionBackend ||
+      cachedPreferredAudioBackend != preferredAudioBackend;
 
   gemma.InferenceModel model;
   if (needsNewModel) {
@@ -136,8 +185,20 @@ Future<ModelResponse> _executeGeneration({
       supportImage: supportImage,
       supportAudio: supportAudio,
       enableSpeculativeDecoding: enableSpeculativeDecoding,
+      preferredBackend: preferredBackend,
+      preferredVisionBackend: preferredVisionBackend,
+      preferredAudioBackend: preferredAudioBackend,
     );
-    onModelCached(model, maxTokens, supportImage, supportAudio, enableSpeculativeDecoding);
+    onModelCached(
+      model,
+      maxTokens,
+      supportImage,
+      supportAudio,
+      enableSpeculativeDecoding,
+      preferredBackend,
+      preferredVisionBackend,
+      preferredAudioBackend,
+    );
   } else {
     model = cachedModel;
   }
@@ -203,9 +264,17 @@ Future<ModelResponse> _generateBlocking(
         latencyMs: latencyMs,
       );
     case gemma.ParallelFunctionCallResponse(:final calls):
-      return convertFinalResponse('', functionCalls: calls, latencyMs: latencyMs);
+      return convertFinalResponse(
+        '',
+        functionCalls: calls,
+        latencyMs: latencyMs,
+      );
     case gemma.ThinkingResponse(:final content):
-      return convertFinalResponse('', reasoningText: content, latencyMs: latencyMs);
+      return convertFinalResponse(
+        '',
+        reasoningText: content,
+        latencyMs: latencyMs,
+      );
   }
 }
 
@@ -237,8 +306,7 @@ Future<ModelResponse> _generateStreaming(
   return convertFinalResponse(
     fullText.toString(),
     functionCalls: functionCalls.isNotEmpty ? functionCalls : null,
-    reasoningText:
-        reasoningText.isNotEmpty ? reasoningText.toString() : null,
+    reasoningText: reasoningText.isNotEmpty ? reasoningText.toString() : null,
     latencyMs: stopwatch.elapsedMilliseconds.toDouble(),
   );
 }

--- a/packages/genkit_flutter_gemma/lib/src/flutter_gemma_options.dart
+++ b/packages/genkit_flutter_gemma/lib/src/flutter_gemma_options.dart
@@ -49,6 +49,17 @@ abstract class $FlutterGemmaModelOptions {
   /// (LiteRT-LM v0.11.0+). `null` honors the model's default; `true`/`false`
   /// forces on/off. Ignored by models without an embedded MTP drafter.
   bool? get enableSpeculativeDecoding;
+
+  /// Hardware backend for the text decoder ('cpu', 'gpu', 'npu'). Null uses the engine default.
+  String? get preferredBackend;
+
+  /// Backend for the vision encoder ('cpu', 'gpu', 'npu'). Null defaults to CPU
+  /// (the Metal/WebGPU delegates can't prepare its ops). Ignored by MediaPipe.
+  String? get preferredVisionBackend;
+
+  /// Backend for the audio encoder ('cpu', 'gpu', 'npu'). Null defaults to CPU;
+  /// set 'gpu' for faster audio (Gemma 3n ~2x on Metal). Ignored by MediaPipe.
+  String? get preferredAudioBackend;
 }
 
 /// Configuration options for flutter_gemma embedding generation.

--- a/packages/genkit_flutter_gemma/lib/src/flutter_gemma_options.g.dart
+++ b/packages/genkit_flutter_gemma/lib/src/flutter_gemma_options.g.dart
@@ -25,6 +25,9 @@ base class FlutterGemmaModelOptions {
     String? systemInstruction,
     int? maxFunctionBufferLength,
     bool? enableSpeculativeDecoding,
+    String? preferredBackend,
+    String? preferredVisionBackend,
+    String? preferredAudioBackend,
   }) {
     _json = {
       'maxTokens': ?maxTokens,
@@ -39,6 +42,9 @@ base class FlutterGemmaModelOptions {
       'systemInstruction': ?systemInstruction,
       'maxFunctionBufferLength': ?maxFunctionBufferLength,
       'enableSpeculativeDecoding': ?enableSpeculativeDecoding,
+      'preferredBackend': ?preferredBackend,
+      'preferredVisionBackend': ?preferredVisionBackend,
+      'preferredAudioBackend': ?preferredAudioBackend,
     };
   }
 
@@ -191,6 +197,42 @@ base class FlutterGemmaModelOptions {
     }
   }
 
+  String? get preferredBackend {
+    return _json['preferredBackend'] as String?;
+  }
+
+  set preferredBackend(String? value) {
+    if (value == null) {
+      _json.remove('preferredBackend');
+    } else {
+      _json['preferredBackend'] = value;
+    }
+  }
+
+  String? get preferredVisionBackend {
+    return _json['preferredVisionBackend'] as String?;
+  }
+
+  set preferredVisionBackend(String? value) {
+    if (value == null) {
+      _json.remove('preferredVisionBackend');
+    } else {
+      _json['preferredVisionBackend'] = value;
+    }
+  }
+
+  String? get preferredAudioBackend {
+    return _json['preferredAudioBackend'] as String?;
+  }
+
+  set preferredAudioBackend(String? value) {
+    if (value == null) {
+      _json.remove('preferredAudioBackend');
+    } else {
+      _json['preferredAudioBackend'] = value;
+    }
+  }
+
   @override
   String toString() {
     return _json.toString();
@@ -228,6 +270,9 @@ base class _FlutterGemmaModelOptionsTypeFactory
             'systemInstruction': $Schema.string(),
             'maxFunctionBufferLength': $Schema.integer(),
             'enableSpeculativeDecoding': $Schema.boolean(),
+            'preferredBackend': $Schema.string(),
+            'preferredVisionBackend': $Schema.string(),
+            'preferredAudioBackend': $Schema.string(),
           },
           required: [],
           description: 'Configuration options for flutter_gemma inference',

--- a/packages/genkit_flutter_gemma/lib/src/flutter_gemma_runtime.dart
+++ b/packages/genkit_flutter_gemma/lib/src/flutter_gemma_runtime.dart
@@ -12,6 +12,9 @@ abstract class FlutterGemmaRuntime {
     bool supportImage = false,
     bool supportAudio = false,
     bool? enableSpeculativeDecoding,
+    gemma.PreferredBackend? preferredBackend,
+    gemma.PreferredBackend? preferredVisionBackend,
+    gemma.PreferredBackend? preferredAudioBackend,
   });
 
   /// Retrieves the active embedding model.
@@ -30,12 +33,18 @@ class DefaultFlutterGemmaRuntime implements FlutterGemmaRuntime {
     bool supportImage = false,
     bool supportAudio = false,
     bool? enableSpeculativeDecoding,
+    gemma.PreferredBackend? preferredBackend,
+    gemma.PreferredBackend? preferredVisionBackend,
+    gemma.PreferredBackend? preferredAudioBackend,
   }) {
     return gemma.FlutterGemma.getActiveModel(
       maxTokens: maxTokens,
       supportImage: supportImage,
       supportAudio: supportAudio,
       enableSpeculativeDecoding: enableSpeculativeDecoding,
+      preferredBackend: preferredBackend,
+      preferredVisionBackend: preferredVisionBackend,
+      preferredAudioBackend: preferredAudioBackend,
     );
   }
 

--- a/packages/genkit_flutter_gemma/pubspec.yaml
+++ b/packages/genkit_flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.4.3
+version: 0.4.4
 homepage: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma
 issue_tracker: https://github.com/DenisovAV/flutter_gemma/issues
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   genkit: ^0.14.1
-  flutter_gemma: ^1.0.1
+  flutter_gemma: ^1.5.9
   http: ^1.2.0
   schemantic: ^0.2.0
 

--- a/packages/genkit_flutter_gemma/test/backend_parse_test.dart
+++ b/packages/genkit_flutter_gemma/test/backend_parse_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_gemma/flutter_gemma.dart' as gemma;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genkit/plugin.dart';
+import 'package:genkit_flutter_gemma/src/backend_parse.dart';
+
+void main() {
+  group('parsePreferredBackend', () {
+    test('maps each valid string to the matching enum', () {
+      // npu is exercised ONLY here — the model/embedder tests all use gpu/cpu,
+      // so a `case 'npu': return gpu` typo would otherwise ship silently.
+      expect(parsePreferredBackend('cpu'), gemma.PreferredBackend.cpu);
+      expect(parsePreferredBackend('gpu'), gemma.PreferredBackend.gpu);
+      expect(parsePreferredBackend('npu'), gemma.PreferredBackend.npu);
+    });
+
+    test('null returns null', () {
+      expect(parsePreferredBackend(null), isNull);
+    });
+
+    test('unknown value throws INVALID_ARGUMENT naming the field', () {
+      // The `field:` label must reach the message so the user learns WHICH
+      // parameter was bad — the model-layer invalid test asserts status only.
+      expect(
+        () => parsePreferredBackend('tpu', field: 'preferredAudioBackend'),
+        throwsA(
+          isA<GenkitException>()
+              .having((e) => e.status, 'status', StatusCodes.INVALID_ARGUMENT)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('preferredAudioBackend'),
+              ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/genkit_flutter_gemma/test/flutter_gemma_model_test.dart
+++ b/packages/genkit_flutter_gemma/test/flutter_gemma_model_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_gemma/flutter_gemma.dart' as gemma;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genkit/plugin.dart';
 import 'package:genkit_flutter_gemma/src/flutter_gemma_model.dart';
+import 'package:genkit_flutter_gemma/src/flutter_gemma_options.dart';
 
 import 'src/fake_runtime.dart';
 
@@ -72,10 +73,7 @@ void main() {
       final model = buildModel();
       final chunks = <ModelResponseChunk>[];
 
-      final response = await model(
-        simpleRequest(),
-        onChunk: chunks.add,
-      );
+      final response = await model(simpleRequest(), onChunk: chunks.add);
 
       expect(chunks, hasLength(2));
       expect(chunks[0].content.first.isText, isTrue);
@@ -86,19 +84,13 @@ void main() {
 
     test('streaming: handles function call in stream', () async {
       fakeChat.streamingResponses = [
-        const gemma.FunctionCallResponse(
-          name: 'search',
-          args: {'q': 'dart'},
-        ),
+        const gemma.FunctionCallResponse(name: 'search', args: {'q': 'dart'}),
       ];
 
       final model = buildModel();
       final chunks = <ModelResponseChunk>[];
 
-      final response = await model(
-        simpleRequest(),
-        onChunk: chunks.add,
-      );
+      final response = await model(simpleRequest(), onChunk: chunks.add);
 
       expect(response.message!.content.first.isToolRequest, isTrue);
       expect(response.message!.content.first.toolRequest!.name, 'search');
@@ -172,12 +164,17 @@ void main() {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [
-          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
-        ],
-        config: {'toolChoice': 'required'},
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'toolChoice': 'required'},
+        ),
+      );
 
       expect(fakeModel.lastToolChoice, gemma.ToolChoice.required);
     });
@@ -186,12 +183,17 @@ void main() {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [
-          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
-        ],
-        config: {'toolChoice': 'none'},
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'toolChoice': 'none'},
+        ),
+      );
 
       expect(fakeModel.lastToolChoice, gemma.ToolChoice.none);
     });
@@ -209,36 +211,54 @@ void main() {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
-        config: {'maxFunctionBufferLength': 4096},
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'maxFunctionBufferLength': 4096},
+        ),
+      );
 
       expect(fakeModel.lastMaxFunctionBufferLength, 4096);
     });
 
-    test('passes null maxFunctionBufferLength to createChat when not set',
-        () async {
-      fakeChat.blockingResponse = const gemma.TextResponse('ok');
-      final model = buildModel();
+    test(
+      'passes null maxFunctionBufferLength to createChat when not set',
+      () async {
+        fakeChat.blockingResponse = const gemma.TextResponse('ok');
+        final model = buildModel();
 
-      await model(simpleRequest());
+        await model(simpleRequest());
 
-      expect(fakeModel.lastMaxFunctionBufferLength, isNull);
-    });
+        expect(fakeModel.lastMaxFunctionBufferLength, isNull);
+      },
+    );
 
-    test('passes enableSpeculativeDecoding to getActiveModel when set',
-        () async {
-      fakeChat.blockingResponse = const gemma.TextResponse('ok');
-      final model = buildModel();
+    test(
+      'passes enableSpeculativeDecoding to getActiveModel when set',
+      () async {
+        fakeChat.blockingResponse = const gemma.TextResponse('ok');
+        final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
-        config: {'enableSpeculativeDecoding': true},
-      ));
+        await model(
+          ModelRequest(
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'Hi')],
+              ),
+            ],
+            config: {'enableSpeculativeDecoding': true},
+          ),
+        );
 
-      expect(runtime.lastEnableSpeculativeDecoding, isTrue);
-    });
+        expect(runtime.lastEnableSpeculativeDecoding, isTrue);
+      },
+    );
 
     test('passes null enableSpeculativeDecoding when not set', () async {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
@@ -254,33 +274,227 @@ void main() {
       final model = buildModel();
 
       await model(simpleRequest());
-      await model(ModelRequest(
-        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
-        config: {'enableSpeculativeDecoding': false},
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'enableSpeculativeDecoding': false},
+        ),
+      );
 
       expect(runtime.getActiveModelCallCount, 2);
     });
 
-    test('recreates model when enableSpeculativeDecoding reverts to null',
-        () async {
+    test(
+      'recreates model when enableSpeculativeDecoding reverts to null',
+      () async {
+        fakeChat.blockingResponse = const gemma.TextResponse('ok');
+        final model = buildModel();
+
+        await model(
+          ModelRequest(
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'Hi')],
+              ),
+            ],
+            config: {'enableSpeculativeDecoding': true},
+          ),
+        );
+        await model(simpleRequest());
+
+        expect(runtime.getActiveModelCallCount, 2);
+        expect(runtime.lastEnableSpeculativeDecoding, isNull);
+      },
+    );
+
+    test('passes preferredBackend to getActiveModel when set', () async {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
-        config: {'enableSpeculativeDecoding': true},
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'preferredBackend': 'gpu'},
+        ),
+      );
+
+      expect(runtime.lastPreferredBackend, gemma.PreferredBackend.gpu);
+    });
+
+    test('passes preferredVisionBackend to getActiveModel when set', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'preferredVisionBackend': 'gpu'},
+        ),
+      );
+
+      expect(runtime.lastPreferredVisionBackend, gemma.PreferredBackend.gpu);
+    });
+
+    test('passes preferredAudioBackend to getActiveModel when set', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'preferredAudioBackend': 'gpu'},
+        ),
+      );
+
+      expect(runtime.lastPreferredAudioBackend, gemma.PreferredBackend.gpu);
+    });
+
+    test('passes null backends to getActiveModel when not set', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
       await model(simpleRequest());
 
+      expect(runtime.lastPreferredBackend, isNull);
+      expect(runtime.lastPreferredVisionBackend, isNull);
+      expect(runtime.lastPreferredAudioBackend, isNull);
+    });
+
+    test('invalid preferredVisionBackend throws GenkitException', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await expectLater(
+        model(
+          ModelRequest(
+            messages: [
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'Hi')],
+              ),
+            ],
+            config: {'preferredVisionBackend': 'xyz'},
+          ),
+        ),
+        throwsA(
+          isA<GenkitException>().having(
+            (e) => e.status,
+            'status',
+            StatusCodes.INVALID_ARGUMENT,
+          ),
+        ),
+      );
+    });
+
+    test('recreates model when preferredVisionBackend changes', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(simpleRequest());
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'preferredVisionBackend': 'gpu'},
+        ),
+      );
+
       expect(runtime.getActiveModelCallCount, 2);
-      expect(runtime.lastEnableSpeculativeDecoding, isNull);
+      // Recreated AND forwarded the new value (not a stale-value recreate).
+      expect(runtime.lastPreferredVisionBackend, gemma.PreferredBackend.gpu);
+    });
+
+    test('recreates model when preferredBackend changes', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(simpleRequest());
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'preferredBackend': 'gpu'},
+        ),
+      );
+
+      expect(runtime.getActiveModelCallCount, 2);
+      expect(runtime.lastPreferredBackend, gemma.PreferredBackend.gpu);
+    });
+
+    test('recreates model when preferredAudioBackend changes', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(simpleRequest());
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'preferredAudioBackend': 'gpu'},
+        ),
+      );
+
+      expect(runtime.getActiveModelCallCount, 2);
+      expect(runtime.lastPreferredAudioBackend, gemma.PreferredBackend.gpu);
+    });
+
+    test('FlutterGemmaModelOptions round-trips backend strings', () {
+      final json = FlutterGemmaModelOptions(
+        preferredBackend: 'npu',
+        preferredVisionBackend: 'gpu',
+        preferredAudioBackend: 'cpu',
+      ).toJson();
+
+      expect(json['preferredBackend'], 'npu');
+      expect(json['preferredVisionBackend'], 'gpu');
+      expect(json['preferredAudioBackend'], 'cpu');
+
+      final parsed = FlutterGemmaModelOptions.fromJson(json);
+      expect(parsed.preferredBackend, 'npu');
+      expect(parsed.preferredVisionBackend, 'gpu');
+      expect(parsed.preferredAudioBackend, 'cpu');
     });
 
     test('blocking: returns parallel function call response', () async {
       fakeChat.blockingResponse = const gemma.ParallelFunctionCallResponse(
         calls: [
-          gemma.FunctionCallResponse(name: 'get_weather', args: {'city': 'Moscow'}),
+          gemma.FunctionCallResponse(
+            name: 'get_weather',
+            args: {'city': 'Moscow'},
+          ),
           gemma.FunctionCallResponse(name: 'get_time', args: {'tz': 'MSK'}),
         ],
       );
@@ -310,10 +524,7 @@ void main() {
       final model = buildModel();
       final chunks = <ModelResponseChunk>[];
 
-      final response = await model(
-        simpleRequest(),
-        onChunk: chunks.add,
-      );
+      final response = await model(simpleRequest(), onChunk: chunks.add);
 
       expect(chunks, hasLength(2));
       final parts = response.message!.content;
@@ -321,8 +532,7 @@ void main() {
     });
 
     test('blocking: returns reasoning for ThinkingResponse', () async {
-      fakeChat.blockingResponse =
-          const gemma.ThinkingResponse('step by step');
+      fakeChat.blockingResponse = const gemma.ThinkingResponse('step by step');
 
       final model = buildModel();
       final response = await model(simpleRequest());
@@ -343,10 +553,7 @@ void main() {
       final model = buildModel();
       final chunks = <ModelResponseChunk>[];
 
-      final response = await model(
-        simpleRequest(),
-        onChunk: chunks.add,
-      );
+      final response = await model(simpleRequest(), onChunk: chunks.add);
 
       expect(chunks, hasLength(3));
       expect(chunks[0].content.first.isReasoning, isTrue);
@@ -371,15 +578,10 @@ void main() {
     });
 
     test('streaming: response includes latencyMs', () async {
-      fakeChat.streamingResponses = [
-        const gemma.TextResponse('ok'),
-      ];
+      fakeChat.streamingResponses = [const gemma.TextResponse('ok')];
       final model = buildModel();
 
-      final response = await model(
-        simpleRequest(),
-        onChunk: (_) {},
-      );
+      final response = await model(simpleRequest(), onChunk: (_) {});
 
       expect(response.latencyMs, isNotNull);
       expect(response.latencyMs, greaterThanOrEqualTo(0));
@@ -388,22 +590,24 @@ void main() {
     test('null request throws GenkitException', () async {
       final model = buildModel();
 
-      await expectLater(
-        model(null),
-        throwsA(isA<GenkitException>()),
-      );
+      await expectLater(model(null), throwsA(isA<GenkitException>()));
     });
 
     test('passes systemInstruction from config to createChat', () async {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [
-          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
-        ],
-        config: {'systemInstruction': 'Be concise.'},
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+          config: {'systemInstruction': 'Be concise.'},
+        ),
+      );
 
       expect(fakeModel.lastSystemInstruction, 'Be concise.');
     });
@@ -412,73 +616,94 @@ void main() {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [
-          Message(
-            role: Role.system,
-            content: [TextPart(text: 'You are helpful.')],
-          ),
-          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
-        ],
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.system,
+              content: [TextPart(text: 'You are helpful.')],
+            ),
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hi')],
+            ),
+          ],
+        ),
+      );
 
       expect(fakeModel.lastSystemInstruction, 'You are helpful.');
     });
 
-    test('config systemInstruction takes priority over system messages',
-        () async {
-      fakeChat.blockingResponse = const gemma.TextResponse('ok');
-      final model = buildModel();
+    test(
+      'config systemInstruction takes priority over system messages',
+      () async {
+        fakeChat.blockingResponse = const gemma.TextResponse('ok');
+        final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [
-          Message(
-            role: Role.system,
-            content: [TextPart(text: 'From message.')],
+        await model(
+          ModelRequest(
+            messages: [
+              Message(
+                role: Role.system,
+                content: [TextPart(text: 'From message.')],
+              ),
+              Message(
+                role: Role.user,
+                content: [TextPart(text: 'Hi')],
+              ),
+            ],
+            config: {'systemInstruction': 'From config.'},
           ),
-          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
-        ],
-        config: {'systemInstruction': 'From config.'},
-      ));
+        );
 
-      expect(fakeModel.lastSystemInstruction, 'From config.');
-    });
+        expect(fakeModel.lastSystemInstruction, 'From config.');
+      },
+    );
 
     test('system messages are not prepended to user messages', () async {
       fakeChat.blockingResponse = const gemma.TextResponse('ok');
       final model = buildModel();
 
-      await model(ModelRequest(
-        messages: [
-          Message(
-            role: Role.system,
-            content: [TextPart(text: 'Be helpful.')],
-          ),
-          Message(role: Role.user, content: [TextPart(text: 'Hello')]),
-        ],
-      ));
+      await model(
+        ModelRequest(
+          messages: [
+            Message(
+              role: Role.system,
+              content: [TextPart(text: 'Be helpful.')],
+            ),
+            Message(
+              role: Role.user,
+              content: [TextPart(text: 'Hello')],
+            ),
+          ],
+        ),
+      );
 
       // System message should be passed via createChat, not prepended to user message.
       expect(fakeChat.receivedMessages, hasLength(1));
       expect(fakeChat.receivedMessages[0].text, 'Hello');
     });
 
-    test('throws on system-only messages (no user or model messages)',
-        () async {
-      fakeChat.blockingResponse = const gemma.TextResponse('ok');
-      final model = buildModel();
+    test(
+      'throws on system-only messages (no user or model messages)',
+      () async {
+        fakeChat.blockingResponse = const gemma.TextResponse('ok');
+        final model = buildModel();
 
-      await expectLater(
-        model(ModelRequest(
-          messages: [
-            Message(
-              role: Role.system,
-              content: [TextPart(text: 'Be helpful.')],
+        await expectLater(
+          model(
+            ModelRequest(
+              messages: [
+                Message(
+                  role: Role.system,
+                  content: [TextPart(text: 'Be helpful.')],
+                ),
+              ],
             ),
-          ],
-        )),
-        throwsA(isA<GenkitException>()),
-      );
-    });
+          ),
+          throwsA(isA<GenkitException>()),
+        );
+      },
+    );
   });
 }

--- a/packages/genkit_flutter_gemma/test/src/fake_runtime.dart
+++ b/packages/genkit_flutter_gemma/test/src/fake_runtime.dart
@@ -7,8 +7,8 @@ import 'package:genkit_flutter_gemma/src/flutter_gemma_runtime.dart';
 /// without depending on the real flutter_gemma static API.
 class FakeRuntime implements FlutterGemmaRuntime {
   FakeRuntime({FakeInferenceModel? model, FakeEmbeddingModel? embedder})
-      : modelToReturn = model ?? FakeInferenceModel(),
-        embedderToReturn = embedder ?? FakeEmbeddingModel();
+    : modelToReturn = model ?? FakeInferenceModel(),
+      embedderToReturn = embedder ?? FakeEmbeddingModel();
 
   final FakeInferenceModel modelToReturn;
   final FakeEmbeddingModel embedderToReturn;
@@ -16,6 +16,9 @@ class FakeRuntime implements FlutterGemmaRuntime {
   int getActiveEmbedderCallCount = 0;
 
   bool? lastEnableSpeculativeDecoding;
+  gemma.PreferredBackend? lastPreferredBackend;
+  gemma.PreferredBackend? lastPreferredVisionBackend;
+  gemma.PreferredBackend? lastPreferredAudioBackend;
 
   @override
   Future<gemma.InferenceModel> getActiveModel({
@@ -23,14 +26,18 @@ class FakeRuntime implements FlutterGemmaRuntime {
     bool supportImage = false,
     bool supportAudio = false,
     bool? enableSpeculativeDecoding,
+    gemma.PreferredBackend? preferredBackend,
+    gemma.PreferredBackend? preferredVisionBackend,
+    gemma.PreferredBackend? preferredAudioBackend,
   }) async {
     getActiveModelCallCount++;
     modelToReturn._maxTokens = maxTokens;
     lastEnableSpeculativeDecoding = enableSpeculativeDecoding;
+    lastPreferredBackend = preferredBackend;
+    lastPreferredVisionBackend = preferredVisionBackend;
+    lastPreferredAudioBackend = preferredAudioBackend;
     return modelToReturn;
   }
-
-  gemma.PreferredBackend? lastPreferredBackend;
 
   @override
   Future<gemma.EmbeddingModel> getActiveEmbedder({
@@ -124,15 +131,12 @@ class FakeInferenceModel extends gemma.InferenceModel {
 
 /// Fake chat that returns preconfigured responses.
 class FakeInferenceChat extends gemma.InferenceChat {
-  FakeInferenceChat()
-      : super(
-          sessionCreator: null,
-          maxTokens: 1024,
-        );
+  FakeInferenceChat() : super(sessionCreator: null, maxTokens: 1024);
 
   /// Response returned by [generateChatResponse].
-  gemma.ModelResponse blockingResponse =
-      const gemma.TextResponse('fake response');
+  gemma.ModelResponse blockingResponse = const gemma.TextResponse(
+    'fake response',
+  );
 
   /// Responses yielded by [generateChatResponseAsync].
   List<gemma.ModelResponse> streamingResponses = [
@@ -151,7 +155,11 @@ class FakeInferenceChat extends gemma.InferenceChat {
   }
 
   @override
-  Future<void> addQueryChunk(gemma.Message message, [bool noTool = false, bool prefix = false]) async {
+  Future<void> addQueryChunk(
+    gemma.Message message, [
+    bool noTool = false,
+    bool prefix = false,
+  ]) async {
     addQueryChunkCallCount++;
     receivedMessages.add(message);
   }

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -20,7 +20,7 @@ with the on-device model exactly as it would with any cloud provider.
 
 ```
 dependencies:
-  genkit_flutter_gemma: ^0.4.3
+  genkit_flutter_gemma: ^0.4.4
   flutter_gemma: ^1.5.9
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.4.2   # .litertlm models (mobile + desktop)
@@ -116,6 +116,10 @@ final response = await ai.generate(
     temperature: 0.5,
     topK: 40,
     supportImage: true,
+    // Optional per-component backend ('cpu'/'gpu'/'npu'):
+    preferredBackend: 'gpu',        // text decoder
+    preferredAudioBackend: 'gpu',   // audio encoder (~2x on Metal; defaults to CPU)
+    // preferredVisionBackend defaults to CPU (Metal/WebGPU can't run its ops).
   ),
 );
 ```


### PR DESCRIPTION
Exposes the per-component backend selection (core 1.5.9's `preferredVisionBackend` / `preferredAudioBackend`, plus the text `preferredBackend` that genkit never surfaced) through the Genkit inference wrapper — so a `FlutterGemmaModelOptions` config can pick each component's backend, e.g. `preferredAudioBackend: 'gpu'` for the Gemma 3n audio speedup.

## Changes
- `FlutterGemmaModelOptions` gains 3 `String?` options (`'cpu'/'gpu'/'npu'`, null → engine/CPU default), hand-wired through the maintained `.g.dart` (ctor / `_json` / getter+setter / `jsonSchema()`).
- New shared `parsePreferredBackend` helper (String→enum, throws `INVALID_ARGUMENT` on unknown); the embedder's inline switch is refactored onto it (behavior-identical).
- Threaded through the runtime + the model action's cache-key (recreates the model when any backend changes) → `getActiveModel`.
- **floor raised `flutter_gemma: ^1.0.1 → ^1.5.9`** (the new params need core 1.5.9).

## Review + tests
4-agent review (correctness / tests / comments): sound; `.g.dart` consistent across all 4 spots, cache-key correct, docs accurate. Added recreate-on-change tests for all 3 backends (with value asserts) + a direct `parsePreferredBackend` unit test (npu mapping + the `field:` label in the error). **106 tests, analyze clean.**

## Docs (same PR)
- `README.md`: 3 new options-table rows.
- `website/content/docs/genkit.md`: pin bump `^0.4.4` + a per-component-backend example.

genkit 0.4.3 → **0.4.4**.
