### PR TITLE
chore: one CHANGELOG line per issue, and write that into the rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,11 @@
 - **Exception: web** — Flutter SDK does NOT support `flutter test -d chrome/web-server` for `integration_test` (only `flutter test --platform chrome`, which is deprecated for app-level tests per Flutter docs). The **only** officially supported web integration test runner is `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/<file>.dart -d chrome` (or `-d web-server` headless). On web `flutter drive` is the canonical Flutter-supported path, not a workaround — use it.
 
 ## Rule 7: CHANGELOG ENTRIES ARE ONE LINE ⛔
+- **ONE line per ISSUE**, not per change. A fix that touched nine things is still one bullet
 - Every `## X.Y.Z` bullet must fit on a single short line (~10-15 words)
 - No multi-sentence explanations, no embedded paragraphs in CHANGELOG.md
+- Collateral found while fixing an issue does NOT get its own bullet — it is already in the issue and the PR
+- Never document something that never shipped: a regression introduced and fixed inside the same PR is invisible to users
 - Detailed context (what was broken / how it's fixed / migration) goes into the release post (LinkedIn / blog), not CHANGELOG
 - Match the existing 0.15.x entries' brevity
 

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,13 +1,5 @@
 ## 1.6.3
-- Scope download updates to our own task group; `FileDownloader().updates` stays the host's (#445).
-- iOS download priority now 0 (highest); was 10, the lowest URLSession priority (#445).
-- Android download priority now 5, not 10 — below 5 shortens the OS execution guarantee.
-- Download notification is scoped to our task group instead of becoming the app-wide default.
-- The default download path no longer overwrites the app-wide `runInForeground` setting.
-- Paused and enqueued downloads re-arm the resume watchdog instead of hanging unbounded.
-- A reattached download that is gone reports notFound, not a 90-second network timeout.
-- Download progress no longer snaps to 0% when the platform reports a state sentinel.
-- `dispose()` ends a download in progress with a typed error instead of retrying it.
+- Download updates are scoped to our own task group; `FileDownloader().updates` stays the host's (#445).
 
 ## 1.6.2
 - Web: `ModelFileType.onnx` install is fileless — Transformers.js owns the repo, install just sets it active.


### PR DESCRIPTION
The 1.6.3 entry had nine bullets for one issue.

Two were the reported bug. Two were collateral of the same class found by review. Three were pre-existing bugs found on the way. And one described a regression that was introduced and fixed **inside the same PR** — something no user ever had, so documenting it told the reader that 1.6.2 was broken in a way it was not.

All of it is already in #445 and in #450. A CHANGELOG bullet is for what changed for the reader, not for what the work involved.

Collapsed to:

```
## 1.6.3
- Download updates are scoped to our own task group; `FileDownloader().updates` stays the host's (#445).
```

Rule 7 now states the rule rather than leaving it to judgement: one line per **issue** rather than per change, collateral gets no bullet of its own, and nothing that never shipped is documented.

1.6.3 is not published yet, so this lands before the entry reaches anyone.