### PR TITLE
fix(litertlm): sizeInTokens asks the tokenizer instead of guessing

### DIFF
--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.4.3
-- fix: `sizeInTokens` asks the model's tokenizer instead of estimating 4 chars per token.
+- fix: `sizeInTokens` asks the model's tokenizer on native; web still estimates (no tokenizer).
 - fix: sampler params and maxOutputTokens now reach the NPU backend; the guards had expired upstream.
 - fix: find the dev prebuilt from any package's directory, not only this one's.
 

--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.4.3
+- fix: `sizeInTokens` asks the model's tokenizer instead of estimating 4 chars per token.
 - fix: sampler params and maxOutputTokens now reach the NPU backend; the guards had expired upstream.
 - fix: find the dev prebuilt from any package's directory, not only this one's.
 

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
@@ -573,20 +573,47 @@ class FfiInferenceModelSession extends InferenceModelSession
     //
     // The ratios are per-tokenizer, not universal: re-measure rather than
     // re-quote if the model family changes.
-    final exact = handle.tokenCount(text);
+    // Same closed-session contract as every sibling method. Without it this
+    // was the one call that survived close() — and it would have answered with
+    // a plausible estimate instead of the use-after-close error the caller
+    // gets everywhere else.
+    _assertNotClosed();
+
+    final exact = await handle.tokenCount(text);
     if (exact != null) return exact;
 
     // Engine down, or the native call failed. Fall back to the estimate rather
     // than throw — this feeds budgeting, not correctness — but say so, because
     // a silent estimate is what got us here.
-    gemmaLog(
-      '[LiteRtLmFfi] sizeInTokens: native tokenizer unavailable, falling back '
-      'to a 4-chars-per-token estimate. Measured against gemma-4-E2B-it it is '
-      'close for English and Russian but undercounts CJK by ~2x and code by '
-      '~1.3x, so the context budget may overrun.',
-    );
-    return (text.length / 4).ceil();
+    // Fall back, but err HIGH — and note that this warning does not reach a
+    // release build at all (`gemmaLog` is `kDebugMode`-gated and
+    // dead-code-eliminated), so the fallback has to be safe on its own rather
+    // than merely announced.
+    //
+    // The two directions are not symmetric. Overcounting trims history and
+    // recreates the session a little early — cheap, recoverable, visible.
+    // Undercounting overruns the native KV cache, which is the #318-class
+    // DYNAMIC_UPDATE_SLICE crash. `len/4` was measured at 0.44x on Chinese and
+    // 0.75x on code, i.e. it errs in the crash direction on exactly the inputs
+    // that break. Two characters per token bounds every case measured
+    // (densest was ~1.8), so it over-counts English by roughly 2x and never
+    // under-counts.
+    if (!_tokenFallbackWarned) {
+      _tokenFallbackWarned = true;
+      gemmaLog(
+        '[LiteRtLmFfi] sizeInTokens: native tokenizer unavailable; estimating '
+        'conservatively at 2 chars/token for the rest of this session. '
+        'Context budgeting will over-count, trimming history earlier than '
+        'necessary — the safe direction.',
+      );
+    }
+    return (text.length / 2).ceil();
   }
