### PR TITLE
test(rag): one filter, both stores, the same rows

### DIFF
--- a/packages/flutter_gemma/lib/core/utils/host_native_library.dart
+++ b/packages/flutter_gemma/lib/core/utils/host_native_library.dart
@@ -1,0 +1,134 @@
+// Finding a native library on the HOST, for dev and test runs.
+//
+// In a real app nothing here is used: the library is in the app bundle and
+// dlopen resolves it by its bundled name. On the host there is no bundle, so
+// every package that runs native code under `flutter test` has to look for the
+// file itself — and three of them had written that search separately
+// (litert_bindings.dart, vec0_locator.dart, qdrant_locator.dart). The copies
+// had already stopped agreeing, which is how this kind of duplication always
+// ends and why the rule now lives in one place.
+//
+// TWO ORDERING RULES, both bought with incidents rather than chosen:
+//
+//   1. The hook's download cache comes before any local build artifact. The
+//      cache is version-validated by hook/build.dart (`_readMarker` /
+//      `_invalidateBundleCacheIfStale`); a local prebuilt is gitignored, made
+//      by a hand-run build script, and carries no version marker. They hold the
+//      same bytes today. After the next `native-v*` bump a stale local copy
+//      would silently shadow the refreshed download, and host tests would run
+//      against a different native version than the app ships.
+//
+//   2. Package-relative paths are walked UP from the working directory rather
+//      than assumed. Assuming cost nine red speech tests once: the error named
+//      a path and said "not found", so it read as "the library was never built"
+//      rather than "I looked in the wrong place", and nobody questioned it.
+//
+// An explicit environment override stays ahead of both — it is an instruction
+// from whoever started the run, and an override that can be overridden is not
+// one.
+library;
+
+import 'dart:io';
+
+/// Root the Native Assets hooks cache downloaded bundles under.
+///
+/// Mirrors `_cacheBaseDir()` in the hooks. Null when the platform's home
+/// directory is not readable, in which case the cache is simply not a
+/// candidate — callers still have their local paths.
+String? hostNativeCacheBase() {
+  final env = Platform.environment;
+  if (Platform.isWindows) {
+    final local = env['LOCALAPPDATA'];
+    return (local == null || local.isEmpty)
+        ? null
+        : '$local\\flutter_gemma\\native';
+  }
+  final home = env['HOME'];
+  if (home == null || home.isEmpty) return null;
+  if (Platform.isMacOS) return '$home/Library/Caches/flutter_gemma/native';
+  return '$home/.cache/flutter_gemma/native';
+}
+
+/// Host platform subdirectory used by both the hooks' cache layout and the
+/// in-repo `prebuilt/` trees.
+///
+/// Linux ships both x86_64 and arm64, so this asks `uname -m` rather than
+/// guessing: on an arm64 host the x86_64 file also exists, and preferring it by
+/// existence hands the caller an incompatible ELF.
+String? hostNativeDirName() {
+  if (Platform.isMacOS) return 'macos_arm64';
+  if (Platform.isWindows) return 'windows_x86_64';
+  if (Platform.isLinux) {
+    final arch = _unameMachine();
+    if (arch == 'aarch64' || arch == 'arm64') return 'linux_arm64';
+    return 'linux_x86_64';
+  }
+  return null;
+}
+
+String? _unameMachine() {
+  try {
+    final r = Process.runSync('uname', const ['-m']);
+    if (r.exitCode != 0) return null;
+    return r.stdout.toString().trim();
+  } on ProcessException {
+    return null;
+  }
+}
+
+/// Platform-correct file name for a library called [baseName].
+String hostNativeLibraryFileName(String baseName) {
+  if (Platform.isMacOS || Platform.isIOS) return 'lib$baseName.dylib';
+  if (Platform.isWindows) return '$baseName.dll';
+  return 'lib$baseName.so';
+}
+
+/// Every path to try for a host-side native library, in order.
+///
+/// [envOverride] is the value of a caller-specific environment variable, or
+/// null. [cacheNamespace] is the bundle's subdirectory under the cache root —
+/// null for the flat layout LiteRT uses. [relativePaths] are package-relative,
+/// and each is tried at every level walked up from the working directory.
+///
+/// Returns the list rather than the first hit so callers can name every path
+/// they tried: a wrong working directory and a genuinely absent library
+/// otherwise produce the same message, which is what made the search look like
+/// a build failure.
+List<String> hostNativeLibraryCandidates({
+  required String libFileName,
+  String? envOverride,
+  String? cacheNamespace,
+  List<String> relativePaths = const [],
+  int walkUpLevels = 8,
+}) {
+  final out = <String>[];
+  if (envOverride != null && envOverride.isNotEmpty) out.add(envOverride);
+
+  final base = hostNativeCacheBase();
+  final host = hostNativeDirName();
+  if (base != null && host != null) {
+    final ns = cacheNamespace == null ? '' : '$cacheNamespace/';
+    out.add('$base/$ns$host/$libFileName');
+  }
+
+  if (relativePaths.isNotEmpty) {
+    var dir = Directory.current.absolute;
+    for (var hop = 0; hop < walkUpLevels; hop++) {
+      for (final rel in relativePaths) {
+        out.add('${dir.path}/$rel');
+      }
+      final parent = dir.parent;
+      if (parent.path == dir.path) break;
+      dir = parent;
+    }
+  }
+  return out;
+}
+
+/// First candidate that exists, as an absolute path, or null.
+String? firstExistingPath(List<String> candidates) {
+  for (final p in candidates) {
+    if (File(p).existsSync()) return File(p).absolute.path;
+  }
+  return null;
+}

--- a/packages/flutter_gemma_litertlm/lib/src/ffi/litert_bindings.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/ffi/litert_bindings.dart
@@ -18,6 +18,8 @@
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:flutter_gemma/core/utils/host_native_library.dart';
+
 import 'package:ffi/ffi.dart';
 
 // ----- Opaque handle typedefs ------------------------------------------------
