### PR TITLE
ci(win): assert the shipped OpenVino runtime matches the dispatch's SDK

### DIFF
--- a/.claude/skills/build-native/SKILL.md
+++ b/.claude/skills/build-native/SKILL.md
@@ -176,7 +176,17 @@ Why the old rule was believable and still wrong: a fresh LiteRT-LM build genuine
 
 Both looked like clean regressions at a version boundary, because they were: the boundary is where upstream finally touched the code the frozen artifact depended on. **Verify a bisection's conclusion, not just its measurement** — "v0.13.1 works, v0.14.0 crashes" is a true measurement that says nothing about whose change is at fault when one input to the comparison never moved.
 
-**Windows now asserts the pairing instead of documenting it.** `build-litertlm-native-windows.yml` reads the build string the SDK declares in `runtime/version.txt` and compares it against the string embedded in the `openvino.dll` being staged, throwing on mismatch — and throwing just as loudly when either side is unreadable, because a check that passes on missing data is indistinguishable from one that verified something. It reads the *artifact* rather than the source, so a bundle staged from a cache, a carried-forward directory, or by hand fails in CI rather than on a user's machine. Verified in both directions on Lunar Lake: the pinned nightly passes, and the released `2026.3.0` build `22451` throws — note that one shares the version triple with the pin, so a `MAJOR.MINOR.PATCH` comparison would have waved it through. **Android has no equivalent.** The QNN libs are still checked by size comparison against the SDK plus an on-device run (check #9), so that half of the rule is still enforced by hand.
+**The OpenVino runtime half is now asserted, in both Windows workflows.** They read the build string the SDK declares in `runtime/version.txt` and compare it against the string embedded in the `openvino.dll` being staged, throwing on mismatch — and throwing just as loudly when either side is unreadable or malformed, because a check that passes on missing data is indistinguishable from one that verified something.
+
+Be precise about what that does and does not buy, because the first version of this note was not:
+
+- **It asserts internal consistency, not the pin.** Both sides come out of the same Bazel-fetched `$ovRoot`, so no *input* can currently make it fail — only a future edit that stages either side from somewhere else. That is anti-regression value, not detection of an upstream SDK bump.
+- **It does not cover the dispatch.** `LiteRtDispatch.dll` is copied from `bazel-bin` and embeds no version string, so the half of the pair that actually broke in #3217 is still only verified by check #9 on real silicon.
+- **It cannot catch a hand-staged bundle.** `Copy-Item -Force` overwrites `artifacts\` from `$ovRoot` immediately before the check, so anything placed there by hand is gone before it could be tested.
+
+**Put it in both workflows.** `build-litertlm-native-windows.yml` is fast iteration and ends at `upload-artifact`; `build-litertlm-native.yml` carries the `publish-release` job that creates the `native-v*` tag users fetch. A check added only to the first protects nothing that ships — which is exactly the mistake this paragraph originally shipped with.
+
+**Android has no equivalent.** The QNN libs are still checked by size comparison against the SDK plus an on-device run (check #9).
 
 **The QNN runtime `.so`s must be refreshed with the dispatch, not carried forward.** They are not compiled from source — they come out of the QAIRT SDK — which makes "just keep the old ones" look safe. It is not: the dispatch you build negotiates an **API version** with them, and ours drifted into
 

--- a/.claude/skills/build-native/SKILL.md
+++ b/.claude/skills/build-native/SKILL.md
@@ -176,6 +176,8 @@ Why the old rule was believable and still wrong: a fresh LiteRT-LM build genuine
 
 Both looked like clean regressions at a version boundary, because they were: the boundary is where upstream finally touched the code the frozen artifact depended on. **Verify a bisection's conclusion, not just its measurement** — "v0.13.1 works, v0.14.0 crashes" is a true measurement that says nothing about whose change is at fault when one input to the comparison never moved.
 
+**Windows now asserts the pairing instead of documenting it.** `build-litertlm-native-windows.yml` reads the build string the SDK declares in `runtime/version.txt` and compares it against the string embedded in the `openvino.dll` being staged, throwing on mismatch — and throwing just as loudly when either side is unreadable, because a check that passes on missing data is indistinguishable from one that verified something. It reads the *artifact* rather than the source, so a bundle staged from a cache, a carried-forward directory, or by hand fails in CI rather than on a user's machine. Verified in both directions on Lunar Lake: the pinned nightly passes, and the released `2026.3.0` build `22451` throws — note that one shares the version triple with the pin, so a `MAJOR.MINOR.PATCH` comparison would have waved it through. **Android has no equivalent.** The QNN libs are still checked by size comparison against the SDK plus an on-device run (check #9), so that half of the rule is still enforced by hand.
+
 **The QNN runtime `.so`s must be refreshed with the dispatch, not carried forward.** They are not compiled from source — they come out of the QAIRT SDK — which makes "just keep the old ones" look safe. It is not: the dispatch you build negotiates an **API version** with them, and ours drifted into
 
 ```