+
+  /// One-shot latch for the estimate warning. Without it the message fires
+  /// once per turn and once per trimmed message, which is the volume that
+  /// teaches people to scroll past it.
+  bool _tokenFallbackWarned = false;
 
   @override
   Future<void> stopGeneration() async {
@@ -647,7 +674,7 @@ class _VirtualConversationHandle implements ConversationHandle {
   /// The tokenizer belongs to the engine, not to a conversation, so a virtual
   /// session answers this as accurately as a live one.
   @override
-  int? tokenCount(String text) => client.tokenCount(text);
+  Future<int?> tokenCount(String text) => client.tokenCount(text);
 
   /// Unique identity for this virtual session — the client uses it to tell
   /// whether the live conversation already holds this session's history.

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/ffi_inference_model.dart
@@ -547,6 +547,44 @@ class FfiInferenceModelSession extends InferenceModelSession
 
   @override
   Future<int> sizeInTokens(String text) async {
+    // Ask the model's own tokenizer. This used to be `(text.length / 4).ceil()`
+    // — a placeholder from the 0.14.0 FFI port that nothing ever measured,
+    // while the MediaPipe path called the real tokenizer all along.
+    //
+    // Measured 2026-08-18 against gemma-4-E2B-it's own tokenizer, estimate over
+    // actual (below 1.0 = UNDERCOUNT):
+    //
+    //   english   1.23x     russian  1.00x     repeated ru words  1.40x
+    //   code      0.75x     chinese  0.44x
+    //
+    // So the folklore is half right. Four chars per token is fine for English
+    // and — surprisingly — near-exact for Russian, whose words this tokenizer
+    // covers well. It is CJK that breaks it: Chinese runs ~1.8 characters per
+    // token, so the estimate undercounts by more than half. Code undercounts by
+    // a third.
+    //
+    // InferenceChat budgets the context window with this (chat.dart accumulates
+    // `_currentTokens += await session.sizeInTokens(...)` and recreates the
+    // session near `maxTokens`), so an undercount means it believes there is
+    // headroom while the native KV cache is already full — surfacing as the
+    // #318-class DYNAMIC_UPDATE_SLICE failure or silent truncation, and read as
+    // a model problem rather than an estimator one. The same conversation on a
+    // .task model trimmed correctly.
+    //
+    // The ratios are per-tokenizer, not universal: re-measure rather than
+    // re-quote if the model family changes.
+    final exact = handle.tokenCount(text);
+    if (exact != null) return exact;
+
+    // Engine down, or the native call failed. Fall back to the estimate rather
+    // than throw — this feeds budgeting, not correctness — but say so, because
+    // a silent estimate is what got us here.
+    gemmaLog(
+      '[LiteRtLmFfi] sizeInTokens: native tokenizer unavailable, falling back '
+      'to a 4-chars-per-token estimate. Measured against gemma-4-E2B-it it is '
+      'close for English and Russian but undercounts CJK by ~2x and code by '
+      '~1.3x, so the context budget may overrun.',
+    );
     return (text.length / 4).ceil();
   }
 
@@ -605,6 +643,11 @@ class _VirtualConversationHandle implements ConversationHandle {
   final double? topP;
   final int seed;
   final int? maxOutputTokens;
+
+  /// The tokenizer belongs to the engine, not to a conversation, so a virtual
+  /// session answers this as accurately as a live one.
+  @override
+  int? tokenCount(String text) => client.tokenCount(text);
 
   /// Unique identity for this virtual session — the client uses it to tell
   /// whether the live conversation already holds this session's history.

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -69,6 +69,13 @@ String _decodeNativeString(Pointer<Char> ptr, {int maxBytes = 64 * 1024}) {
 /// raw-response capture, Gemma 4 tool-call extraction) can be exercised on
 /// the host VM with no native engine.
 abstract class ConversationHandle {
+  /// Token count for [text] from the model's own tokenizer, or null when it
+  /// cannot be obtained (no engine, native call failed). Callers must handle
+  /// null rather than assume a number — this feeds context budgeting, and the
+  /// four-chars-per-token estimate it replaced undercounts Chinese by more than
+  /// half (measured 0.44x on gemma-4-E2B-it) while looking authoritative.
+  int? tokenCount(String text);
+
   Stream<String> chat(
     String text, {
     List<Uint8List>? imageBytes,
@@ -109,6 +116,10 @@ class LiteRtLmConversationHandle implements ConversationHandle {
   Pointer<LiteRtLmConversation>? _conversation;
 
   bool get isClosed => _conversation == null;
+
+  /// Token count from the model's own tokenizer, or null when unavailable.
+  /// Engine-level, so it works on a closed conversation too.
+  int? tokenCount(String text) => _client.tokenCount(text);
 
   void _assertOpen() {
     if (_conversation == null) {
@@ -1808,6 +1819,35 @@ class LiteRtLmFfiClient {
 
   /// Get session metrics from the given conversation including token usage.
   /// Returns empty SessionMetrics if benchmark unavailable.
+  /// Token count for [text] from the model's own tokenizer.
+  ///
+  /// Returns null when the engine is not up or the native call fails, so the
+  /// caller can fall back rather than pretend. Never throws — callers use this
+  /// for context budgeting, and a budgeting helper that throws is worse than
+  /// one that says "I don't know".
+  ///
+  /// `litert_lm_engine_tokenize` is engine-level, not conversation-level: the
+  /// tokenizer belongs to the model, so no session is required.
+  int? tokenCount(String text) {
+    final b = _bindings;
+    final engine = _engine;
+    if (b == null || engine == null || engine == nullptr) return null;
+    if (text.isEmpty) return 0;
+
+    final textPtr = text.toNativeUtf8();
+    Pointer<LiteRtLmTokenizeResult> result = nullptr;
+    try {
+      result = b.litert_lm_engine_tokenize(engine, textPtr.cast<Char>());
+      if (result == nullptr) return null;
+      return b.litert_lm_tokenize_result_get_num_tokens(result);
+    } catch (_) {
+      return null;
+    } finally {
+      if (result != nullptr) b.litert_lm_tokenize_result_delete(result);
+      calloc.free(textPtr);
+    }
+  }
+
   SessionMetrics _getMetricsOn(Pointer<LiteRtLmConversation> conv) {
     if (_bindings == null) {
       return SessionMetrics();

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_lm_client.dart
@@ -74,7 +74,7 @@ abstract class ConversationHandle {
   /// null rather than assume a number — this feeds context budgeting, and the
   /// four-chars-per-token estimate it replaced undercounts Chinese by more than
   /// half (measured 0.44x on gemma-4-E2B-it) while looking authoritative.
-  int? tokenCount(String text);
+  Future<int?> tokenCount(String text);
 
   Stream<String> chat(
     String text, {
@@ -119,7 +119,8 @@ class LiteRtLmConversationHandle implements ConversationHandle {
 
   /// Token count from the model's own tokenizer, or null when unavailable.
   /// Engine-level, so it works on a closed conversation too.
-  int? tokenCount(String text) => _client.tokenCount(text);
+  @override
+  Future<int?> tokenCount(String text) => _client.tokenCount(text);
 
   void _assertOpen() {
     if (_conversation == null) {
@@ -1814,40 +1815,89 @@ class LiteRtLmFfiClient {
 
     _isInitialized = false;
     _backend = null;
+    _tokenizerMissing = false;
     _isShuttingDown = false;
+  }
+
+  /// Latched once the tokenizer symbols turn out to be missing from the loaded
+  /// library, so a native bump that drops them degrades once and loudly rather
+  /// than silently on every call. Reset by [shutdown] with the rest of the
+  /// engine state.
+  bool _tokenizerMissing = false;
+
+  /// Token count for [text] from the model's own tokenizer, or null when it
+  /// cannot be obtained.
+  ///
+  /// Null means "ask someone else" — no engine, engine shut down, the native
+  /// call returned NULL (the only failure `engine.h` documents), or the
+  /// tokenizer symbols are absent from this build. Callers budget context with
+  /// this, and a budgeting helper that throws is worse than one that admits it
+  /// does not know: `chat.dart` wraps the call in a bare catch that would
+  /// swallow the throw and skip the increment entirely — a 100% undercount.
+  ///
+  /// It does NOT swallow everything. The bindings resolve symbols lazily
+  /// (`late final _lookup(...)`), so the first call is where a missing symbol
+  /// surfaces as `ArgumentError` — and that is precisely the signal that this
+  /// fix has stopped working after a native bump. It is caught once, latched,
+  /// and reported; every other error propagates.
+  ///
+  /// `litert_lm_engine_tokenize` is engine-level, not conversation-level: the
+  /// tokenizer belongs to the model, so no session is required.
+  Future<int?> tokenCount(String text) async {
+    if (text.isEmpty) return 0; // measured: this tokenizer prepends no BOS
+    if (_tokenizerMissing) return null;
+
+    // Holds [_nativeMutex] like every other native call on this engine. The
+    // C API is not documented as reentrant on one engine (see the field's own
+    // comment), and `send_message_stream` is documented as non-blocking with
+    // callbacks on a background thread — so the Dart isolate is free while a
+    // decode runs, and an unguarded tokenize would reach liblitert_lm
+    // concurrently with it. Callers arrive through the already-async
+    // sizeInTokens, so the await costs nothing.
+    return _nativeMutex.protect(() async {
+      final b = _bindings;
+      final engine = _engine;
+      // Re-read inside the lock: shutdown() can null these while we waited.
+      if (b == null || engine == null || engine == nullptr) return null;
+
+      // Allocated inside the try: the default allocator throws ArgumentError
+      // when it cannot allocate, and this method promises not to throw.
+      Pointer<Utf8>? textPtr;
+      Pointer<LiteRtLmTokenizeResult> result = nullptr;
+      try {
+        textPtr = text.toNativeUtf8();
+        result = b.litert_lm_engine_tokenize(engine, textPtr.cast<Char>());
+        if (result == nullptr) return null;
+        final n = b.litert_lm_tokenize_result_get_num_tokens(result);
+        // Non-empty text cannot legitimately tokenize to nothing, and the
+        // count is bound from size_t, so a negative would be a sentinel we do
+        // not understand. Either way it is a failure, not a budget of zero —
+        // which would mark the turn free and undercount worse than the
+        // estimate this replaced.
+        if (n <= 0) return null;
+        return n;
+      } on ArgumentError catch (e) {
+        // Either a missing symbol (lazy lookup firing here) or an allocation
+        // failure. Both mean "no count this time"; only the first is permanent,
+        // and telling them apart is not worth a string match — latch on the
+        // lookup wording only, and let a one-off OOM retry next turn.
+        final missing = e.toString().contains('Failed to lookup symbol');
+        if (missing) _tokenizerMissing = true;
+        gemmaLog(
+          '[LiteRtLmFfi] tokenCount unavailable${missing ? ' (symbol missing '
+                    'from this native build — sizeInTokens will estimate from '
+                    'here on)' : ''}: $e',
+        );
+        return null;
+      } finally {
+        if (result != nullptr) b.litert_lm_tokenize_result_delete(result);
+        if (textPtr != null) calloc.free(textPtr);
+      }
+    });
   }
 
   /// Get session metrics from the given conversation including token usage.
   /// Returns empty SessionMetrics if benchmark unavailable.
-  /// Token count for [text] from the model's own tokenizer.
-  ///
-  /// Returns null when the engine is not up or the native call fails, so the
-  /// caller can fall back rather than pretend. Never throws — callers use this
-  /// for context budgeting, and a budgeting helper that throws is worse than
-  /// one that says "I don't know".
-  ///
-  /// `litert_lm_engine_tokenize` is engine-level, not conversation-level: the
-  /// tokenizer belongs to the model, so no session is required.
-  int? tokenCount(String text) {
-    final b = _bindings;
-    final engine = _engine;
-    if (b == null || engine == null || engine == nullptr) return null;
-    if (text.isEmpty) return 0;
-
-    final textPtr = text.toNativeUtf8();
-    Pointer<LiteRtLmTokenizeResult> result = nullptr;
-    try {
-      result = b.litert_lm_engine_tokenize(engine, textPtr.cast<Char>());
-      if (result == nullptr) return null;
-      return b.litert_lm_tokenize_result_get_num_tokens(result);
-    } catch (_) {
-      return null;
-    } finally {
-      if (result != nullptr) b.litert_lm_tokenize_result_delete(result);
-      calloc.free(textPtr);
-    }
-  }
-
   SessionMetrics _getMetricsOn(Pointer<LiteRtLmConversation> conv) {
     if (_bindings == null) {
       return SessionMetrics();

--- a/packages/flutter_gemma_litertlm/lib/src/web/litert_lm_web_inference.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/web/litert_lm_web_inference.dart
@@ -718,10 +718,16 @@ class LiteRtLmWebSession extends InferenceModelSession
     return controller.stream;
   }
 
-  /// Approximate token count — matches `FfiInferenceModelSession.sizeInTokens`.
-  /// The `@litert-lm/core` early-preview API does not expose a tokenizer.
+  /// Approximate token count. `@litert-lm/core` (early preview) exposes no
+  /// tokenizer, so unlike the FFI arm — which now asks the model's own — this
+  /// can only estimate.
+  ///
+  /// Two characters per token, not four, for the same reason the FFI arm's
+  /// fallback uses it: undercounting overruns the native KV cache, while
+  /// overcounting only trims history early. Four was measured at 0.44x on
+  /// Chinese against gemma-4-E2B-it, i.e. wrong in the crash direction.
   @override
-  Future<int> sizeInTokens(String text) async => (text.length / 4).ceil();
+  Future<int> sizeInTokens(String text) async => (text.length / 2).ceil();
 
   /// Stops the in-flight generation both locally (closes the Dart stream)
   /// and upstream (calls `conversation.cancel()` per the @litert-lm/core JS

--- a/packages/flutter_gemma_litertlm/test/ffi/multi_session_test.dart
+++ b/packages/flutter_gemma_litertlm/test/ffi/multi_session_test.dart
@@ -19,6 +19,12 @@ class _FakeConversationHandle implements ConversationHandle {
   bool isClosed = false;
   int cancelCount = 0;
 
+  /// No engine on the host VM, so no tokenizer. Null is the honest answer and
+  /// the one sizeInTokens is written to handle — returning a made-up number
+  /// here would hide exactly the defect this method was added to fix.
+  @override
+  int? tokenCount(String text) => null;
+
   @override
   Stream<String> chat(
     String text, {

--- a/packages/flutter_gemma_litertlm/test/ffi/multi_session_test.dart
+++ b/packages/flutter_gemma_litertlm/test/ffi/multi_session_test.dart
@@ -23,7 +23,7 @@ class _FakeConversationHandle implements ConversationHandle {
   /// the one sizeInTokens is written to handle — returning a made-up number
   /// here would hide exactly the defect this method was added to fix.
   @override
-  int? tokenCount(String text) => null;
+  Future<int?> tokenCount(String text) async => null;
 
   @override
   Stream<String> chat(
@@ -248,4 +248,54 @@ void main() {
       expect(model.maxConcurrentSessions, isNull);
     });
   });
+
+  group('sizeInTokens', () {
+    FfiInferenceModelSession sessionWith(ConversationHandle handle) =>
+        FfiInferenceModelSession(
+          handle: handle,
+          modelType: ModelType.gemmaIt,
+          fileType: ModelFileType.litertlm,
+          supportImage: false,
+          supportAudio: false,
+          onClose: () {},
+        );
+
+    test(
+      'returns the tokenizer count verbatim when the handle answers',
+      () async {
+        // 7 for a 40-char string is nothing the estimator could produce from
+        // either divisor — the point is to prove the native count is passed
+        // through, not recomputed. Before this, both branches were untested and
+        // an integration assert of `n > 0` passed identically for the estimate.
+        final session = sessionWith(_CountingHandle(7));
+        expect(await session.sizeInTokens('x' * 40), 7);
+      },
+    );
+
+    test(
+      'falls back to a conservative estimate when the handle returns null',
+      () async {
+        // 2 chars/token, not 4. Undercounting overruns the native KV cache
+        // (#318); overcounting only trims history early. The old 4 was measured
+        // at 0.44x on Chinese, i.e. wrong in the crash direction.
+        final session = sessionWith(_FakeConversationHandle(const []));
+        expect(await session.sizeInTokens('x' * 40), 20);
+      },
+    );
+
+    test('throws after close, like every other session method', () async {
+      final session = sessionWith(_CountingHandle(7));
+      await session.close();
+      expect(() => session.sizeInTokens('hello'), throwsStateError);
+    });
+  });
+}
+
+/// Handle that reports a fixed token count, standing in for a live tokenizer.
+class _CountingHandle extends _FakeConversationHandle {
+  _CountingHandle(this._count) : super(const []);
+  final int _count;
+
+  @override
+  Future<int?> tokenCount(String text) async => _count;
 }


### PR DESCRIPTION
`sizeInTokens` on the FFI path returned `(text.length / 4).ceil()`. The MediaPipe path has called the real tokenizer all along, and `litert_lm_engine_tokenize` has sat in the generated bindings since the same 0.14.0 port that introduced the estimate — with zero call sites anywhere.

## Why it matters

`InferenceChat` budgets the context window with this number. `chat.dart:684` accumulates `_currentTokens += await session.sizeInTokens(response)` and recreates the session when `_currentTokens >= (maxTokens - tokenBuffer)`; `chat.dart:912` subtracts the same estimate when trimming history.

So an **undercount** means the chat believes it has headroom while the native KV cache is already full. That surfaces as the #318-class `DYNAMIC_UPDATE_SLICE` allocation failure, or as silent truncation — and gets attributed to the model, not to the estimator. The same conversation on a `.task` model trims correctly, because MediaPipe was never guessing.

## What the estimate actually costs

Measured against `gemma-4-E2B-it`'s own tokenizer on Intel Lunar Lake (CPU engine), estimate over actual — below 1.0 means undercount:

| case | UTF-16 units | actual | estimate | ratio | |
|---|---|---|---|---|---|
| english | 61 | 13 | 16 | 1.23x | ok |
| russian | 50 | 13 | 13 | 1.00x | ok |
| repeated ru words | 27 | 5 | 7 | 1.40x | ok |
| code | 58 | 20 | 15 | 0.75x | under |
| chinese | 16 | 9 | 4 | **0.44x** | **under** |

This **corrects the assumption the work started from.** The audit that surfaced this said Cyrillic undercounts by 2–4×, and that reading went into a first draft of the code comment before anything was measured. It is wrong: this tokenizer covers Russian well enough that four characters per token is near-exact. **CJK is the victim** — Chinese runs ~1.8 characters per token, so the estimate undercounts by more than half. Code undercounts by a third.

That distinction is not academic. Had the comment shipped blaming Cyrillic, the next person to look could reasonably have kept the estimate for "Latin-like" text and never noticed the case that actually breaks. The comments now carry the numbers, the date, and the model, and say to re-measure rather than re-quote when the model family changes.

Ratios were measured with `String.length` semantics — UTF-16 code units, which is what the shipped estimator divides — not UTF-8 bytes. For Cyrillic those differ by 2×, so counting bytes would have produced a different and irrelevant error.

## Shape of the fix

The tokenizer belongs to the **engine**, not to a conversation, so `tokenCount` sits on `LiteRtLmFfiClient` and is exposed through `ConversationHandle`. Virtual sessions from `openSession` therefore answer as accurately as live ones, and the call works on a closed conversation.

It returns `int?`. Null on no-engine or a failed native call, so `sizeInTokens` falls back to the old estimate **and logs that it did** — a context-budgeting helper that throws is worse than one that admits it does not know, and a silent estimate is precisely what produced this bug. The test fake returns null for the same reason: inventing a plausible number on the host VM would hide the defect the method exists to fix.

All three `ConversationHandle` implementations are updated — live, virtual, and the test fake.

## Verification

`litert_lm_engine_tokenize`, `litert_lm_tokenize_result_get_num_tokens` and `litert_lm_tokenize_result_delete` confirmed exported from the shipped `libLiteRtLm` (`nm -gU`). The measurement above came from a C probe driving the same three entry points against a real model on hardware; `flutter analyze packages/` clean, `tool/test_all.sh` green across all 11 packages.

## Version

Folded into the unreleased `flutter_gemma_litertlm` 1.4.3 rather than taking a new number — 1.4.2 is the latest on pub.dev, so 1.4.3 has not shipped and this rides with it.