@@ -277,30 +279,22 @@ class LiteRtRankedTensorTypeView {
 /// tests sat red under that misreading. So: walk UP to the workspace root
 /// instead of assuming it.
 ///
-/// The Native Assets hook cache comes FIRST. It is version-validated by
-/// `hook/build.dart` (`_readMarker` / `_invalidateBundleCacheIfStale`), whereas
-/// `native/litert_lm/prebuilt/` is gitignored, produced by a local
-/// `build_macos.sh`, and carries no version marker at all. They are the same
-/// bytes today, but after the next `native-v*` bump a stale local prebuilt
-/// would otherwise shadow the refreshed cache and host tests would silently run
-/// against a different native version than the app ships.
-Iterable<String> _devLiteRtLmCandidates() sync* {
-  const rel = 'native/litert_lm/prebuilt/macos_arm64/libLiteRtLm.dylib';
-
-  final home = Platform.environment['HOME'];
-  if (home != null && home.isNotEmpty) {
-    yield '$home/Library/Caches/flutter_gemma/native/macos_arm64/libLiteRtLm.dylib';
-  }
-
-  var dir = Directory.current.absolute;
-  for (var hop = 0; hop < 8; hop++) {
-    yield '${dir.path}/packages/flutter_gemma_litertlm/$rel';
-    yield '${dir.path}/$rel';
-    final parent = dir.parent;
-    if (parent.path == dir.path) break;
-    dir = parent;
-  }
-}
+/// The ordering rules — cache before local build, walk up rather than assume —
+/// and the incidents behind them now live in ONE place, core's
+/// host_native_library.dart, because this search had been written three times
+/// (here, and twice in rag_sqlite's tests) and the copies had drifted.
+List<String> _devLiteRtLmCandidates() => hostNativeLibraryCandidates(
+  // Reached only from the macOS branch of _openLiteRt (iOS throws before it),
+  // so the host names the shared helper computes are the macOS ones.
+  libFileName: hostNativeLibraryFileName('LiteRtLm'),
+  // LiteRT uses the FLAT cache layout: <cacheBase>/<host>/, no namespace.
+  relativePaths: [
+    'packages/flutter_gemma_litertlm/native/litert_lm/prebuilt/'
+        '${hostNativeDirName()}/${hostNativeLibraryFileName('LiteRtLm')}',
+    'native/litert_lm/prebuilt/'
+        '${hostNativeDirName()}/${hostNativeLibraryFileName('LiteRtLm')}',
+  ],
+);
 
 DynamicLibrary _openLiteRt() {
   if (Platform.isMacOS || Platform.isIOS) {

--- a/packages/flutter_gemma_rag_sqlite/lib/src/sqlite_vector_store.dart
+++ b/packages/flutter_gemma_rag_sqlite/lib/src/sqlite_vector_store.dart
@@ -1,5 +1,7 @@
 import 'dart:ffi';
 import 'dart:io';
+
+import 'package:meta/meta.dart';
 import 'dart:typed_data';
 
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
@@ -81,7 +83,24 @@ class SqliteVectorStore implements VectorStoreRepository {
   /// real app the per-platform `vec0.<ext>` is bundled by `hook/build.dart`
   /// (Native Assets) and resolved by its bundled filename — the same mechanism
   /// qdrant-edge uses.
+  /// Host-test override for the loadable's path; null in production.
+  ///
+  /// The qdrant store already had this (`QdrantEdgeClient.debugOverrideDylibPath`)
+  /// and vec0 had only the environment variable, so a test could hand one store
+  /// its library and had to configure the other through the process environment
+  /// — which meant `tool/test_all.sh` had to know about it, and a plain
+  /// `flutter test` in this package failed on a dlopen for no visible reason.
+  /// Same mechanism on both sides now.
+  ///
+  /// Setting it after the first load has no effect: sqlite3 caches the
+  /// extension.
+  @visibleForTesting
+  static String? debugOverrideDylibPath;
+
   static String _resolveVec0Path() {
+    final testOverride = debugOverrideDylibPath;
+    if (testOverride != null && testOverride.isNotEmpty) return testOverride;
+
     final override = Platform.environment['VEC0_DYLIB'];
     if (override != null && override.isNotEmpty) return override;
 

--- a/packages/flutter_gemma_rag_sqlite/lib/src/sqlite_vector_store_stub.dart
+++ b/packages/flutter_gemma_rag_sqlite/lib/src/sqlite_vector_store_stub.dart
@@ -3,6 +3,14 @@ import 'package:flutter_gemma/flutter_gemma.dart';
 /// Stub for SqliteVectorStore on web/WASM platforms.
 /// Web uses WebSqliteVectorStore (package:sqlite3/wasm + vec0) instead.
 class SqliteVectorStore implements VectorStoreRepository {
+  /// Present only so the stub keeps the same surface as the native class.
+  ///
+  /// Analysis resolves the conditional export to THIS file, so a static added
+  /// to the native arm and not to the stub is an error that `flutter test`
+  /// never sees and `flutter build web` reports much later. That drift is a
+  /// known hazard in this repo, so the two arms are kept in step by hand.
+  static String? debugOverrideDylibPath;
+
   @override
   bool get isInitialized => false;
 

--- a/packages/flutter_gemma_rag_sqlite/test/cross_backend_parity_test.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/cross_backend_parity_test.dart
@@ -1,0 +1,355 @@
+// One filter, one document set, two stores — the same answer, or a failure.
+//
+// WHY THIS FILE EXISTS
+//
+// The two RAG backends are supposed to be interchangeable: `VectorStoreRepository`
+// promises the same `Filter` means the same thing on sqlite-vec/vec0 and on
+// qdrant-edge. Three review passes over PR #442 found nine ways that was false,
+// and every one of them was invisible to the tests that existed, for one reason:
+//
+//   the tests compared each codec's OUTPUT to a string in the same file.
+//
+// `filter_to_vec0_test.dart` asserts generated SQL. `filter_codec_test.dart`
+// asserts JSON shape. Both are restatements of their own implementation, so a
+// codec and its test can be wrong together and stay green forever — and both
+// were. Worse, neither package's tests could even see the other backend, so
+// "parity" was a word in a group name, not a thing being checked.
+//
+// This file asserts on ROWS returned by both REAL stores. It cannot pass by
+// agreeing with a comment.
+//
+// HOW BOTH BACKENDS GET HERE
+//
+// qdrant-edge needs no local Rust build and no environment variable. Its dylib
+// arrives exactly the way LiteRT's does: flutter_gemma_rag_qdrant's
+// `hook/build.dart` downloads the release archive, verifies its SHA256 and
+// caches it, and Native Assets links it into whichever package is under test —
+// this package dev-depends on rag_qdrant, so `flutter test` here resolves it
+// like any other native asset. An earlier draft of this file reached for
+// $QDRANT_DYLIB and a cargo target path; that was solving a problem the hook
+// had already solved.
+//
+// vec0 is the one that still needs $VEC0_DYLIB, because SqliteVectorStore
+// resolves it as `vec0.framework/vec0` — a path that exists only inside a built
+// app. tool/test_all.sh exports it; vec0_locator.dart is the gate.
+//
+// If qdrant does NOT initialize, this file fails rather than skipping. That is
+// the point: three review passes found nine cross-backend defects, every one of
+// them invisible because no test ran both stores, and a suite that silently
+// checks half of what it claims is the very defect it exists to catch.
+//
+//   flutter test test/cross_backend_parity_test.dart
+import 'dart:io';
+
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_rag_qdrant/flutter_gemma_rag_qdrant.dart';
+import 'package:flutter_gemma_rag_qdrant/src/qdrant_edge_client.dart';
+import 'package:flutter_gemma_rag_sqlite/flutter_gemma_rag_sqlite.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'qdrant_locator.dart';
+import 'vec0_locator.dart';
+
+/// One document: an id and the metadata JSON it carries.
+typedef Doc = ({String id, String metadata});
+
+/// One row of the table: a filter, and the ids both stores must return.
+typedef Case = ({String name, Filter filter, List<String> expected});
+
+/// Declared once for every case, so a divergence cannot be blamed on the
+/// schema differing between the two stores.
+final schema = FilterSchema(
+  fields: [
+    FilterField(name: 'lang', type: FilterFieldType.string),
+    FilterField(name: 'price', type: FilterFieldType.number),
+    FilterField(name: 'archived', type: FilterFieldType.bool),
+  ],
+);
+
+/// The corpus. Deliberately heterogeneous — a field missing here, a value of
+/// the wrong type there — because that is where the two backends came apart,
+/// not on well-formed rows.
+const docs = <Doc>[
+  (id: 'en_cheap', metadata: '{"lang":"en","price":10,"archived":false}'),
+  (id: 'fr_dear', metadata: '{"lang":"fr","price":90,"archived":false}'),
+  (id: 'de_arch', metadata: '{"lang":"de","price":50,"archived":true}'),
+  // archived written as 1 rather than true — the same document to a reader,
+  // and two different payload variants to qdrant.
+  (id: 'es_arch1', metadata: '{"lang":"es","price":50,"archived":1}'),
+  // No `price` at all. The normal RAG case, and the one that could not even be
+  // inserted before absent-value sentinels.
+  (id: 'no_price', metadata: '{"lang":"it","archived":false}'),
+  // A price that is not a number. sqlite cannot store it; qdrant keeps it.
+  (id: 'str_price', metadata: '{"lang":"pt","price":"cheap","archived":false}'),
+];
+
+final cases = <Case>[
+  (
+    name: 'equality on a string field',
+    filter: const Filter(
+      must: [FieldEquals(key: 'lang', value: 'en')],
+    ),
+    expected: ['en_cheap'],
+  ),
+  (
+    name: 'equality compares numbers by value, not by JSON spelling',
+    // 50 and 50.0 are the same number; a store must not disagree.
+    filter: const Filter(must: [FieldEquals(key: 'price', value: 50.0)]),
+    expected: ['de_arch', 'es_arch1'],
+  ),
+  (
+    name: 'a missing field never satisfies a condition',
+    filter: const Filter(must: [FieldRange(key: 'price', gte: 0)]),
+    expected: ['en_cheap', 'fr_dear', 'de_arch', 'es_arch1'],
+  ),
+  (
+    name: 'mustNot RETURNS the document that lacks the field',
+    // The rule core documents: must excludes it, mustNot keeps it.
+    filter: const Filter(mustNot: [FieldRange(key: 'price', gte: 60)]),
+    expected: ['en_cheap', 'de_arch', 'es_arch1', 'no_price', 'str_price'],
+  ),
+  (
+    name: 'both JSON spellings of a bool are one value',
+    filter: const Filter(must: [FieldEquals(key: 'archived', value: true)]),
+    expected: ['de_arch', 'es_arch1'],
+  ),
+  (
+    name: 'a value that cannot inhabit the declared type matches nothing',
+    // qdrant used to match str_price here and sqlite did not.
+    filter: const Filter(
+      must: [FieldEquals(key: 'price', value: 'cheap')],
+    ),
+    expected: [],
+  ),
+  (
+    name: 'a non-bool-ish number is not a bool',
+    // `value == 1` made 2 mean false, matching every unarchived document.
+    filter: const Filter(must: [FieldEquals(key: 'archived', value: 2)]),
+    expected: [],
+  ),
+  (
+    name: 'set membership over a string field',
+    filter: const Filter(
+      must: [
+        FieldMatchAny(key: 'lang', values: ['en', 'de']),
+      ],
+    ),
+    expected: ['en_cheap', 'de_arch'],
+  ),
+  (
+    name: 'set membership over a number field',
+    filter: const Filter(
+      must: [
+        FieldMatchAny(key: 'price', values: [10, 90]),
+      ],
+    ),
+    expected: ['en_cheap', 'fr_dear'],
+  ),
+  (
+    name: 'an off-type member of a set is dropped, not matched',
+    filter: const Filter(
+      must: [
+        FieldMatchAny(key: 'price', values: ['cheap', 10]),
+      ],
+    ),
+    expected: ['en_cheap'],
+  ),
+  (
+    name: 'an undeclared key is a no-op, not a narrowing',
+    filter: const Filter(
+      must: [
+        FieldEquals(key: 'lang', value: 'en'),
+        FieldEquals(key: 'nosuchfield', value: 'x'),
+      ],
+    ),
+    expected: ['en_cheap'],
+  ),
+  (
+    name: 'an undeclared key in should does not narrow either',
+    filter: const Filter(
+      should: [
+        FieldEquals(key: 'lang', value: 'en'),
+        FieldEquals(key: 'nosuchfield', value: 'x'),
+      ],
+    ),
+    expected: ['en_cheap'],
+  ),
+  (
+    name: 'an unbounded range constrains nothing',
+    filter: const Filter(
+      must: [
+        FieldEquals(key: 'lang', value: 'en'),
+        FieldRange(key: 'price'),
+      ],
+    ),
+    expected: ['en_cheap'],
+  ),
+  (
+    name: 'an always-true arm makes the whole should bucket true',
+    filter: const Filter(
+      should: [
+        FieldEquals(key: 'lang', value: 'en'),
+        FieldRange(key: 'price'),
+      ],
+    ),
+    expected: [
+      'en_cheap',
+      'fr_dear',
+      'de_arch',
+      'es_arch1',
+      'no_price',
+      'str_price',
+    ],
+  ),
+  (
+    name: 'an ignored range on a string field is skipped in should',
+    filter: const Filter(
+      should: [
+        FieldEquals(key: 'lang', value: 'en'),
+        FieldRange(key: 'lang', gte: 1),
+      ],
+    ),
+    expected: ['en_cheap'],
+  ),
+  (
+    name: 'an empty set matches nothing',
+    filter: const Filter(
+      must: [FieldMatchAny(key: 'lang', values: [])],
+    ),
+    expected: [],
+  ),
+  (
+    name: 'excluding an empty set excludes nothing',
+    filter: const Filter(
+      mustNot: [FieldMatchAny(key: 'lang', values: [])],
+    ),
+    expected: [
+      'en_cheap',
+      'fr_dear',
+      'de_arch',
+      'es_arch1',
+      'no_price',
+      'str_price',
+    ],
+  ),
+  (
+    name: 'mustNot over a set',
+    filter: const Filter(
+      mustNot: [
+        FieldMatchAny(key: 'lang', values: ['en', 'fr']),
+      ],
+    ),
+    expected: ['de_arch', 'es_arch1', 'no_price', 'str_price'],
+  ),
+  (
+    name: 'must and mustNot compose',
+    filter: const Filter(
+      must: [FieldRange(key: 'price', gte: 10, lte: 90)],
+      mustNot: [FieldEquals(key: 'lang', value: 'fr')],
+    ),
+    expected: ['en_cheap', 'de_arch', 'es_arch1'],
+  ),
+];
+
+/// A vector that is the same for every document, so distance never decides the
+/// result set and any difference is the filter's doing.
+final embedding = List<double>.filled(4, 0.5);
+
+void main() {
+  final vec0Skip = vec0SkipReason;
+
+  group('cross-backend filter parity', () {
+    late Directory tmp;
+    late SqliteVectorStore sqlite;
+    QdrantVectorStore? qdrant;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('parity_');
+
+      sqlite = SqliteVectorStore();
+      sqlite.configure(schema);
+      await sqlite.initialize('${tmp.path}/vec.db');
+
+      // Pointed at the file the HOOK downloaded — see qdrant_locator.dart.
+      // Outside a built app the client cannot resolve its own bundled name,
+      // the same gap vec0 has.
+      // ignore: invalid_use_of_visible_for_testing_member
+      QdrantEdgeClient.debugOverrideDylibPath = qdrantPath;
+      final q = QdrantVectorStore();
+      q.configure(schema);
+      await q.initialize('${tmp.path}/shard');
+      qdrant = q;
+
+      for (final doc in docs) {
+        await sqlite.addDocument(
+          id: doc.id,
+          content: doc.id,
+          embedding: embedding,
+          metadata: doc.metadata,
+        );
+        await qdrant?.addDocument(
+          id: doc.id,
+          content: doc.id,
+          embedding: embedding,
+          metadata: doc.metadata,
+        );
+      }
+    });
+
+    tearDown(() async {
+      await sqlite.close();
+      await qdrant?.close();
+      qdrant = null;
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    Future<List<String>> ids(VectorStoreRepository store, Filter f) async {
+      final hits = await store.searchSimilar(
+        queryEmbedding: embedding,
+        topK: docs.length,
+        filter: f,
+      );
+      return hits.map((h) => h.id).toList()..sort();
+    }
+
+    for (final c in cases) {
+      test(c.name, () async {
+        final want = [...c.expected]..sort();
+
+        // The sqlite half always runs, so the table is asserted even on a
+        // machine without the qdrant dylib.
+        expect(await ids(sqlite, c.filter), want, reason: 'sqlite-vec');
+
+        final q = qdrant;
+        if (q == null) return;
+        expect(await ids(q, c.filter), want, reason: 'qdrant-edge');
+      });
+    }
+  }, skip: vec0Skip);
+
+  // Not a decoration. Three review passes found nine cross-backend defects, and
+  // the reason none was caught earlier is that no test ran both stores. So the
+  // file states, as an assertion rather than as a comment, that both halves
+  // actually executed.
+  //
+  // The qdrant half needs no guard of its own: setUp initializes the store
+  // unconditionally, so a missing native asset fails every case above. This
+  // covers the other half — vec0, which really can be absent, and whose absence
+  // would otherwise skip the group and leave the file looking green.
+  test('both backends were actually exercised', () {
+    expect(
+      vec0SkipReason,
+      isNull,
+      reason:
+          'the sqlite-vec half did not run, so nothing in this file was '
+          'compared across backends: $vec0SkipReason',
+    );
+    expect(
+      qdrantSkipReason,
+      isNull,
+      reason:
+          'the qdrant half did not run, so nothing in this file was compared '
+          'across backends: $qdrantSkipReason',
+    );
+  });
+}

--- a/packages/flutter_gemma_rag_sqlite/test/cross_backend_parity_test.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/cross_backend_parity_test.dart
@@ -266,6 +266,11 @@ void main() {
     setUp(() async {
       tmp = await Directory.systemTemp.createTemp('parity_');
 
+      // Both stores are pointed at their library the same way, from the same
+      // shared locator — see core's host_native_library.dart. Neither needs an
+      // environment variable.
+      // ignore: invalid_use_of_visible_for_testing_member
+      SqliteVectorStore.debugOverrideDylibPath = vec0Path;
       sqlite = SqliteVectorStore();
       sqlite.configure(schema);
       await sqlite.initialize('${tmp.path}/vec.db');

--- a/packages/flutter_gemma_rag_sqlite/test/degenerate_conditions_test.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/degenerate_conditions_test.dart
@@ -26,6 +26,7 @@ void main() {
     late Database db;
 
     setUp(() {
+      useHostNativeLibraries();
       sqlite3.ensureExtensionLoaded(
         SqliteExtension.inLibrary(
           DynamicLibrary.open(vec0Path!),

--- a/packages/flutter_gemma_rag_sqlite/test/mustnot_pushdown_test.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/mustnot_pushdown_test.dart
@@ -24,6 +24,7 @@ void main() {
     late Database db;
 
     setUp(() {
+      useHostNativeLibraries();
       sqlite3.ensureExtensionLoaded(
         SqliteExtension.inLibrary(
           DynamicLibrary.open(vec0Path!),

--- a/packages/flutter_gemma_rag_sqlite/test/number_set_membership_test.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/number_set_membership_test.dart
@@ -34,6 +34,7 @@ void main() {
     late Database db;
 
     setUp(() {
+      useHostNativeLibraries();
       sqlite3.ensureExtensionLoaded(
         SqliteExtension.inLibrary(
           DynamicLibrary.open(vec0Path!),

--- a/packages/flutter_gemma_rag_sqlite/test/qdrant_locator.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/qdrant_locator.dart
@@ -1,135 +1,54 @@
-// Locates the qdrant-edge FFI library for host-side tests, the same way
-// vec0_locator.dart locates the sqlite-vec loadable.
+// Locates the qdrant-edge FFI library for host-side tests.
 //
-// The library is NOT built here and is not in the repository. It is DOWNLOADED,
-// exactly like the LiteRT natives: flutter_gemma_rag_qdrant's hook/build.dart
-// fetches `qdrant-edge-<platform>.tar.gz` from the GitHub release, verifies its
-// SHA256, and caches it. Running `flutter test` in a package that depends on
-// rag_qdrant runs that hook, so both the per-package Native Assets output and
-// the shared cache are populated as a side effect — no cargo, no CI step.
+// The library is NOT built here and is not in the repository: it is DOWNLOADED
+// by flutter_gemma_rag_qdrant/hook/build.dart, exactly like the LiteRT natives.
+// `flutter test` runs that hook, so the file is on disk before this reads it.
 //
 // What does NOT work is letting QdrantEdgeClient resolve it on its own: outside
 // a built app it looks for the bundled name and fails with "native library not
-// found for macos". That is the same gap vec0 has, and the same fix — point the
-// client at the file the hook already downloaded.
+// found for macos". Same gap vec0 has, same fix -- hand it the downloaded file.
 //
-// An earlier draft of the parity suite reached for a cargo target directory
-// instead. That worked on the one machine that had run cargo, which is the
-// property a test must not have.
+// The search order lives in core's host_native_library.dart, shared with vec0
+// and litertlm. See it for why the cache outranks a local build and why the
+// relative paths are walked up rather than assumed.
 library;
 
 import 'dart:io';
 
-/// Host-platform subdirectory name used by the hook's cache layout.
-String? get _hostDir {
-  if (Platform.isMacOS) return 'macos_arm64';
-  if (Platform.isWindows) return 'windows_x86_64';
-  if (Platform.isLinux) {
-    final arch = _unameMachine();
-    if (arch == 'aarch64' || arch == 'arm64') return 'linux_arm64';
-    return 'linux_x86_64';
-  }
-  return null;
-}
+import 'package:flutter_gemma/core/utils/host_native_library.dart';
 
-String? _unameMachine() {
-  try {
-    final r = Process.runSync('uname', const ['-m']);
-    if (r.exitCode != 0) return null;
-    return r.stdout.toString().trim();
-  } on ProcessException {
-    return null;
-  }
-}
+String get _libName => hostNativeLibraryFileName('qdrant_edge_ffi');
 
-String get _libName {
-  if (Platform.isMacOS) return 'libqdrant_edge_ffi.dylib';
-  if (Platform.isWindows) return 'qdrant_edge_ffi.dll';
-  return 'libqdrant_edge_ffi.so';
-}
-
-/// Root the hook caches downloaded bundles under, mirroring `_cacheBaseDir()`
-/// in hook/build.dart. Kept in sync by hand; the candidate list below tries the
-/// per-package Native Assets output first, so a drift here degrades to "one
-/// fewer candidate" rather than to a failure.
-String? get _cacheBase {
-  final env = Platform.environment;
-  if (Platform.isWindows) {
-    final local = env['LOCALAPPDATA'];
-    return local == null ? null : '$local\\flutter_gemma\\native';
-  }
-  final home = env['HOME'];
-  if (home == null) return null;
-  if (Platform.isMacOS) return '$home/Library/Caches/flutter_gemma/native';
-  return '$home/.cache/flutter_gemma/native';
-}
-
-/// Every path tried, in order. Named so the skip reason can list them.
-///
-/// The ORDER copies flutter_gemma_litertlm's `_devLiteRtLmCandidates`, and both
-/// of its choices are there because of an incident, not a preference:
-///
-///   * the hook's CACHE comes before any local artifact. The cache is
-///     version-validated by hook/build.dart (`_readMarker` /
-///     `_invalidateBundleCacheIfStale`); a build output is not. They hold the
-///     same bytes today, and after the next `qdrant-edge-v*` bump a stale local
-///     copy would silently shadow the refreshed download, so host tests would
-///     run against a different native version than the app ships.
-///   * the package-relative paths WALK UP from the working directory instead of
-///     assuming it. litertlm's comment records what assuming costs: the error
-///     named a path and said "not found", so it read as "the library was never
-///     built" rather than "I looked in the wrong place", and nine speech tests
-///     sat red under that misreading.
-///
-/// $QDRANT_DYLIB stays first: it is an explicit instruction from whoever ran
-/// the tests, and overriding it would make the override useless.
+/// Every path tried, in order.
 List<String> get qdrantCandidates {
-  final out = <String>[];
-
-  final override = Platform.environment['QDRANT_DYLIB'];
-  if (override != null && override.isNotEmpty) out.add(override);
-
-  // The version-validated download.
-  final base = _cacheBase;
-  final host = _hostDir;
-  if (base != null && host != null) {
-    out.add('$base/qdrant_edge/$host/$_libName');
-  }
-
-  // The hook's Native Assets output, found by walking up rather than by
-  // assuming the working directory is the package root.
   final osDir = Platform.isMacOS
       ? 'macos'
       : Platform.isWindows
       ? 'windows'
       : 'linux';
   const pkg = 'packages/flutter_gemma_rag_sqlite';
-  var dir = Directory.current.absolute;
-  for (var hop = 0; hop < 8; hop++) {
-    out.add('${dir.path}/build/native_assets/$osDir/$_libName');
-    out.add('${dir.path}/.dart_tool/lib/$_libName');
-    out.add('${dir.path}/$pkg/build/native_assets/$osDir/$_libName');
-    out.add('${dir.path}/$pkg/.dart_tool/lib/$_libName');
-    final parent = dir.parent;
-    if (parent.path == dir.path) break;
-    dir = parent;
-  }
-  return out;
+  return hostNativeLibraryCandidates(
+    libFileName: _libName,
+    envOverride: Platform.environment['QDRANT_DYLIB'],
+    cacheNamespace: 'qdrant_edge',
+    relativePaths: [
+      // The hook's Native Assets output for this package.
+      'build/native_assets/$osDir/$_libName',
+      '.dart_tool/lib/$_libName',
+      '$pkg/build/native_assets/$osDir/$_libName',
+      '$pkg/.dart_tool/lib/$_libName',
+    ],
+  );
 }
 
 /// First candidate that exists, or null when none does.
-String? get qdrantPath {
-  for (final p in qdrantCandidates) {
-    if (File(p).existsSync()) return File(p).absolute.path;
-  }
-  return null;
-}
+String? get qdrantPath => firstExistingPath(qdrantCandidates);
 
 /// Reason string for `skip:`, or null when the library is present.
 String? get qdrantSkipReason {
   if (qdrantPath != null) return null;
   return 'qdrant-edge library not found. Looked in: '
       '${qdrantCandidates.join(", ")} (cwd: ${Directory.current.path}). '
-      'It is downloaded by flutter_gemma_rag_qdrant/hook/build.dart — run '
+      'It is downloaded by flutter_gemma_rag_qdrant/hook/build.dart -- run '
       '`flutter test` once in that package, or set \$QDRANT_DYLIB.';
 }

--- a/packages/flutter_gemma_rag_sqlite/test/qdrant_locator.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/qdrant_locator.dart
@@ -1,0 +1,109 @@
+// Locates the qdrant-edge FFI library for host-side tests, the same way
+// vec0_locator.dart locates the sqlite-vec loadable.
+//
+// The library is NOT built here and is not in the repository. It is DOWNLOADED,
+// exactly like the LiteRT natives: flutter_gemma_rag_qdrant's hook/build.dart
+// fetches `qdrant-edge-<platform>.tar.gz` from the GitHub release, verifies its
+// SHA256, and caches it. Running `flutter test` in a package that depends on
+// rag_qdrant runs that hook, so both the per-package Native Assets output and
+// the shared cache are populated as a side effect — no cargo, no CI step.
+//
+// What does NOT work is letting QdrantEdgeClient resolve it on its own: outside
+// a built app it looks for the bundled name and fails with "native library not
+// found for macos". That is the same gap vec0 has, and the same fix — point the
+// client at the file the hook already downloaded.
+//
+// An earlier draft of the parity suite reached for a cargo target directory
+// instead. That worked on the one machine that had run cargo, which is the
+// property a test must not have.
+library;
+
+import 'dart:io';
+
+/// Host-platform subdirectory name used by the hook's cache layout.
+String? get _hostDir {
+  if (Platform.isMacOS) return 'macos_arm64';
+  if (Platform.isWindows) return 'windows_x86_64';
+  if (Platform.isLinux) {
+    final arch = _unameMachine();
+    if (arch == 'aarch64' || arch == 'arm64') return 'linux_arm64';
+    return 'linux_x86_64';
+  }
+  return null;
+}
+
+String? _unameMachine() {
+  try {
+    final r = Process.runSync('uname', const ['-m']);
+    if (r.exitCode != 0) return null;
+    return r.stdout.toString().trim();
+  } on ProcessException {
+    return null;
+  }
+}
+
+String get _libName {
+  if (Platform.isMacOS) return 'libqdrant_edge_ffi.dylib';
+  if (Platform.isWindows) return 'qdrant_edge_ffi.dll';
+  return 'libqdrant_edge_ffi.so';
+}
+
+/// Root the hook caches downloaded bundles under, mirroring `_cacheBaseDir()`
+/// in hook/build.dart. Kept in sync by hand; the candidate list below tries the
+/// per-package Native Assets output first, so a drift here degrades to "one
+/// fewer candidate" rather than to a failure.
+String? get _cacheBase {
+  final env = Platform.environment;
+  if (Platform.isWindows) {
+    final local = env['LOCALAPPDATA'];
+    return local == null ? null : '$local\\flutter_gemma\\native';
+  }
+  final home = env['HOME'];
+  if (home == null) return null;
+  if (Platform.isMacOS) return '$home/Library/Caches/flutter_gemma/native';
+  return '$home/.cache/flutter_gemma/native';
+}
+
+/// Every path tried, in order. Named so the skip reason can list them: a wrong
+/// working directory and a genuinely absent library otherwise look identical.
+List<String> get qdrantCandidates {
+  final out = <String>[];
+
+  final override = Platform.environment['QDRANT_DYLIB'];
+  if (override != null && override.isNotEmpty) out.add(override);
+
+  // The hook's output for THIS package — produced by the very test run that is
+  // about to read it.
+  final osDir = Platform.isMacOS
+      ? 'macos'
+      : Platform.isWindows
+      ? 'windows'
+      : 'linux';
+  out.add('build/native_assets/$osDir/$_libName');
+  out.add('.dart_tool/lib/$_libName');
+
+  // The shared download cache the hook writes to.
+  final base = _cacheBase;
+  final host = _hostDir;
+  if (base != null && host != null) {
+    out.add('$base/qdrant_edge/$host/$_libName');
+  }
+  return out;
+}
+
+/// First candidate that exists, or null when none does.
+String? get qdrantPath {
+  for (final p in qdrantCandidates) {
+    if (File(p).existsSync()) return File(p).absolute.path;
+  }
+  return null;
+}
+
+/// Reason string for `skip:`, or null when the library is present.
+String? get qdrantSkipReason {
+  if (qdrantPath != null) return null;
+  return 'qdrant-edge library not found. Looked in: '
+      '${qdrantCandidates.join(", ")} (cwd: ${Directory.current.path}). '
+      'It is downloaded by flutter_gemma_rag_qdrant/hook/build.dart — run '
+      '`flutter test` once in that package, or set \$QDRANT_DYLIB.';
+}

--- a/packages/flutter_gemma_rag_sqlite/test/qdrant_locator.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/qdrant_locator.dart
@@ -64,29 +64,55 @@ String? get _cacheBase {
   return '$home/.cache/flutter_gemma/native';
 }
 
-/// Every path tried, in order. Named so the skip reason can list them: a wrong
-/// working directory and a genuinely absent library otherwise look identical.
+/// Every path tried, in order. Named so the skip reason can list them.
+///
+/// The ORDER copies flutter_gemma_litertlm's `_devLiteRtLmCandidates`, and both
+/// of its choices are there because of an incident, not a preference:
+///
+///   * the hook's CACHE comes before any local artifact. The cache is
+///     version-validated by hook/build.dart (`_readMarker` /
+///     `_invalidateBundleCacheIfStale`); a build output is not. They hold the
+///     same bytes today, and after the next `qdrant-edge-v*` bump a stale local
+///     copy would silently shadow the refreshed download, so host tests would
+///     run against a different native version than the app ships.
+///   * the package-relative paths WALK UP from the working directory instead of
+///     assuming it. litertlm's comment records what assuming costs: the error
+///     named a path and said "not found", so it read as "the library was never
+///     built" rather than "I looked in the wrong place", and nine speech tests
+///     sat red under that misreading.
+///
+/// $QDRANT_DYLIB stays first: it is an explicit instruction from whoever ran
+/// the tests, and overriding it would make the override useless.
 List<String> get qdrantCandidates {
   final out = <String>[];
 
   final override = Platform.environment['QDRANT_DYLIB'];
   if (override != null && override.isNotEmpty) out.add(override);
 
-  // The hook's output for THIS package — produced by the very test run that is
-  // about to read it.
+  // The version-validated download.
+  final base = _cacheBase;
+  final host = _hostDir;
+  if (base != null && host != null) {
+    out.add('$base/qdrant_edge/$host/$_libName');
+  }
+
+  // The hook's Native Assets output, found by walking up rather than by
+  // assuming the working directory is the package root.
   final osDir = Platform.isMacOS
       ? 'macos'
       : Platform.isWindows
       ? 'windows'
       : 'linux';
-  out.add('build/native_assets/$osDir/$_libName');
-  out.add('.dart_tool/lib/$_libName');
-
-  // The shared download cache the hook writes to.
-  final base = _cacheBase;
-  final host = _hostDir;
-  if (base != null && host != null) {
-    out.add('$base/qdrant_edge/$host/$_libName');
+  const pkg = 'packages/flutter_gemma_rag_sqlite';
+  var dir = Directory.current.absolute;
+  for (var hop = 0; hop < 8; hop++) {
+    out.add('${dir.path}/build/native_assets/$osDir/$_libName');
+    out.add('${dir.path}/.dart_tool/lib/$_libName');
+    out.add('${dir.path}/$pkg/build/native_assets/$osDir/$_libName');
+    out.add('${dir.path}/$pkg/.dart_tool/lib/$_libName');
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
   }
   return out;
 }

--- a/packages/flutter_gemma_rag_sqlite/test/sqlite_vector_store_test.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/sqlite_vector_store_test.dart
@@ -25,6 +25,7 @@ void main() {
     late String dbPath;
 
     setUp(() {
+      useHostNativeLibraries();
       repo = SqliteVectorStore();
       dbPath =
           '${Directory.systemTemp.path}/test_vec0_store_'

--- a/packages/flutter_gemma_rag_sqlite/test/vec0_locator.dart
+++ b/packages/flutter_gemma_rag_sqlite/test/vec0_locator.dart
@@ -14,35 +14,8 @@ library;
 
 import 'dart:io';
 
-/// Host-platform subdirectory under `native/sqlite_vec/prebuilt/`.
-/// Null on a host we ship no loadable for (tests run on the host, so the
-/// iOS/Android prebuilts are never the answer here).
-///
-/// Linux ships BOTH `linux_x86_64` and `linux_arm64`, so "prefer x86_64 and let
-/// existence pick the other" does not work — the x86_64 file always exists, so
-/// arm64 was unreachable and an arm64 host got an incompatible ELF. Ask uname.
-String? get _hostPrebuiltDir {
-  if (Platform.isMacOS) return 'macos_arm64';
-  if (Platform.isWindows) return 'windows_x86_64';
-  if (Platform.isLinux) {
-    final arch = _unameMachine();
-    if (arch == 'aarch64' || arch == 'arm64') return 'linux_arm64';
-    return 'linux_x86_64';
-  }
-  return null;
-}
-
-/// `uname -m`, or null when it cannot be read. dart:io exposes no CPU
-/// architecture, and `Platform.version` names the SDK's target, not the host's.
-String? _unameMachine() {
-  try {
-    final r = Process.runSync('uname', const ['-m']);
-    if (r.exitCode != 0) return null;
-    return (r.stdout as String).trim();
-  } catch (_) {
-    return null;
-  }
-}
+import 'package:flutter_gemma/core/utils/host_native_library.dart';
+import 'package:flutter_gemma_rag_sqlite/flutter_gemma_rag_sqlite.dart';
 
 String get _libName {
   if (Platform.isMacOS) return 'libvec0.dylib';
@@ -53,23 +26,23 @@ String get _libName {
 /// Every path considered, in order. Exposed so a failure message can name them
 /// all — "not found" and "looked in the wrong place" must not read alike.
 List<String> get vec0Candidates {
-  final env = Platform.environment['VEC0_DYLIB'];
-  final out = <String>[if (env != null && env.isNotEmpty) env];
-
-  // Tests run from the package directory (tool/test_all.sh guarantees it).
-  const base = 'native/sqlite_vec/prebuilt';
-  final host = _hostPrebuiltDir;
-  if (host != null) out.add('$base/$host/$_libName');
-  return out;
+  final host = hostNativeDirName();
+  return hostNativeLibraryCandidates(
+    libFileName: _libName,
+    envOverride: Platform.environment['VEC0_DYLIB'],
+    // vec0's prebuilt is committed to this repository, so there is no download
+    // cache for it -- the shared helper simply finds nothing there.
+    relativePaths: host == null
+        ? const []
+        : [
+            'native/sqlite_vec/prebuilt/$host/$_libName',
+            'packages/flutter_gemma_rag_sqlite/native/sqlite_vec/prebuilt/$host/$_libName',
+          ],
+  );
 }
 
 /// First candidate that exists, or null when none does.
-String? get vec0Path {
-  for (final p in vec0Candidates) {
-    if (File(p).existsSync()) return p;
-  }
-  return null;
-}
+String? get vec0Path => firstExistingPath(vec0Candidates);
 
 /// Reason string for `skip:` when the extension is genuinely unavailable, or
 /// null when it is present. Names every path tried, and the working directory,
@@ -79,4 +52,21 @@ String? get vec0SkipReason {
   return 'vec0 loadable extension not found. Looked in: '
       '${vec0Candidates.join(", ")} (cwd: ${Directory.current.path}). '
       'Run from the package directory, or set \$VEC0_DYLIB.';
+}
+
+/// Points both vector stores at the libraries the shared locator found.
+///
+/// Call from `setUp`/`setUpAll` in any suite that opens a store. Before this
+/// existed each suite needed `$VEC0_DYLIB` exported by tool/test_all.sh, so a
+/// plain `flutter test` in this package failed on a dlopen with nothing to
+/// suggest the environment was the problem — and the qdrant side had a
+/// programmatic override while the sqlite side did not, so a test could
+/// configure one store and had to configure the other through the process
+/// environment.
+void useHostNativeLibraries() {
+  final vec0 = vec0Path;
+  if (vec0 != null) {
+    // ignore: invalid_use_of_visible_for_testing_member
+    SqliteVectorStore.debugOverrideDylibPath = vec0;
+  }
 }

--- a/tool/test_all.sh
+++ b/tool/test_all.sh
@@ -64,6 +64,13 @@ if [[ -z "${VEC0_DYLIB:-}" ]]; then
   fi
 fi
 
+# NOTE: the cross-backend parity suite needs no wiring here. qdrant-edge's
+# library is DOWNLOADED by flutter_gemma_rag_qdrant/hook/build.dart, exactly
+# like the LiteRT natives, and `flutter test` runs that hook — so the library is
+# already on disk by the time the suite reads it (test/qdrant_locator.dart finds
+# it). An earlier draft exported $QDRANT_DYLIB from a cargo target directory and
+# told CI to build Rust; that was solving a problem the hook had already solved.
+
 # NOTE, so nobody re-adds it: an earlier revision of this script excluded
 # flutter_gemma_speech's `qwen3-artifacts` tag whenever the HuggingFace model
 # snapshot was absent, on the assumption that those suites would otherwise fail

--- a/tool/test_all.sh
+++ b/tool/test_all.sh
@@ -38,9 +38,16 @@ WANT_COVERAGE=0
 # override (sqlite_vector_store.dart:77) and this repo ships the loadable for
 # every platform, so point at it.
 #
-# Without this those 20 store tests fail on a dlopen. They used to SKIP instead,
-# gated on $VEC0_DYLIB being set — which it never was — so a suite that had
-# never once executed looked exactly like a suite that passed.
+# The SUITES no longer need this: they call useHostNativeLibraries() (see
+# rag_sqlite/test/vec0_locator.dart), which hands the store its path through the
+# same programmatic override qdrant always had, from the same shared locator in
+# core. A plain `flutter test` in that package now works with no environment at
+# all. The export stays because the opt-in benchmark still reads it, and
+# dropping it would silently turn that off.
+#
+# History worth keeping: those store tests used to SKIP, gated on $VEC0_DYLIB
+# being set — which it never was — so a suite that had never once executed
+# looked exactly like a suite that passed.
 if [[ -z "${VEC0_DYLIB:-}" ]]; then
   _vec0_base="packages/flutter_gemma_rag_sqlite/native/sqlite_vec/prebuilt"
   case "$(uname -s)" in


### PR DESCRIPTION
## Why

Three review passes over #442 found nine ways the two RAG backends answered the same `Filter` differently. Every one of them was invisible to the tests that existed, for a single reason:

**each package asserted its own codec's output against a string in the same file.**

`filter_to_vec0_test.dart` pins generated SQL. `filter_codec_test.dart` pins JSON shape. Both are restatements of the implementation they test, so a codec and its test can be wrong together and stay green forever — and both were. And neither package's tests could see the other backend, so "parity" was the name of a test group rather than something being checked.

## What this adds

A table: one `Filter`, one document set, both **real** stores, compare returned ids.

19 cases over a deliberately heterogeneous corpus — a document with no `price`, `archived` written as `1` rather than `true`, a `price` that is the string `"cheap"` — because that is where the backends came apart. Well-formed rows always agreed.

It cannot pass by agreeing with a comment: it asserts on rows returned by sqlite-vec/vec0 and qdrant-edge.

## It discriminates

Mutation-checked. Restoring the old bool gate (`value == 1`) makes `FieldEquals(archived, 2)` return four documents on qdrant and none on sqlite, and the failure names the differing backend:

```
cross-backend filter parity a non-bool-ish number is not a bool [E]
  Expected: []
    Actual: ['en_cheap', 'fr_dear', 'no_price', 'str_price']
  qdrant-edge
```

## No new build step

qdrant-edge's library is **downloaded** by `flutter_gemma_rag_qdrant/hook/build.dart` — the same mechanism as the LiteRT natives — and `flutter test` runs that hook, so the file is on disk before the suite reads it.

`test/qdrant_locator.dart` finds it, mirroring `vec0_locator.dart`. It has to hand the path to the client explicitly because `QdrantEdgeClient` cannot resolve its own bundled name outside a built app — the same gap vec0 has, with the same fix.

An earlier draft pointed at a cargo target directory and would have needed a Rust build in CI. That version passed only on a machine where someone had run cargo, which is the property a test must not have.

## Completeness is asserted, not assumed

The suite fails if either half did not run. A run with one backend checks half of what the file claims, and that has to be visible in the output rather than inferred from a line that is missing — which is the same defect the nine findings shared.

## Verification

`flutter analyze packages/` clean, `tool/test_all.sh` green across all 11 packages, with both backends exercised and no environment variable set for qdrant.

## Base

Branched off `#442` because the table is red without its fixes. Retarget to `main` once #442 merges.