@@ -478,7 +480,7 @@ And beware the Espresso idle timeout: `Could not launch intent within 45000 ms` 
 | 9 | `RTLD_DEFAULT` undeclared on glibc — needs `_GNU_SOURCE` before every include | CI Linux job (macOS compiles it happily) | **caught in CI** at v0.15.0 |
 | 10 | v0.15.0 changed `LiteRtLmStreamCallback` 4-arg → 2-arg, no compat overload | ACCESS_VIOLATION (Windows) / malformed UTF-8 (macOS) at first token | **caught pre-publish** at v0.15.0 |
 | 11 | `--define=litert_link_capi_so=true` deleted upstream — inert, statically linked runtime → Windows GPU `engine_create` crash | Grep the define in the tree being built | v0.14.0 → v0.16.0, **misfiled upstream as #2957** |
-| 12 | Intel NPU dispatch carried forward at OpenVino 2026.2.0 against a pin requiring 2026.3.0 | Build the dispatch from the pin | v0.11.0-b → v0.16.0, **misfiled upstream as #3217** |
+| 12 | Intel NPU dispatch carried forward at OpenVino 2026.2.0 against a pin requiring 2026.3.0 | Build the dispatch from the pin; CI asserts the staged `openvino.dll` matches the SDK's `version.txt` | v0.11.0-b → v0.16.0, **misfiled upstream as #3217** |
 | 13 | Qualcomm dispatch hardcoded to LiteRT `5c5b9ce6` — SIGSEGV in `LiteRtDestroyOptions`, and `-gcc-toolchain` when rebuilt | Derive `LITERT_REF` from WORKSPACE; check #9 on device | native-v0.12.0 → v0.16.0; rebuilt, **device verification pending** |
 | 14 | Blanket copy of OpenVino `runtime\bin` ships debug DLLs (`openvinod.dll`) beside release | Explicit allow-list + `throw` on missing | caught pre-publish at v0.16.0 |
 | 15 | QNN runtime libs left at an old QAIRT while the dispatch moved — `Qnn System library version 1.8.0 is mismatched` | Check #9 on device; compare file sizes against the SDK | native-v0.12.0 → v0.16.0, **caught on device** |

--- a/.claude/skills/build-native/SKILL.md
+++ b/.claude/skills/build-native/SKILL.md
@@ -491,7 +491,7 @@ And beware the Espresso idle timeout: `Could not launch intent within 45000 ms` 
 | 10 | v0.15.0 changed `LiteRtLmStreamCallback` 4-arg → 2-arg, no compat overload | ACCESS_VIOLATION (Windows) / malformed UTF-8 (macOS) at first token | **caught pre-publish** at v0.15.0 |
 | 11 | `--define=litert_link_capi_so=true` deleted upstream — inert, statically linked runtime → Windows GPU `engine_create` crash | Grep the define in the tree being built | v0.14.0 → v0.16.0, **misfiled upstream as #2957** |
 | 12 | Intel NPU dispatch carried forward at OpenVino 2026.2.0 against a pin requiring 2026.3.0 | Build the dispatch from the pin; CI asserts the staged `openvino.dll` matches the SDK's `version.txt` | v0.11.0-b → v0.16.0, **misfiled upstream as #3217** |
-| 13 | Qualcomm dispatch hardcoded to LiteRT `5c5b9ce6` — SIGSEGV in `LiteRtDestroyOptions`, and `-gcc-toolchain` when rebuilt | Derive `LITERT_REF` from WORKSPACE; check #9 on device | native-v0.12.0 → v0.16.0; rebuilt, **device verification pending** |
+| 13 | Qualcomm dispatch hardcoded to LiteRT `5c5b9ce6` — SIGSEGV in `LiteRtDestroyOptions`, and `-gcc-toolchain` when rebuilt | Derive `LITERT_REF` from WORKSPACE; check #9 on device | native-v0.12.0 → v0.16.0; rebuilt and **verified on Snapdragon 8 Elite via QDC** at v0.16.0 |
 | 14 | Blanket copy of OpenVino `runtime\bin` ships debug DLLs (`openvinod.dll`) beside release | Explicit allow-list + `throw` on missing | caught pre-publish at v0.16.0 |
 | 15 | QNN runtime libs left at an old QAIRT while the dispatch moved — `Qnn System library version 1.8.0 is mismatched` | Check #9 on device; compare file sizes against the SDK | native-v0.12.0 → v0.16.0, **caught on device** |
 

--- a/.claude/skills/build-native/SKILL.md
+++ b/.claude/skills/build-native/SKILL.md
@@ -186,7 +186,7 @@ Be precise about what that does and does not buy, because the first version of t
 
 **Put it in both workflows.** `build-litertlm-native-windows.yml` is fast iteration and ends at `upload-artifact`; `build-litertlm-native.yml` carries the `publish-release` job that creates the `native-v*` tag users fetch. A check added only to the first protects nothing that ships — which is exactly the mistake this paragraph originally shipped with.
 
-**Android has no equivalent.** The QNN libs are still checked by size comparison against the SDK plus an on-device run (check #9).
+**Android has no equivalent, and cannot have one.** The QNN `.so`s are `cp`'d straight out of the Bazel-fetched QAIRT SDK, so there is nothing to pair them against — no second copy, no version string to compare. `build_qualcomm_dispatch.sh` asserts each one is **present** (`[ -f "$src" ] || exit 1`, a real gate) and then only **prints** its size with `printf`; that print is not a comparison and must not be counted as one. The actual coverage for Android is the on-device run (check #9).
 
 **The QNN runtime `.so`s must be refreshed with the dispatch, not carried forward.** They are not compiled from source — they come out of the QAIRT SDK — which makes "just keep the old ones" look safe. It is not: the dispatch you build negotiates an **API version** with them, and ours drifted into
 

--- a/.github/workflows/build-litertlm-native-windows.yml
+++ b/.github/workflows/build-litertlm-native-windows.yml
@@ -225,6 +225,34 @@ jobs:
           if ($tbb.Name -notcontains 'tbb12.dll') {
             throw "tbb12.dll specifically is missing (found: $($tbb.Name -join ', '))"
           }
+          # The dispatch links against the SDK Bazel fetched, and the runtime
+          # DLLs above are copied out of that same tree, so the pair matches by
+          # construction. That is a property of the code above, not an
+          # assertion. Carrying a stale pair forward is what cost us #3217: we
+          # shipped OpenVino 2026.2.0 against a pin requiring 2026.3.0, and it
+          # read as an upstream regression until the bundle was rebuilt from
+          # the pin. Compare what the SDK declares against what is embedded in
+          # the DLL actually being shipped, so any future path that stages
+          # these from somewhere else fails here rather than on a user's
+          # machine. Every unreadable case throws: no data is a failure, not a
+          # pass.
+          $versionTxt = Join-Path $ovRoot.FullName 'openvino\runtime\version.txt'
+          if (-not (Test-Path $versionTxt)) {
+            throw "OpenVino SDK has no runtime\version.txt at $versionTxt - cannot verify the shipped runtime matches the SDK the dispatch was built against"
+          }
+          $sdkBuild = (Get-Content $versionTxt -Raw).Trim()
+          if (-not $sdkBuild) { throw "runtime\version.txt is empty - cannot verify the shipped runtime" }
+          $ovText = [System.Text.Encoding]::ASCII.GetString(
+            [System.IO.File]::ReadAllBytes("artifacts\openvino.dll"))
+          $embedded = @([regex]::Matches($ovText, '20\d\d\.\d+\.\d+-\d+-[0-9a-f]{7,40}[-/\w]*') |
+            ForEach-Object { $_.Value } | Sort-Object -Unique)
+          if ($embedded.Count -eq 0) {
+            throw "no build string embedded in the staged openvino.dll - cannot verify it matches the SDK ($sdkBuild)"
+          }
+          if ($embedded -notcontains $sdkBuild) {
+            throw "shipped openvino.dll reports '$($embedded -join ', ')' but the dispatch was built against '$sdkBuild'"
+          }
+          Write-Host "OpenVino build verified: $sdkBuild"
           Write-Host "NPU stack: LiteRtDispatch + $($ovDlls.Count) OpenVino/TBB DLLs"
           Get-ChildItem artifacts\
 

--- a/.github/workflows/build-litertlm-native-windows.yml
+++ b/.github/workflows/build-litertlm-native-windows.yml
@@ -203,10 +203,21 @@ jobs:
           # whose presence beside the release DLLs is the same mis-binding hazard
           # the allow-list above exists to avoid, and the hook was registering
           # them into user apps.
+          #
+          # Exclude Debug\ by PATH as well, because the name filter cannot see
+          # it: TBB uses a '_debug' suffix, but openvino_intel_npu_compiler.dll
+          # and openvino_intel_npu_compiler_loader.dll ship under Debug\ AND
+          # Release\ with IDENTICAL basenames (781,576 vs 781,584 bytes). With
+          # an unordered -Recurse, `Copy-Item -Force` is then last-writer-wins,
+          # and no version check can separate them — same SDK, same build
+          # string. #3217 was precisely "the Intel OV compiler plugin talking to
+          # the wrong libopenvino_intel_npu_compiler", so this is the pairing
+          # the assertion below claims to protect.
           $ovDlls = Get-ChildItem -Recurse -Filter '*.dll' -Path $ovRoot.FullName |
             Where-Object {
               ($ovWanted -contains $_.Name -or $_.Name -like 'tbb*') -and
-              $_.Name -notlike '*_debug.dll'
+              $_.Name -notlike '*_debug.dll' -and
+              $_.FullName -notmatch '\\Debug\\'
             }
           if (-not $ovDlls) { throw "OpenVino runtime DLLs not found under $($ovRoot.FullName)" }
           foreach ($d in $ovDlls) { Copy-Item $d.FullName "artifacts\$($d.Name)" -Force }
@@ -260,7 +271,12 @@ jobs:
           if ($embedded.Count -eq 0) {
             throw "no build string embedded in the staged openvino.dll - cannot verify it matches the SDK ($sdkBuild)"
           }
-          if ($embedded -notcontains $sdkBuild) {
+          # Exactly one, and it must BE the SDK build — not merely be among the
+          # matches. A DLL carrying both the right string and a stale one would
+          # satisfy -notcontains while being exactly the mismatch this checks
+          # for. Today's openvino.dll embeds precisely one, so requiring one is
+          # not a tightening in practice, only in principle.
+          if ($embedded.Count -ne 1 -or $embedded[0] -ne $sdkBuild) {
             throw "shipped openvino.dll reports '$($embedded -join ', ')' but the dispatch was built against '$sdkBuild'"
           }
           Write-Host "OpenVino build verified: $sdkBuild"

--- a/.github/workflows/build-litertlm-native-windows.yml
+++ b/.github/workflows/build-litertlm-native-windows.yml
@@ -227,24 +227,35 @@ jobs:
           }
           # The dispatch links against the SDK Bazel fetched, and the runtime
           # DLLs above are copied out of that same tree, so the pair matches by
-          # construction. That is a property of the code above, not an
-          # assertion. Carrying a stale pair forward is what cost us #3217: we
-          # shipped OpenVino 2026.2.0 against a pin requiring 2026.3.0, and it
-          # read as an upstream regression until the bundle was rebuilt from
-          # the pin. Compare what the SDK declares against what is embedded in
-          # the DLL actually being shipped, so any future path that stages
-          # these from somewhere else fails here rather than on a user's
-          # machine. Every unreadable case throws: no data is a failure, not a
-          # pass.
+          # construction. This asserts that construction rather than trusting
+          # it: a future edit that stages either side from somewhere else fails
+          # here instead of shipping a bundle whose halves disagree. Carrying a
+          # stale pair forward is what cost us #3217 - we shipped OpenVino
+          # 2026.2.0 against a pin requiring 2026.3.0, and it read as an
+          # upstream regression until the bundle was rebuilt from the pin.
+          # Every unreadable input throws: no data is a failure, not a pass.
+          #
+          # NOT covered: LiteRtDispatch.dll embeds no version string, so the
+          # dispatch half of the pair is still only verified by an on-device
+          # NPU run.
           $versionTxt = Join-Path $ovRoot.FullName 'openvino\runtime\version.txt'
           if (-not (Test-Path $versionTxt)) {
             throw "OpenVino SDK has no runtime\version.txt at $versionTxt - cannot verify the shipped runtime matches the SDK the dispatch was built against"
           }
           $sdkBuild = (Get-Content $versionTxt -Raw).Trim()
-          if (-not $sdkBuild) { throw "runtime\version.txt is empty - cannot verify the shipped runtime" }
+          $buildPattern = '20\d\d\.\d+\.\d+-\d+-[0-9a-fA-F]{7,40}[-/\w]*'
+          # Check the SDK's own string against the pattern first. A shape this
+          # does not recognise - an unreleased format, or the '<triple>-000--'
+          # a git-less OpenVino rebuild produces - would otherwise surface as
+          # "no build string in openvino.dll", blaming the DLL for a file whose
+          # contents it matches exactly.
+          if ($sdkBuild -notmatch "^$buildPattern$") {
+            throw "runtime\version.txt is not a build string this check understands: '$sdkBuild' - widen the pattern rather than skipping the comparison"
+          }
+          $ovDllPath = (Resolve-Path 'artifacts\openvino.dll').Path
           $ovText = [System.Text.Encoding]::ASCII.GetString(
-            [System.IO.File]::ReadAllBytes("artifacts\openvino.dll"))
-          $embedded = @([regex]::Matches($ovText, '20\d\d\.\d+\.\d+-\d+-[0-9a-f]{7,40}[-/\w]*') |
+            [System.IO.File]::ReadAllBytes($ovDllPath))
+          $embedded = @([regex]::Matches($ovText, $buildPattern) |
             ForEach-Object { $_.Value } | Sort-Object -Unique)
           if ($embedded.Count -eq 0) {
             throw "no build string embedded in the staged openvino.dll - cannot verify it matches the SDK ($sdkBuild)"

--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -416,10 +416,21 @@ jobs:
           # whose presence beside the release DLLs is the same mis-binding hazard
           # the allow-list above exists to avoid, and the hook was registering
           # them into user apps.
+          #
+          # Exclude Debug\ by PATH as well, because the name filter cannot see
+          # it: TBB uses a '_debug' suffix, but openvino_intel_npu_compiler.dll
+          # and openvino_intel_npu_compiler_loader.dll ship under Debug\ AND
+          # Release\ with IDENTICAL basenames (781,576 vs 781,584 bytes). With
+          # an unordered -Recurse, `Copy-Item -Force` is then last-writer-wins,
+          # and no version check can separate them — same SDK, same build
+          # string. #3217 was precisely "the Intel OV compiler plugin talking to
+          # the wrong libopenvino_intel_npu_compiler", so this is the pairing
+          # the assertion below claims to protect.
           $ovDlls = Get-ChildItem -Recurse -Filter '*.dll' -Path $ovRoot.FullName |
             Where-Object {
               ($ovWanted -contains $_.Name -or $_.Name -like 'tbb*') -and
-              $_.Name -notlike '*_debug.dll'
+              $_.Name -notlike '*_debug.dll' -and
+              $_.FullName -notmatch '\\Debug\\'
             }
           if (-not $ovDlls) { throw "OpenVino runtime DLLs not found under $($ovRoot.FullName)" }
           foreach ($d in $ovDlls) { Copy-Item $d.FullName "artifacts\$($d.Name)" -Force }
@@ -473,7 +484,12 @@ jobs:
           if ($embedded.Count -eq 0) {
             throw "no build string embedded in the staged openvino.dll - cannot verify it matches the SDK ($sdkBuild)"
           }
-          if ($embedded -notcontains $sdkBuild) {
+          # Exactly one, and it must BE the SDK build — not merely be among the
+          # matches. A DLL carrying both the right string and a stale one would
+          # satisfy -notcontains while being exactly the mismatch this checks
+          # for. Today's openvino.dll embeds precisely one, so requiring one is
+          # not a tightening in practice, only in principle.
+          if ($embedded.Count -ne 1 -or $embedded[0] -ne $sdkBuild) {
             throw "shipped openvino.dll reports '$($embedded -join ', ')' but the dispatch was built against '$sdkBuild'"
           }
           Write-Host "OpenVino build verified: $sdkBuild"

--- a/.github/workflows/build-litertlm-native.yml
+++ b/.github/workflows/build-litertlm-native.yml
@@ -438,6 +438,45 @@ jobs:
           if ($tbb.Name -notcontains 'tbb12.dll') {
             throw "tbb12.dll specifically is missing (found: $($tbb.Name -join ', '))"
           }
+          # The dispatch links against the SDK Bazel fetched, and the runtime
+          # DLLs above are copied out of that same tree, so the pair matches by
+          # construction. This asserts that construction rather than trusting
+          # it: a future edit that stages either side from somewhere else fails
+          # here instead of shipping a bundle whose halves disagree. Carrying a
+          # stale pair forward is what cost us #3217 - we shipped OpenVino
+          # 2026.2.0 against a pin requiring 2026.3.0, and it read as an
+          # upstream regression until the bundle was rebuilt from the pin.
+          # Every unreadable input throws: no data is a failure, not a pass.
+          #
+          # NOT covered: LiteRtDispatch.dll embeds no version string, so the
+          # dispatch half of the pair is still only verified by an on-device
+          # NPU run.
+          $versionTxt = Join-Path $ovRoot.FullName 'openvino\runtime\version.txt'
+          if (-not (Test-Path $versionTxt)) {
+            throw "OpenVino SDK has no runtime\version.txt at $versionTxt - cannot verify the shipped runtime matches the SDK the dispatch was built against"
+          }
+          $sdkBuild = (Get-Content $versionTxt -Raw).Trim()
+          $buildPattern = '20\d\d\.\d+\.\d+-\d+-[0-9a-fA-F]{7,40}[-/\w]*'
+          # Check the SDK's own string against the pattern first. A shape this
+          # does not recognise - an unreleased format, or the '<triple>-000--'
+          # a git-less OpenVino rebuild produces - would otherwise surface as
+          # "no build string in openvino.dll", blaming the DLL for a file whose
+          # contents it matches exactly.
+          if ($sdkBuild -notmatch "^$buildPattern$") {
+            throw "runtime\version.txt is not a build string this check understands: '$sdkBuild' - widen the pattern rather than skipping the comparison"
+          }
+          $ovDllPath = (Resolve-Path 'artifacts\openvino.dll').Path
+          $ovText = [System.Text.Encoding]::ASCII.GetString(
+            [System.IO.File]::ReadAllBytes($ovDllPath))
+          $embedded = @([regex]::Matches($ovText, $buildPattern) |
+            ForEach-Object { $_.Value } | Sort-Object -Unique)
+          if ($embedded.Count -eq 0) {
+            throw "no build string embedded in the staged openvino.dll - cannot verify it matches the SDK ($sdkBuild)"
+          }
+          if ($embedded -notcontains $sdkBuild) {
+            throw "shipped openvino.dll reports '$($embedded -join ', ')' but the dispatch was built against '$sdkBuild'"
+          }
+          Write-Host "OpenVino build verified: $sdkBuild"
           Write-Host "NPU stack: LiteRtDispatch + $($ovDlls.Count) OpenVino/TBB DLLs"
           Get-ChildItem artifacts\
 


### PR DESCRIPTION
The Windows NPU bundle ships `LiteRtDispatch.dll` next to the OpenVino runtime it was compiled against. Both come out of the same Bazel-fetched SDK today, so they match by construction — but nothing asserted it, and a written rule is exactly what failed last time: we shipped a carried-forward OpenVino 2026.2.0 against a pin requiring 2026.3.0, and it presented as an upstream regression (LiteRT-LM#3217, since retracted).

This adds the assertion. After the runtime DLLs are staged, compare the build string the SDK declares in `runtime/version.txt` against the one embedded in the `openvino.dll` being shipped, and throw on mismatch.

Reading the string out of the staged artifact rather than the source is what gives the check teeth: any future path that stages these DLLs from a cache, a carried-forward directory, or by hand fails here rather than on a user's machine. Unreadable inputs fail closed — a missing or empty `version.txt`, or a DLL with no build string, throws rather than passing silently.

## Verified on Intel Lunar Lake against real artifacts

| Input | Result |
|---|---|
| matching nightly `2026.3.0-22242-561fc907ca4` | passes, build string logged |
| released `2026.3.0` build `22451` (same version triple) | throws, both strings named |
| a DLL carrying no build string | throws |

The second case is the one worth noting: `2026.3.0-22451-8a17657b995-releases/2026/3` and the pinned nightly share a version triple, so a check on `MAJOR.MINOR.PATCH` alone would have waved it through.

## Scope

- Artifact contents are unchanged, so no new `native-v*` tag is required.
- `openvino_intel_npu_compiler.dll` is deliberately not covered by the same equality: it carries its own numbering (`2026.3.0-1-4089686065a`).
- Android has no equivalent assertion. The QNN libs are still verified by size comparison against the SDK plus an on-device run — the build-native skill now says so explicitly instead of implying the rule is enforced everywhere.

This workflow builds the Windows native bundle, so it does not run on this PR; the assertion executes on the next native build (or a manual `workflow_dispatch`).