### PR TITLE
docs(website): full content audit + Built-in AI page + Engines nav group

### DIFF
--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -76,6 +76,7 @@ runs in a sandboxed `<iframe>`.
 ```dart
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma_agent/flutter_gemma_agent.dart';
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
 
 // 1. Register the inference engine (and, optionally, the skill executors).
 await FlutterGemma.initialize(

--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -20,6 +20,21 @@ model (Gemma 4 E2B/E4B recommended). See <a href="/docs/function-calling">Functi
 Calling</a> for the model support matrix.
 </Info>
 
+## Install
+
+Add the core and the agent package. The agent builds on flutter_gemma's
+function-calling loop, so you also register an inference engine from an engine
+package (e.g. `flutter_gemma_litertlm`, which provides the `LiteRtLmEngine()`
+used below).
+
+```
+dependencies:
+  flutter_gemma: ^1.6.5
+  flutter_gemma_agent: ^0.2.5
+```
+
+The agent is **not supported on Web** yet — see the note below.
+
 ## The four skill mechanisms
 
 A skill is a Markdown file (`SKILL.md`) with YAML frontmatter and one of four

--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -31,6 +31,7 @@ used below).
 dependencies:
   flutter_gemma: ^1.6.5
   flutter_gemma_agent: ^0.2.5
+  flutter_gemma_litertlm: ^1.5.2   # an inference engine (LiteRtLmEngine)
 ```
 
 The agent is **not supported on Web** yet — see the note below.

--- a/website/content/docs/builtin-ai.md
+++ b/website/content/docs/builtin-ai.md
@@ -94,7 +94,13 @@ The point of a pluggable engine: **use the built-in model when the device
 supports it (zero download, private, fast); otherwise fall back to a downloaded
 open model** — through the same API, without rewriting the app.
 
+The fallback below registers a second engine, so add its package too — e.g.
+`flutter_gemma_litertlm` (for `LiteRtLmEngine`), or `flutter_gemma_mediapipe` /
+`flutter_gemma_onnx`:
+
 ```dart
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
+
 await FlutterGemma.initialize(
   inferenceEngines: const [
     BuiltInAiEngine(),   // flutter_gemma_builtin_ai

--- a/website/content/docs/builtin-ai.md
+++ b/website/content/docs/builtin-ai.md
@@ -1,0 +1,166 @@
+---
+title: Built-in AI
+description: Run the device's own OS/browser AI as an engine — Gemini Nano (Android + Web) and Apple Foundation Models (iOS/macOS) — with no model to download, plus the availability-probe → open-model fallback pattern.
+image: https://fluttergemma.dev/images/og-image.png
+---
+
+flutter_gemma's engines are **pluggable**: you register them in
+`FlutterGemma.initialize(...)`, and the registry picks one per model by its
+declared `ModelFileType`. One of those engines is `flutter_gemma_builtin_ai` —
+it runs the model the **operating system (or browser) already ships**, so there
+is **nothing to download**: installation only records which built-in model you
+want, and the platform owns the weights.
+
+## Runtimes & devices
+
+| Platform | Built-in model | Runtime | Minimum devices |
+|----------|----------------|---------|-----------------|
+| Android | **Gemini Nano** | ML Kit GenAI / AICore | Pixel 9+, Galaxy S25+ (`minSdk 26`) |
+| iOS / macOS | **Apple Foundation Models** (Apple Intelligence) | FoundationModels framework | iPhone 15 Pro+, Apple Silicon Macs — Apple Intelligence enabled |
+| Web | **Gemini Nano** | Chrome **Prompt API** (`self.LanguageModel`) | Desktop Chrome / Chromium-Edge only |
+
+> **Note:** the Chrome Prompt API *is* Gemini Nano — the browser runs the same
+> on-device model, exposed through a JS API. **Windows and Linux have no OS
+> built-in model** (no ML Kit, no Apple Foundation Models, no browser Prompt API
+> in a Flutter desktop app) — there `availability()` reports
+> `unavailableDeviceUnsupported`, and you fall back to a downloaded model
+> (see [the fallback pattern](#the-fallback-pattern)).
+
+Availability is a runtime property of the device/OS/browser — never assume it at
+build time; always probe with `BuiltInAi.availability()` /
+`BuiltInAi.ensureReady()` before creating the model.
+
+## Setup
+
+Add the package and register `BuiltInAiEngine()` at startup, alongside any other
+engines your app uses:
+
+```yaml
+dependencies:
+  flutter_gemma: latest_version
+  flutter_gemma_builtin_ai: latest_version   # OS/browser built-in AI
+```
+
+```dart
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_builtin_ai/flutter_gemma_builtin_ai.dart';
+
+await FlutterGemma.initialize(
+  inferenceEngines: const [BuiltInAiEngine()],
+);
+```
+
+> **Android:** `flutter_gemma_builtin_ai` declares `minSdk 26` (the ML Kit GenAI
+> / AICore floor). Raise your app's `android/app/build.gradle(.kts)` `minSdk` to
+> 26 or the manifest merger fails.
+
+## Install a built-in model
+
+Built-in models have no file to fetch, so installation just records the
+identity — pass `fileType: ModelFileType.builtIn` and use one of the ready-made
+specs from `BuiltInAiModels`:
+
+```dart
+await FlutterGemma.installModel(
+  modelType: ModelType.general,
+  fileType: ModelFileType.builtIn,
+).fromBundled(BuiltInAiModels.geminiNano.name).install();
+```
+
+`BuiltInAiModels.geminiNano` (Android + Web) and
+`BuiltInAiModels.appleFoundationModels` (iOS/macOS) are plain
+`InferenceModelSpec`s you can also reference directly when building your own
+model list.
+
+## Probe availability (and download, if needed)
+
+`BuiltInAi.availability()` reports whether the OS model is ready.
+`BuiltInAi.ensureReady()` makes sure the feature is on — and drives the on-device
+download the first time it is used (Android), reporting progress:
+
+```dart
+final status = await BuiltInAi.availability();
+// available · downloadable · downloading · unavailable* (device/OS/disabled/other)
+
+await BuiltInAi.ensureReady(
+  onProgress: (percent) => debugPrint('Preparing built-in AI: $percent%'),
+);
+// Throws BuiltInAiUnavailableException for any unavailable* status.
+```
+
+## The fallback pattern
+
+The point of a pluggable engine: **use the built-in model when the device
+supports it (zero download, private, fast); otherwise fall back to a downloaded
+open model** — through the same API, without rewriting the app.
+
+```dart
+await FlutterGemma.initialize(
+  inferenceEngines: const [
+    BuiltInAiEngine(),   // flutter_gemma_builtin_ai
+    LiteRtLmEngine(),    // flutter_gemma_litertlm — the fallback
+  ],
+);
+
+// Does this device have a usable built-in model?
+final builtInReady =
+    await BuiltInAi.availability() == BuiltInAiAvailability.available;
+
+if (builtInReady) {
+  // Built-in: nothing to download.
+  await FlutterGemma.installModel(
+    modelType: ModelType.general,
+    fileType: ModelFileType.builtIn,
+  ).fromBundled(BuiltInAiModels.geminiNano.name).install();
+} else {
+  // Fallback: install an open model (Gemma / Qwen / Phi …).
+  await FlutterGemma.installModel(
+    modelType: ModelType.gemmaIt,
+    fileType: ModelFileType.litertlm,
+  ).fromNetwork('https://…/gemma3-1b-it.litertlm').install();
+}
+
+// From here the code is identical regardless of which engine backs the model:
+final model = await FlutterGemma.getActiveModel(maxTokens: 4096);
+final session = await model.createSession();
+await session.addQueryChunk(const Message(text: 'Hello!', isUser: true));
+final response = await session.getResponse();
+```
+
+## Capabilities & limits
+
+| Feature | Android (Gemini Nano) | iOS / macOS (Apple FM) | Web (Chrome Prompt API) |
+|---------|------------------------|-------------------------|--------------------------|
+| Streaming | ✅ | ✅ | ✅ |
+| Function calling | ✅ prompt-based | ✅ prompt-based | ✅ prompt-based |
+| Vision (image input) | ✅ | ✅ on OS 27+ (text-only on OS 26) | ❌ (v1, tracked) |
+| Audio · Thinking · LoRA | ❌ | ❌ | ❌ |
+| `sizeInTokens` | ✅ native count | ✅ native count | ✅ `measureContextUsage` |
+
+- **Function calling is prompt-based** — tool definitions are woven into the
+  prompt by core `InferenceChat`; the OS models don't expose a usable native
+  tool-calling API. On Web, Chrome's native Prompt-API tool use is experimental
+  and not production-usable (Chrome 151), so it too goes through the prompt-based
+  path. Gemini Nano handles single-turn calls; multi-turn agent chaining is not
+  supported on Web (see [Agent Skills](/docs/agent)).
+- **Web is text-only in this release** (image/audio dropped with a one-time log).
+
+## Web setup
+
+There is **no CDN `<script>` tag** — the Chrome Prompt API is a browser global
+(`self.LanguageModel`). What it needs is the feature *enabled*:
+
+- **Production:** register your origin for the [Prompt API origin
+  trial](https://developer.chrome.com/origintrials) and add the token to
+  `web/index.html`:
+  ```html
+  <meta http-equiv="origin-trial" content="YOUR_TOKEN_HERE">
+  ```
+- **Local dev:** enable `chrome://flags/#prompt-api-for-gemini-nano` and restart
+  Chrome. Floor: desktop Chrome/Edge, ~22 GB free disk + a GPU with >4 GB VRAM
+  (or a 16 GB-RAM CPU-only path).
+
+`BuiltInAi.availability()` reports `unavailableDeviceUnsupported` on any
+browser/version without the Prompt API — always probe before creating a model.
+
+See the [`flutter_gemma_builtin_ai` package](/docs/packages) for the full API.

--- a/website/content/docs/builtin-ai.md
+++ b/website/content/docs/builtin-ai.md
@@ -159,7 +159,7 @@ There is **no CDN `<script>` tag** — the Chrome Prompt API is a browser global
 - **Production:** register your origin for the [Prompt API origin
   trial](https://developer.chrome.com/origintrials) and add the token to
   `web/index.html`:
-  ```html
+  ```
   <meta http-equiv="origin-trial" content="YOUR_TOKEN_HERE">
   ```
 - **Local dev:** enable `chrome://flags/#prompt-api-for-gemini-nano` and restart

--- a/website/content/docs/builtin-ai.md
+++ b/website/content/docs/builtin-ai.md
@@ -16,7 +16,7 @@ want, and the platform owns the weights.
 | Platform | Built-in model | Runtime | Minimum devices |
 |----------|----------------|---------|-----------------|
 | Android | **Gemini Nano** | ML Kit GenAI / AICore | Pixel 9+, Galaxy S25+ (`minSdk 26`) |
-| iOS / macOS | **Apple Foundation Models** (Apple Intelligence) | FoundationModels framework | iPhone 15 Pro+, Apple Silicon Macs — Apple Intelligence enabled |
+| iOS / macOS | **Apple Foundation Models** (Apple Intelligence) | FoundationModels framework | iOS 26+ / macOS 26+ on iPhone 15 Pro+, Apple Silicon Macs — Apple Intelligence enabled |
 | Web | **Gemini Nano** | Chrome **Prompt API** (`self.LanguageModel`) | Desktop Chrome / Chromium-Edge only |
 
 > **Note:** the Chrome Prompt API *is* Gemini Nano — the browser runs the same

--- a/website/content/docs/builtin-ai.md
+++ b/website/content/docs/builtin-ai.md
@@ -35,7 +35,7 @@ build time; always probe with `BuiltInAi.availability()` /
 Add the package and register `BuiltInAiEngine()` at startup, alongside any other
 engines your app uses:
 
-```yaml
+```
 dependencies:
   flutter_gemma: latest_version
   flutter_gemma_builtin_ai: latest_version   # OS/browser built-in AI

--- a/website/content/docs/desktop.md
+++ b/website/content/docs/desktop.md
@@ -9,7 +9,13 @@ Linux**. Desktop platforms run LiteRT-LM **directly via `dart:ffi`** — no
 Kotlin/JVM gRPC server, no Java required, no separate process, no IPC overhead.
 Engine startup is ~2 s instead of ~10–15 s.
 
-Desktop is served exclusively by the **`flutter_gemma_litertlm`** package; see
+LiteRT-LM (`.litertlm`) is the **primary, default** desktop engine — but not the
+only one. **`flutter_gemma_onnx`** ([ONNX Runtime](/docs/onnx) — ORT-GenAI
+generation + ORT embeddings) also runs on all three desktop OSes
+(macOS/Windows/Linux), and on **macOS** the OS built-in model is available through
+**`flutter_gemma_builtin_ai`** ([Apple Foundation Models](/docs/builtin-ai),
+macOS only — not Windows/Linux). What holds across all of desktop is the narrower
+statement: **there is no MediaPipe engine on desktop.** See
 [Installation](/docs/installation) and [Packages](/docs/packages).
 
 ## Architecture
@@ -43,10 +49,11 @@ and iOS use the same `LiteRtLmFfiClient` against the same C API. Only the dynami
 library loading sequence differs per platform.
 
 <Warning>
-**Model format:** desktop accepts only LiteRT-LM `.litertlm` files. MediaPipe
-`.bin` / `.task` models used on web won't load on desktop. See the
-[AI Edge Model Garden](https://ai.google.dev/edge/litert/models) for compatible
-models.
+**Model format (LiteRT-LM engine):** the LiteRT-LM engine on desktop accepts only
+`.litertlm` files. MediaPipe `.bin` / `.task` models used on web won't load on
+desktop. See the [AI Edge Model Garden](https://ai.google.dev/edge/litert/models)
+for compatible models. (The [ONNX engine](/docs/onnx) uses its own `.onnx` model
+directories instead.)
 </Warning>
 
 ## Supported platforms
@@ -66,6 +73,14 @@ crash on `PreferredBackend.gpu`. Upgrade to 1.4.0; on the affected versions use
 `PreferredBackend.cpu` or `.npu`. macOS/Linux GPU and Windows CPU/NPU were
 never affected.
 </Warning>
+
+<Info>
+**Windows NPU.** `PreferredBackend.npu` on Windows requires **Intel
+LunarLake/PantherLake** silicon — the Windows native archive ships
+`LiteRtDispatch.dll` + the OpenVino runtime + TBB to drive it. On any other
+Windows hardware the NPU backend is unavailable; use `PreferredBackend.gpu` or
+`.cpu`.
+</Info>
 
 ## Requirements
 

--- a/website/content/docs/embeddings-and-rag.md
+++ b/website/content/docs/embeddings-and-rag.md
@@ -4,7 +4,8 @@ description: Generate text embeddings and run on-device retrieval-augmented gene
 image: https://fluttergemma.dev/images/og-image.png
 ---
 
-flutter_gemma can generate vector embeddings from text (EmbeddingGemma / Gecko)
+flutter_gemma can generate vector embeddings from text (EmbeddingGemma / Gecko on
+LiteRT, or BERT / MiniLM / WordPiece models via the ONNX backend)
 and run on-device RAG with a vector store. Two stores are available, both with
 the same Dart API: **qdrant-edge** — the fastest store on native (HNSW
 approximate nearest-neighbour) — and **sqlite-vec** — a portable, exact store
@@ -33,10 +34,12 @@ See [Installation](/docs/installation) for the full registration reference.
 
 ## Text embeddings
 
-All embedding models generate **768-dimensional vectors**. The number in a model
-name (64/256/512/1024/2048) is the max input sequence length in tokens, not the
-embedding dimension. See [Models](/docs/models#text-embedding-models) for the full
-list.
+The embedding **dimension depends on the model and backend**. The LiteRT models
+(EmbeddingGemma / Gecko) generate **768-dimensional vectors**; with
+`OnnxEmbeddingBackend` the dimension is model-dependent (e.g. all-MiniLM-L6-v2 is
+384-dim). The number in a model name (64/256/512/1024/2048) is the max input
+sequence length in tokens, not the embedding dimension. See
+[Models](/docs/models#text-embedding-models) for the full list.
 
 ### Install an embedding model
 
@@ -64,10 +67,11 @@ final embeddings = await embedder.generateEmbeddings(
 ```
 
 <Info>
-Embedding currently runs on **CPU only**. EmbeddingGemma is an int4 `.tflite`
-model, and the TFLite GPU delegate cannot run int4 — so GPU embedding is not
-possible for this model format. Embedding runs on a background isolate so it
-doesn't block the UI thread.
+The LiteRT `LiteRtEmbeddingBackend` runs embedding on **CPU only**: EmbeddingGemma
+is an int4 `.tflite` model, and the TFLite GPU delegate cannot run int4 — so GPU
+embedding is not possible for that model format. The `OnnxEmbeddingBackend` is not
+bound by this — it runs embeddings on **WebGPU** on Web (onnxruntime-web). Either
+way, embedding runs on a background isolate so it doesn't block the UI thread.
 </Info>
 
 ## On-device RAG / vector store
@@ -209,6 +213,13 @@ qdrant promotes at write time.
 
 Both stores expose the identical Dart API, so you can swap one for the other by
 changing only the `vectorStore:` you register.
+
+| | qdrant-edge | sqlite-vec (`vec0`) |
+|---|---|---|
+| **Platforms** | Native only (Android, iOS, macOS, Linux, Windows) | All six — native **+ Web** |
+| **KNN** | Exact below ~20k points, HNSW above | Exact (brute-force inside SQLite) |
+| **Speed** | Fastest native (~5–11× faster search at 1k–10k docs) | Portable, identical results everywhere |
+| **When to use** | Native throughput at scale | Web reach, or exact results across every platform |
 
 **Which store?** `qdrant-edge` is the fastest **native** option — benchmarked
 ~5–11× faster search than the `sqlite-vec` store at 1k–10k documents — using HNSW

--- a/website/content/docs/embeddings-and-rag.md
+++ b/website/content/docs/embeddings-and-rag.md
@@ -217,7 +217,7 @@ changing only the `vectorStore:` you register.
 | | qdrant-edge | sqlite-vec (`vec0`) |
 |---|---|---|
 | **Platforms** | Native only (Android, iOS, macOS, Linux, Windows) | All six — native **+ Web** |
-| **KNN** | Exact below ~20k points, HNSW above | Exact (brute-force inside SQLite) |
+| **KNN** | HNSW approximate | Exact (brute-force inside SQLite) |
 | **Speed** | Fastest native (~5–11× faster search at 1k–10k docs) | Portable, identical results everywhere |
 | **When to use** | Native throughput at scale | Web reach, or exact results across every platform |
 

--- a/website/content/docs/function-calling.md
+++ b/website/content/docs/function-calling.md
@@ -37,6 +37,55 @@ ignores the tools — the model still works normally for text generation. Check 
 `supportsFunctionCalls` property in your model configuration.
 </Info>
 
+### Built-in AI (OS models)
+
+[Built-in AI](/docs/builtin-ai) models — Gemini Nano (Android), Apple Foundation
+Models (iOS/macOS), and the Chrome Prompt API (Web) — also support function
+calling, but it is **prompt-based**: these OS models don't expose a usable
+structured tool API, so core `InferenceChat` weaves the tool definitions into
+the prompt and parses the calls back out of the model's text. You declare tools
+the same way (see below). Gemini Nano handles single-turn tool calls; multi-turn
+agent chaining is **not** supported on Web.
+
+## Declaring tools
+
+Describe each function as a `Tool` — a `name`, a `description`, and a
+JSON-Schema `parameters` map — then pass the list to `createChat` (or
+`createSession`) together with `supportsFunctionCalls: true`:
+
+```dart
+final tools = [
+  const Tool(
+    name: 'change_background_color',
+    description: 'Change the app background color.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'color': {'type': 'string', 'description': 'A CSS color name.'},
+      },
+      'required': ['color'],
+    },
+  ),
+];
+
+final chat = await model.createChat(
+  tools: tools,
+  supportsFunctionCalls: true,
+  toolChoice: ToolChoice.auto,
+);
+```
+
+`ToolChoice` controls whether the model may call a tool:
+
+- `ToolChoice.auto` (default) — the model decides.
+- `ToolChoice.required` — the model must respond with a function call.
+- `ToolChoice.none` — the model must not call any tool, even when tools are passed.
+
+<Info>
+`ToolChoice.required` is not supported by FunctionGemma — its prompt format has
+no way to express the constraint, so it degrades to `auto` and logs a warning.
+</Info>
+
 ## Handling function calls
 
 When the model wants to call a function, the response stream emits a
@@ -56,6 +105,21 @@ chat.generateChatResponseAsync().listen((response) {
   }
 });
 ```
+
+<Info>
+A model can also request **several** calls at once — the stream then emits a
+`ParallelFunctionCallResponse` carrying a `calls` list of `FunctionCallResponse`s.
+`generateChatResponseWithTools` (below) handles this internally; a manual
+listener must handle it too:
+
+```dart
+} else if (response is ParallelFunctionCallResponse) {
+  for (final call in response.calls) {
+    _handleFunctionCall(call);
+  }
+}
+```
+</Info>
 
 Send the function result back to the model so it can continue:
 
@@ -103,6 +167,11 @@ runs function calls inside a spoken turn through it (see
 Function calling is supported on **Android, iOS, Web, and Desktop**. For Gemma 4,
 the native function-call tokens are routed through the LiteRT-LM SDK chat-template
 path (use `ModelType.gemma4`).
+
+With the [Built-in AI](/docs/builtin-ai) engine (`flutter_gemma_builtin_ai`)
+function calling is prompt-based rather than a native tool API — Gemini Nano
+(Android) and Apple Foundation Models (iOS/macOS) handle single-turn tool calls;
+on Web (Chrome Prompt API) multi-turn agent chaining is not supported.
 
 <Warning>
 Function calling / tool calls are **not** supported on the web `.litertlm` path

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.5.0
-  flutter_gemma: ^1.6.4
+  flutter_gemma: ^1.6.5
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.5.2   # .litertlm models (mobile + desktop) + LiteRtEmbeddingBackend
   flutter_gemma_mediapipe: ^1.0.5  # .task / .bin models (mobile + web)
@@ -115,6 +115,7 @@ final response = await ai.generate(
     temperature: 0.5,
     topK: 40,
     supportImage: true,
+    toolChoice: 'auto',             // tool calling mode: 'auto' / 'required' / 'none'
     // Optional per-component backend ('cpu'/'gpu'/'npu'):
     preferredBackend: 'gpu',        // text decoder
     preferredAudioBackend: 'gpu',   // audio encoder (~2x on Metal; defaults to CPU)
@@ -122,6 +123,9 @@ final response = await ai.generate(
   ),
 );
 ```
+
+`toolChoice` maps to Genkit 0.15's native top-level `toolChoice`: `'auto'`
+lets the model decide, `'required'` forces a tool call, `'none'` forbids one.
 
 <Info>
 The plugin does **not** manage model installation. Call

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -19,6 +19,8 @@ SmolLM and more — see [Models](/docs/models) for the full list.
 - **Local Execution:** Run Gemma and other LLMs (Qwen, DeepSeek, Phi, FastVLM, SmolLM, …) directly on user devices for enhanced privacy and offline functionality.
 - **Platform Support:** Compatible with iOS, Android, Web, macOS, Windows, and Linux.
 - **Desktop Support:** Native desktop apps with GPU acceleration via LiteRT-LM, called directly from Dart through `dart:ffi` — no JVM/JRE bundling. See [Desktop Support](/docs/desktop).
+- **Built-in / System AI:** Use the OS's own on-device model, no download — Gemini Nano (Android + Chrome) + Apple Foundation Models (iOS/macOS). See [Built-in AI](/docs/builtin-ai).
+- **Pluggable Engines:** Opt-in engine packages — LiteRT-LM, MediaPipe, ONNX Runtime, built-in OS AI — registered via `FlutterGemma.initialize(...)`. See [Packages](/docs/packages).
 - **Multimodal Support:** Text + image input with Gemma 4, Gemma3n, FastVLM, Qwen2-VL, SmolVLM2, and LLaVA-OneVision vision models. See [Multimodal](/docs/multimodal).
 - **Audio Input:** Record and send audio messages with Gemma 4 and Gemma3n models (Android, iOS device, Desktop).
 - **Function Calling:** Let models call external functions and integrate with other services. See [Function Calling](/docs/function-calling).
@@ -36,12 +38,29 @@ SmolLM and more — see [Models](/docs/models) for the full list.
 ## What's new in 1.6
 
 - **`flutter_gemma_onnx`** — new opt-in ONNX Runtime engine: text generation via ORT-GenAI (`OnnxEngine`) + embeddings via plain ONNX Runtime (`OnnxEmbeddingBackend`), both `dart:ffi`. Device-verified on macOS, Linux, Windows, Android, and iOS (arm64) — plus **Web**, via Transformers.js (generation) and onnxruntime-web (embeddings). See [Packages](/docs/packages#onnx-runtime-engine).
+- **`flutter_gemma_builtin_ai`** — new opt-in OS built-in AI engine: Gemini Nano (Android; Web via Chrome Prompt API) + Apple Foundation Models (iOS/macOS), via `ModelFileType.builtIn` — no download. See [Built-in AI](/docs/builtin-ai).
 - **BREAKING (`flutter_gemma_embeddings` 2.0.0):** the embedder is now runtime-agnostic — `LiteRtEmbeddingBackend` moved to `flutter_gemma_litertlm` (1.5.0). See [Migration](/docs/migration).
 
 ## What's new in 1.5
 
 - **genai_primitives support** — drive an on-device chat with the Flutter team's standard `ChatMessage` types via `package:flutter_gemma/genai.dart` (`sendMessage`/`generateContent` + streams, covering text, vision, audio, thinking, and tool calls). See [genai_primitives](/docs/genai).
 - **`FlutterGemma` is the one canonical entry point.** RAG moved onto the `FlutterGemma.rag.*` namespace (`initialize`/`addDocument`/`addDocumentWithEmbedding`/`searchSimilar`/`removeDocument`/`stats`/`clear`), and the facade gained model introspection (`activeModelSpec`/`activeEmbedderSpec`/`activeSttSpec`/`activeTtsSpec`, `getModelPath`), storage helpers (`getStorageInfo`/`getOrphanedFiles`/`cleanupStorage`/`performCleanup`), and per-modality uninstallers (`uninstallEmbedder`/`uninstallStt`/`uninstallTts`). `FlutterGemmaPlugin.instance` is now a documented low-level SPI tier — app code shouldn't need it.
+
+## What's new in 1.4
+
+- **`flutter_gemma_speech`** — new opt-in on-device speech package: STT (moonshine) + TTS (Matcha) + a full STT → LLM → TTS voice loop (`VoiceSession`). See [Speech](/docs/speech).
+
+## What's new in 1.3
+
+- **`ModelFileType.builtIn`** for OS system models (Gemini Nano / Apple Foundation Models), plus download-reliability fixes. See [Built-in AI](/docs/builtin-ai).
+
+## What's new in 1.2
+
+- **`flutter_gemma_agent`** — new opt-in agent-skills package (the `skillExecutors:` registration seam), plus the Android Mali GPU fix. See [Agent Skills](/docs/agent).
+
+## What's new in 1.1
+
+- **Declared-column RAG filters** — `FilterSchema`/`FilterField` + `configure`, and `filterSchema:` on `initialize`; `enableHnsw` is deprecated. See [Embeddings & RAG](/docs/embeddings-and-rag).
 
 ## What's new in 1.0
 

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -28,6 +28,9 @@ dependencies:
 
   # Optional — on-device speech (STT + TTS):
   flutter_gemma_speech: latest_version       # transcribe audio + synthesize speech (on-device STT + TTS; native only) + voice loop
+
+  # Optional — on-device agent skills:
+  flutter_gemma_agent: latest_version        # agent skills the model runs itself (text / JS / native-intent / MCP)
 ```
 
 **Pick by need:**
@@ -43,6 +46,7 @@ dependencies:
 | On-device RAG on native, fastest (Android/iOS/desktop) | `flutter_gemma_rag_qdrant` |
 | On-device RAG on web, or a portable/exact store on any platform | `flutter_gemma_rag_sqlite` |
 | Transcribe audio, synthesize speech, or run a voice loop on-device (STT + TTS + voice) | `flutter_gemma_speech` |
+| Run on-device agent skills the model executes itself (text / JS / native-intent / MCP) | `flutter_gemma_agent` |
 
 Core registers **no** engine by itself — you wire the packages you added in
 `await FlutterGemma.initialize(...)` (below). Run `flutter pub get` to install.
@@ -367,11 +371,15 @@ repo for web-compatible builds.
 
 ### Desktop (macOS, Windows, Linux)
 
-Desktop is served exclusively by **`flutter_gemma_litertlm`** and uses
-**LiteRT-LM format only** (`.litertlm` files). There is no MediaPipe engine on
-desktop — `.task` / `.bin` models are **NOT compatible** with desktop. The native
-library is fetched at build time by the package's Native-Assets hook — no manual
-download/bundling.
+Desktop is served **primarily** by **`flutter_gemma_litertlm`** (`.litertlm`
+files) — the default engine, whose native library is fetched at build time by the
+package's Native-Assets hook (no manual download/bundling). **`flutter_gemma_onnx`**
+([ONNX Runtime](/docs/onnx)) also runs on all three desktop OSes
+(macOS/Windows/Linux), and on **macOS** the OS built-in model is available via
+**`flutter_gemma_builtin_ai`** ([Apple Foundation Models](/docs/builtin-ai),
+macOS only — not Windows/Linux). What holds across all of desktop: there is no
+MediaPipe engine on desktop — `.task` / `.bin` models are **NOT compatible** with
+desktop.
 
 See [Desktop Support](/docs/desktop) for the full per-platform reference (macOS
 `Podfile` `post_install`, entitlements, Windows VC++ runtime, Linux Vulkan

--- a/website/content/docs/litertlm.md
+++ b/website/content/docs/litertlm.md
@@ -1,0 +1,136 @@
+---
+title: LiteRT-LM
+description: The default flutter_gemma engine — .litertlm on-device inference over dart:ffi (LiteRT-LM C API) on all five native platforms plus a text-only web preview, with CPU / GPU / NPU acceleration and a LiteRT embedding backend.
+image: https://fluttergemma.dev/images/og-image.png
+---
+
+`flutter_gemma_litertlm` is flutter_gemma's **default inference engine**. It runs
+`.litertlm` models through `dart:ffi` straight onto the **LiteRT-LM C API** — no
+JVM, no gRPC — and it is the **only engine for desktop** (macOS, Windows, Linux).
+The native library is fetched at build time via **Native Assets** (SHA256-verified,
+from the `native-v0.16.0` GitHub release), so there's no manual native setup.
+
+The same package also ships **`LiteRtEmbeddingBackend`**, the LiteRT C API
+embedding backend — see [Embeddings & RAG](/docs/embeddings-and-rag).
+
+## Platforms
+
+| Platform | Support |
+|----------|---------|
+| Android | ✅ FFI (GPU via OpenCL, NPU on Qualcomm Snapdragon) |
+| iOS | ✅ FFI (GPU via Metal on device; CPU on simulator) |
+| macOS / Linux | ✅ FFI (GPU via Metal / Vulkan) |
+| Windows | ✅ FFI (CPU + GPU via DirectX 12 + Intel NPU) |
+| Web | ⚠️ early preview via `@litert-lm/core` (text-only) |
+
+> **Web is a text-only preview.** It runs through `@litert-lm/core` (WebGPU/WASM)
+> and does **not** support vision, audio, thinking mode, function calling, or
+> LoRA. Native platforms have the full feature set. On web you also need the JS
+> handshake in `web/index.html` (see [Web setup](#web-setup)).
+
+## Setup
+
+Add the package and register `LiteRtLmEngine()` at startup, alongside any other
+engines your app uses:
+
+```yaml
+dependencies:
+  flutter_gemma: latest_version
+  flutter_gemma_litertlm: latest_version   # .litertlm inference engine
+```
+
+```dart
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
+
+await FlutterGemma.initialize(
+  inferenceEngines: const [LiteRtLmEngine()],
+);
+```
+
+`LiteRtLmEngine` claims models whose declared `ModelFileType` is `litertlm`; pass
+it alongside `MediaPipeEngine` (from `flutter_gemma_mediapipe`) if your app also
+uses `.task` models.
+
+## Install a `.litertlm` model
+
+> **Declare the file type.** `installModel` defaults `fileType` to
+> `ModelFileType.task`, so a `.litertlm` model **must** set
+> `fileType: ModelFileType.litertlm` explicitly — otherwise it is routed to
+> MediaPipe instead of this engine.
+
+```dart
+await FlutterGemma.installModel(
+  modelType: ModelType.gemma4,
+  fileType: ModelFileType.litertlm,
+).fromNetwork(
+  'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm',
+  token: 'hf_...',
+).install();
+
+// Create the model once and keep it for the app's lifetime.
+final model = await FlutterGemma.getActiveModel(
+  maxTokens: 4096,
+  preferredBackend: PreferredBackend.gpu,
+);
+
+final session = await model.createSession();
+await session.addQueryChunk(const Message(text: 'Hello!', isUser: true));
+await for (final chunk in session.getResponseAsync()) {
+  print(chunk);
+}
+await session.close();
+```
+
+## Backends & acceleration
+
+Pick the accelerator with `preferredBackend:` on `getActiveModel`:
+
+| Backend | Where |
+|---------|-------|
+| `cpu` | All native platforms |
+| `gpu` | Metal (Apple), DirectX 12 / WebGPU (Windows), Vulkan / WebGPU (Linux); required on web |
+| `npu` | Android (Qualcomm Snapdragon, `.litertlm`) and Windows (Intel LunarLake / PantherLake) |
+
+Windows NPU ships the Intel dispatch stack — `LiteRtDispatch.dll` + the OpenVino
+runtime + TBB — inside the Windows native archive. Android bundles the Qualcomm
+QNN dispatch stack. No extra downloads for either NPU path.
+
+## `maxTokens` is the CONTEXT window, not the reply length
+
+`maxTokens` (on `getActiveModel` / `createModel`) sizes the whole **context
+window** — system prompt + history + message **plus** the generated output (the
+KV-cache budget), not the response length. `.litertlm` models bake a fixed
+`kv_cache_max_len` of 1024, so this engine **clamps `maxTokens` up to 1024** (with
+a log warning) to avoid a native KV-cache crash.
+
+To cap **generation length**, use `maxOutputTokens` on the session:
+
+```dart
+final model = await FlutterGemma.getActiveModel(maxTokens: 4096); // context
+final session = await model.createSession(maxOutputTokens: 100);  // reply cap
+```
+
+## Web setup
+
+`.litertlm` web inference runs via `@litert-lm/core`. The ESM doesn't assign
+window globals, so add this handshake to your `web/index.html` `<head>` — Dart
+awaits `window.litertLmReady` (which resolves to the `Engine` constructor):
+
+```html
+<script type="module">
+window.litertLmReady = (async () => {
+  const m = await import('https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm');
+  window.Engine = m.Engine;
+  return m.Engine;
+})();
+</script>
+```
+
+Native platforms need no web setup.
+
+## See also
+
+- [Desktop Support](/docs/desktop) — the FFI path on macOS / Windows / Linux.
+- [Embeddings & RAG](/docs/embeddings-and-rag) — the `LiteRtEmbeddingBackend` this package ships.
+- [Packages](/docs/packages) — the full opt-in package matrix and APIs.

--- a/website/content/docs/litertlm.md
+++ b/website/content/docs/litertlm.md
@@ -36,7 +36,7 @@ embedding backend — see [Embeddings & RAG](/docs/embeddings-and-rag).
 Add the package and register `LiteRtLmEngine()` at startup, alongside any other
 engines your app uses:
 
-```yaml
+```
 dependencies:
   flutter_gemma: latest_version
   flutter_gemma_litertlm: latest_version   # .litertlm inference engine
@@ -120,7 +120,7 @@ final session = await model.createSession(maxOutputTokens: 100);  // reply cap
 window globals, so add this handshake to your `web/index.html` `<head>` — Dart
 awaits `window.litertLmReady` (which resolves to the `Engine` constructor):
 
-```html
+```
 <script type="module">
 window.litertLmReady = (async () => {
   const m = await import('https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm');

--- a/website/content/docs/litertlm.md
+++ b/website/content/docs/litertlm.md
@@ -1,14 +1,17 @@
 ---
 title: LiteRT-LM
-description: The default flutter_gemma engine — .litertlm on-device inference over dart:ffi (LiteRT-LM C API) on all five native platforms plus a text-only web preview, with CPU / GPU / NPU acceleration and a LiteRT embedding backend.
+description: The primary .litertlm engine — on-device inference over dart:ffi (LiteRT-LM C API) on all five native platforms plus a text-only web preview, with CPU / GPU / NPU acceleration and a LiteRT embedding backend.
 image: https://fluttergemma.dev/images/og-image.png
 ---
 
-`flutter_gemma_litertlm` is flutter_gemma's **default inference engine**. It runs
+`flutter_gemma_litertlm` is the **primary `.litertlm` engine**. (Core registers
+no engine by default — you opt in by registering `LiteRtLmEngine()`.) It runs
 `.litertlm` models through `dart:ffi` straight onto the **LiteRT-LM C API** — no
-JVM, no gRPC — and it is the **only engine for desktop** (macOS, Windows, Linux).
-The native library is fetched at build time via **Native Assets** (SHA256-verified,
-from the `native-v0.16.0` GitHub release), so there's no manual native setup.
+JVM, no gRPC — and it is the **primary desktop engine** (macOS, Windows, Linux);
+[ONNX Runtime](/docs/onnx) also runs on desktop, and macOS can additionally use
+[Built-in AI](/docs/builtin-ai). The native library is fetched at build time via
+**Native Assets** (SHA256-verified, from the `native-v0.16.0` GitHub release), so
+there's no manual native setup.
 
 The same package also ships **`LiteRtEmbeddingBackend`**, the LiteRT C API
 embedding backend — see [Embeddings & RAG](/docs/embeddings-and-rag).

--- a/website/content/docs/mediapipe.md
+++ b/website/content/docs/mediapipe.md
@@ -1,0 +1,116 @@
+---
+title: MediaPipe
+description: Run .task / .bin models on Android, iOS and Web through Google's MediaPipe (tasks-genai) engine — chat templates handled internally, GPU-only on Web.
+image: https://fluttergemma.dev/images/og-image.png
+---
+
+flutter_gemma's engines are **pluggable**: you register them in
+`FlutterGemma.initialize(...)`, and the registry picks one per model by its
+declared `ModelFileType`. `flutter_gemma_mediapipe` is the engine for Google's
+**MediaPipe** runtime (`tasks-genai`) — it runs `.task` bundles (and `.bin`).
+A `.task` archive packages the model's `.tflite` weights, tokenizer, and
+metadata together, and **MediaPipe applies each model's chat template
+internally**, so you feed plain messages and it handles the formatting.
+
+## Platforms
+
+| Platform | Support | Runtime |
+|----------|---------|---------|
+| Android | ✅ | `MediaPipeTasksGenAI` (Gradle) |
+| iOS | ✅ | `MediaPipeTasksGenAI` (CocoaPods) — **requires iOS 16.0+** |
+| Web | ✅ | `@mediapipe/tasks-genai` (CDN) |
+| Desktop (macOS/Windows/Linux) | ❌ | no MediaPipe engine — use [LiteRT-LM](/docs/litertlm) or ONNX |
+
+> **Mobile + Web only.** There is no MediaPipe engine on desktop; for
+> macOS/Windows/Linux run the `.litertlm` format via
+> [LiteRT-LM](/docs/litertlm) instead.
+
+## Setup
+
+Add the package and register `MediaPipeEngine()` at startup, alongside any other
+engines your app uses:
+
+```yaml
+dependencies:
+  flutter_gemma: latest_version
+  flutter_gemma_mediapipe: latest_version   # MediaPipe .task engine
+```
+
+```dart
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_mediapipe/flutter_gemma_mediapipe.dart';
+
+await FlutterGemma.initialize(
+  inferenceEngines: [MediaPipeEngine()],
+);
+```
+
+`MediaPipeEngine` handles `ModelFileType.task` / `.bin` models. Pass it
+alongside other engines (e.g. `LiteRtLmEngine` from `flutter_gemma_litertlm`) if
+your app uses both formats — the registry routes each model to the right one.
+
+> **iOS:** this package requires **iOS 16.0+** (MediaPipe GenAI's floor — it is
+> the only flutter_gemma package that needs it). Set `platform :ios, '16.0'` in
+> the `Podfile` **and** the Runner's iOS Deployment Target in Xcode, and use
+> `use_frameworks! :linkage => :static` (MediaPipe ships static xcframeworks).
+> Android needs no extra setup — the MediaPipe Gradle deps are bundled.
+
+## Install a `.task` model
+
+`installModel` defaults `fileType` to `ModelFileType.task`, so a `.task` model
+needs **no explicit file-type declaration**:
+
+```dart
+await FlutterGemma.installModel(
+  modelType: ModelType.gemmaIt,
+).fromNetwork('https://.../gemma3-1b-it.task').install();
+
+final model = await FlutterGemma.getActiveModel(maxTokens: 4096);
+final session = await model.createSession();
+await session.addQueryChunk(const Message(text: 'Hello!', isUser: true));
+final response = await session.getResponse();
+```
+
+Models can also come from an asset, a bundled file, or a local path — see
+[Models](/docs/models) for every source and the model catalog.
+
+## Web setup
+
+On Web the MediaPipe runtime is loaded from a CDN. Add this to your app's
+`web/index.html` inside a `<script type="module">` (before the Flutter
+bootstrap), exposing the symbols on `window`:
+
+```html
+<script type="module">
+import { FilesetResolver, LlmInference } from 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-genai@0.10.27';
+window.FilesetResolver = FilesetResolver;
+window.LlmInference = LlmInference;
+</script>
+```
+
+The pinned version is **`@mediapipe/tasks-genai@0.10.27`**. Web runs **GPU-only**
+— there is no CPU backend in the browser, so `PreferredBackend.gpu` is required.
+**Vision** works on Web with Gemma 4's `.task` web build; thinking mode
+(`extraContext`) is not available through MediaPipe on Web.
+
+## Backends
+
+| `PreferredBackend` | Android | iOS | Web |
+|--------------------|---------|-----|-----|
+| `cpu` | ✅ | ✅ | ❌ |
+| `gpu` | ✅ | ✅ | ✅ (required) |
+
+Pass the backend when you open the model:
+
+```dart
+final model = await FlutterGemma.getActiveModel(
+  maxTokens: 4096,
+  preferredBackend: PreferredBackend.gpu,
+);
+```
+
+## See also
+
+- [Models](/docs/models) — supported models, formats, and download sources
+- [LiteRT-LM](/docs/litertlm) — the `.litertlm` engine (mobile **and** desktop)
+- [Packages](/docs/packages) — the full opt-in package list and their APIs

--- a/website/content/docs/mediapipe.md
+++ b/website/content/docs/mediapipe.md
@@ -30,7 +30,7 @@ internally**, so you feed plain messages and it handles the formatting.
 Add the package and register `MediaPipeEngine()` at startup, alongside any other
 engines your app uses:
 
-```yaml
+```
 dependencies:
   flutter_gemma: latest_version
   flutter_gemma_mediapipe: latest_version   # MediaPipe .task engine
@@ -80,7 +80,7 @@ On Web the MediaPipe runtime is loaded from a CDN. Add this to your app's
 `web/index.html` inside a `<script type="module">` (before the Flutter
 bootstrap), exposing the symbols on `window`:
 
-```html
+```
 <script type="module">
 import { FilesetResolver, LlmInference } from 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-genai@0.10.27';
 window.FilesetResolver = FilesetResolver;

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -34,16 +34,18 @@ Both formats require **manual chat template formatting** in your code.
 
 ### Type 3: System OS models (no file)
 
-- **Gemini Nano** (Android, via AICore / ML Kit GenAI), **Apple Foundation
-  Models** (iOS 26+/macOS), and **Gemini Nano via the Chrome Prompt API** (Web —
-  desktop Chrome/Edge) are **built into the OS/browser** — there is no model file
-  to bundle or download; the platform owns the weights.
-- Add [`flutter_gemma_builtin_ai`](/docs/packages) and register `BuiltInAiEngine()`.
-  Use `ModelFileType.builtIn` (the engine's `BuiltInAiModels.geminiNano` /
-  `.appleFoundationModels` specs set it for you). Chat templates are handled by
-  the OS runtime. Availability is device-gated — probe with `BuiltInAi.availability()`
-  / `BuiltInAi.ensureReady()` before use (Gemini Nano needs Pixel 9+/Galaxy S25+;
-  Apple FM needs Apple Intelligence enabled on iPhone 15 Pro+/M-series).
+**Gemini Nano** (Android, via AICore / ML Kit GenAI), **Apple Foundation Models**
+(iOS 26+/macOS), and **Gemini Nano via the Chrome Prompt API** (Web — desktop
+Chrome/Edge) are **built into the OS/browser** — there is no model file to bundle
+or download; the platform owns the weights. Add
+[`flutter_gemma_builtin_ai`](/docs/packages), register `BuiltInAiEngine()`, and use
+`ModelFileType.builtIn`. Availability is device-gated — Gemini Nano needs Pixel
+9+/Galaxy S25+, and Apple FM needs Apple Intelligence enabled on iPhone
+15 Pro+/M-series. On Android the package requires **`minSdk 26`**.
+
+👉 See **[Built-in AI](/docs/builtin-ai)** for the full setup, the availability
+probe (`BuiltInAi.availability()` / `BuiltInAi.ensureReady()`), and fallback
+guidance.
 
 <Info>
 `ModelFileType` is what selects the engine — it is **not** inferred from the file
@@ -77,8 +79,8 @@ MediaPipe `.task` build.
 
 | Model Family | Best For | Function Calling | Thinking Mode | Vision | Languages | Size |
 |---|---|:---:|:---:|:---:|---|---|
-| **Gemma 4 E2B** | Next-gen multimodal chat — text, image, audio | ✅ | ✅ | ✅ | Multilingual | 2.4GB |
-| **Gemma 4 E4B** | Next-gen multimodal chat — text, image, audio | ✅ | ✅ | ✅ | Multilingual | 4.3GB |
+| **Gemma 4 E2B** | Next-gen multimodal chat — text, image, audio | ✅ | ✅ ¹ | ✅ | Multilingual | 2.4GB |
+| **Gemma 4 E4B** | Next-gen multimodal chat — text, image, audio | ✅ | ✅ ¹ | ✅ | Multilingual | 4.3GB |
 | **Gemma3n** | On-device multimodal chat and image analysis | ✅ | ❌ | ✅ | Multilingual | 3-6GB |
 | **FastVLM 0.5B** | Fast vision-language inference | ❌ | ❌ | ✅ | Multilingual | 0.5GB |
 | **Qwen2-VL 2B** | Vision-language chat (image + text) | ❌ | ❌ | ✅ | Multilingual | 1.8GB |
@@ -95,6 +97,9 @@ MediaPipe `.task` build.
 | **SmolLM 135M** | Ultra-compact, resource-constrained devices | ❌ | ❌ | ❌ | English | 135MB |
 | **SmolLM3 3B** | Multilingual small LLM with reasoning mode | ❌ | ✅ | ❌ | Multilingual | 2.0GB |
 | **TranslateGemma 4B** † | Single-shot 55-language translation | ❌ | ❌ | ❌ | 55 languages | 2-4GB |
+
+¹ Gemma 4 **Thinking Mode** works on Android, iOS, and Desktop only — **not on
+Web** (the MediaPipe web engine does not support the `extraContext` thinking path).
 
 <Warning>
 † **TranslateGemma is CPU-only for now.** Google hasn't released a
@@ -121,7 +126,7 @@ When installing models, specify the correct `ModelType`:
 | **Qwen 2.5** | `ModelType.qwen` | Qwen 2.5 1.5B, Qwen 2.5 0.5B |
 | **Qwen 3** | `ModelType.qwen3` | Qwen3 0.6B |
 | **FunctionGemma** | `ModelType.functionGemma` | FunctionGemma 270M IT |
-| **Phi** | `ModelType.phi` | Phi-4 Mini |
+| **Phi** | `ModelType.general` | Phi-4 Mini |
 | **General** | `ModelType.general` | FastVLM 0.5B, SmolLM 135M, SmolLM3 3B, Phi-4 Mini Reasoning, Qwen2-VL 2B, SmolVLM2 500M, LLaVA-OneVision 0.5B |
 
 <Info>
@@ -160,7 +165,7 @@ await FlutterGemma.installModel(modelType: ModelType.general)
 | [LLaVA-OneVision 0.5B](https://huggingface.co/litert-community/LLaVA-OneVision-0.5B) | 0.83GB | ✅ | ✅ | ❌ |
 | [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT) | 0.5GB | ✅ | ✅ | ✅ |
 | [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it) | 0.3GB | ✅ | ✅ | ✅ |
-| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ❌ |
+| [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it) | 284MB | ✅ | ✅ | ✅ |
 | [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B) | 586MB | ✅ | ✅ | ✅ |
 | [Qwen 2.5 1.5B](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct) | 1.6GB | ✅ | ✅ | ❌ |
 | [Qwen 2.5 0.5B](https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct) | 0.5GB | ❌ | ✅ | ❌ |

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -307,9 +307,11 @@ see [Speech](/docs/speech).
 
 ## Text embedding models
 
-All embedding models generate **768-dimensional vectors**. The numbers in names
-(64/256/512/1024/2048) indicate **maximum input sequence length in tokens**, not
-embedding dimension. See [Embeddings & RAG](/docs/embeddings-and-rag) for usage.
+The LiteRT embedding models below generate **768-dimensional vectors**. The
+numbers in names (64/256/512/1024/2048) indicate **maximum input sequence length
+in tokens**, not embedding dimension. (With the ONNX backend the dimension is
+model-dependent — e.g. all-MiniLM-L6-v2 is 384-dim.) See
+[Embeddings & RAG](/docs/embeddings-and-rag) for usage.
 
 | Model | Parameters | Dimensions | Max Seq Length | Size | Auth Required |
 |---|---|---|---|---|---|

--- a/website/content/docs/multimodal.md
+++ b/website/content/docs/multimodal.md
@@ -12,8 +12,10 @@ devices with 8GB+ RAM.
 
 Vision is supported by **Gemma 4 E2B/E4B**, **Gemma3n E2B/E4B**, **FastVLM 0.5B**
 (desktop), and the community models **Qwen2-VL 2B**, **SmolVLM2 500M**, and
-**LLaVA-OneVision 0.5B** (Android, iOS, Desktop). Gemma 4 / Gemma3n vision runs on
-all four platforms (Android, iOS, Web, Desktop). On the `.litertlm` engine the
+**LLaVA-OneVision 0.5B** (Android, iOS, Desktop). **Gemma 4** vision runs on all
+four platforms (Android, iOS, Web, Desktop); **Gemma3n** vision runs on Android,
+iOS, and Desktop only — its web build is `.litertlm`, which is text-only. On the
+`.litertlm` engine the
 text decoder runs on your chosen backend (Metal / Vulkan / DX12 on GPU), while
 the **vision encoder always runs on CPU by default** — the Metal/WebGPU delegates
 can't prepare its ops — so image input works on a GPU text backend with no extra

--- a/website/content/docs/onnx.md
+++ b/website/content/docs/onnx.md
@@ -1,0 +1,164 @@
+---
+title: ONNX Runtime
+description: Run ONNX models on-device — text generation via ORT-GenAI and embeddings via plain ONNX Runtime — across five native platforms (dart:ffi) and the web (Transformers.js / onnxruntime-web).
+image: https://fluttergemma.dev/images/og-image.png
+---
+
+flutter_gemma's engines are **pluggable**: you register them in
+`FlutterGemma.initialize(...)`, and the registry picks one per model by its
+declared `ModelFileType`. `flutter_gemma_onnx` adds two of them from the
+[ONNX Runtime](https://onnxruntime.ai) family:
+
+- **`OnnxEngine`** — text generation via **ORT-GenAI**.
+- **`OnnxEmbeddingBackend`** — embeddings via **plain ONNX Runtime** (no
+  generation).
+
+On **native** platforms both are pure `dart:ffi` — no JVM, no gRPC — and each
+drives the native library from a long-lived worker isolate, so no FFI pointer
+crosses an isolate boundary. On **Web** there is no FFI: generation runs through
+Transformers.js and embeddings through onnxruntime-web, behind the same public
+API. Either arm can be registered on its own — they don't depend on each other.
+
+## Platforms
+
+Native support is **arm64/x64-gated** — each host is device-verified end-to-end
+(generation + embeddings):
+
+| Platform | Runtime | `OnnxEngine` / `OnnxEmbeddingBackend` |
+|----------|---------|----------------------------------------|
+| macOS (Apple Silicon) | ORT-GenAI + ORT via `dart:ffi` | ✅ ~54 tok/s (M4 Pro) |
+| Linux x64 | ORT-GenAI + ORT via `dart:ffi` | ✅ ~5.3–5.8 tok/s |
+| Windows x64 | ORT-GenAI + ORT via `dart:ffi` | ✅ ~3.3 tok/s |
+| Android (arm64) | ORT-GenAI + ORT via `dart:ffi` | ✅ ~10.4 tok/s (Pixel 8 Pro) |
+| iOS (arm64) | ORT-GenAI + ORT via `dart:ffi` | ✅ device-verified |
+| Web | Transformers.js + onnxruntime-web (WebGPU/WASM) | ✅ both arms |
+
+> On an unsupported native host (macOS Intel, or any other native ABI)
+> `OnnxEngine` politely declines and logs why, letting another registered engine
+> take over. Android needs **`minSdk 24`** (both ORT and ORT-GenAI AARs declare
+> `minSdkVersion=24`). The native library co-location — ORT loaded next to
+> ORT-GenAI — is handled by the package's build hook; you don't configure
+> anything.
+
+## Setup
+
+Add the package and register whichever arm(s) you use at startup:
+
+```yaml
+dependencies:
+  flutter_gemma: latest_version
+  flutter_gemma_onnx: latest_version   # ONNX Runtime engines
+```
+
+```dart
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_onnx/flutter_gemma_onnx.dart';
+
+await FlutterGemma.initialize(
+  inferenceEngines: [OnnxEngine()],            // text generation
+  embeddingBackends: [OnnxEmbeddingBackend()], // embeddings
+);
+```
+
+## Install a model
+
+ONNX models install with `fileType: ModelFileType.onnx`. What that means differs
+by platform.
+
+**Native — a directory, not a file.** An ORT-GenAI model is a **directory**
+(`genai_config.json` + `model.onnx` [+ `model.onnx_data` for external weights] +
+tokenizer files). `OnnxEngine` takes the tracked file's **parent directory** as
+the model directory, so the whole bundle must already live on disk together
+(e.g. shipped as an asset or pre-populated yourself):
+
+```dart
+await FlutterGemma.installModel(
+  modelType: ModelType.general,
+  fileType: ModelFileType.onnx,
+).fromFile(File('/path/to/my-model/genai_config.json')).install();
+```
+
+**Web — fileless.** The model identity is a **Hugging Face repo id**;
+Transformers.js resolves, fetches, and caches it the first time you run
+inference. Install just marks the repo id active — core never downloads model
+bytes:
+
+```dart
+await FlutterGemma.installModel(
+  modelType: ModelType.general,
+  fileType: ModelFileType.onnx,
+).fromNetwork('onnx-community/Qwen2.5-0.5B-Instruct').install();
+```
+
+From here the code is identical to any other engine:
+
+```dart
+final model = await FlutterGemma.getActiveModel(maxTokens: 4096);
+final session = await model.createSession();
+await session.addQueryChunk(const Message(text: 'Hello!', isUser: true));
+final response = await session.getResponse();
+```
+
+## Generation — `OnnxEngine`
+
+Text-only, greedy decoding, one session at a time (v1): no vision, no audio, no
+LoRA, no sampling parameters yet. Prompts use the model's own chat template
+(ORT-GenAI's `OgaTokenizerApplyChatTemplate` natively; the model's
+`chat_template` on Web) — the engine never builds turn markers itself.
+`PreferredBackend.cpu` pins WASM on Web; anything else tries WebGPU first and
+falls back to WASM.
+
+## Embeddings — `OnnxEmbeddingBackend`
+
+A plain ONNX Runtime forward pass over an `.onnx`/`.ort` embedding model. One
+factory handles both tokenizer families, and the **output dimension is
+model-dependent** (not a fixed 768):
+
+- **WordPiece / BERT-style** models (e.g. all-MiniLM-L6-v2, 384-dim) —
+  mean-pooled + normalized client-side.
+- **SentencePiece** models (e.g. EmbeddingGemma-300M-ONNX) — the model's own
+  pooled `sentence_embedding` output.
+
+The output contract and mask requirements are discovered from the session's
+actual graph once it opens — no per-model configuration. It registers at
+priority 10 (above `LiteRtEmbeddingBackend`'s catch-all priority 0), so with
+both registered an `.onnx`/`.ort` model routes here. See
+[Embeddings & RAG](/docs/embeddings-and-rag) for the shared embedding API.
+
+## Web setup
+
+Web needs a small `web/index.html` shim before `FlutterGemma.initialize()` runs
+(the same readiness-handshake pattern the other web arms use). Add the shim for
+whichever arm(s) you register, in `<head>`, ahead of `flutter_bootstrap.js`:
+
+```html
+<!-- Transformers.js v4 — OnnxEngine web generation. -->
+<script type="module">
+window.transformersReady = (async () => {
+  const m = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0');
+  window.transformers = m;
+  return m;
+})();
+</script>
+
+<!-- onnxruntime-web — OnnxEmbeddingBackend web embeddings. -->
+<script type="module">
+window.ortReady = (async () => {
+  const m = await import('https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/ort.bundle.min.mjs');
+  m.env.wasm.wasmPaths = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/';
+  window.ort = m;
+  return m;
+})();
+</script>
+```
+
+Dart awaits `window.transformersReady` / `window.ortReady` before touching
+either module, so the shim must run before the Flutter app boots.
+
+## See also
+
+- [Embeddings & RAG](/docs/embeddings-and-rag) — the shared embedding API this
+  backend plugs into.
+- [Models](/docs/models) — the full supported-model matrix.
+- [Packages](/docs/packages) — every opt-in engine and backend, including
+  `flutter_gemma_onnx`.

--- a/website/content/docs/onnx.md
+++ b/website/content/docs/onnx.md
@@ -44,7 +44,7 @@ Native support is **arm64/x64-gated** — each host is device-verified end-to-en
 
 Add the package and register whichever arm(s) you use at startup:
 
-```yaml
+```
 dependencies:
   flutter_gemma: latest_version
   flutter_gemma_onnx: latest_version   # ONNX Runtime engines
@@ -133,7 +133,7 @@ Web needs a small `web/index.html` shim before `FlutterGemma.initialize()` runs
 (the same readiness-handshake pattern the other web arms use). Add the shim for
 whichever arm(s) you register, in `<head>`, ahead of `flutter_bootstrap.js`:
 
-```html
+```
 <!-- Transformers.js v4 — OnnxEngine web generation. -->
 <script type="module">
 window.transformersReady = (async () => {

--- a/website/content/docs/onnx.md
+++ b/website/content/docs/onnx.md
@@ -75,7 +75,7 @@ the model directory, so the whole bundle must already live on disk together
 await FlutterGemma.installModel(
   modelType: ModelType.general,
   fileType: ModelFileType.onnx,
-).fromFile(File('/path/to/my-model/genai_config.json')).install();
+).fromFile('/path/to/my-model/genai_config.json').install();
 ```
 
 **Web — fileless.** The model identity is a **Hugging Face repo id**;
@@ -117,7 +117,9 @@ model-dependent** (not a fixed 768):
 - **WordPiece / BERT-style** models (e.g. all-MiniLM-L6-v2, 384-dim) —
   mean-pooled + normalized client-side.
 - **SentencePiece** models (e.g. EmbeddingGemma-300M-ONNX) — the model's own
-  pooled `sentence_embedding` output.
+  pooled `sentence_embedding` output. **Native only** — on Web, embeddings are
+  WordPiece/BERT-style only in this release (a pure-Dart SentencePiece parser is
+  pending).
 
 The output contract and mask requirements are discovered from the session's
 actual graph once it opens — no per-model configuration. It registers at

--- a/website/content/docs/onnx.md
+++ b/website/content/docs/onnx.md
@@ -65,9 +65,9 @@ await FlutterGemma.initialize(
 ONNX models install with `fileType: ModelFileType.onnx`. What that means differs
 by platform.
 
-**Native — a directory, not a file.** An ORT-GenAI model is a **directory**
-(`genai_config.json` + `model.onnx` [+ `model.onnx_data` for external weights] +
-tokenizer files). `OnnxEngine` takes the tracked file's **parent directory** as
+**Native — a directory, not a file.** An ORT-GenAI model is a **directory**:
+`genai_config.json`, `model.onnx` (plus `model.onnx_data` for external weights),
+and tokenizer files. `OnnxEngine` takes the tracked file's **parent directory** as
 the model directory, so the whole bundle must already live on disk together
 (e.g. shipped as an asset or pre-populated yourself):
 

--- a/website/content/docs/packages.md
+++ b/website/content/docs/packages.md
@@ -31,7 +31,8 @@ ships only the native weight it actually uses. All packages live in one monorepo
   See [Installation](/docs/installation).
 - **Probe-chain registry.** Engines and backends are pure factories that declare
   `canHandle(spec)` + a priority. The registry selects a provider per model by
-  file type — `.task` / `.bin` / `.tflite` → MediaPipe, `.litertlm` → LiteRT-LM.
+  file type — `.task` / `.bin` / `.tflite` → MediaPipe, `.litertlm` → LiteRT-LM,
+  `.onnx` → Onnx, `builtIn` → BuiltInAi.
 - **One app can run both formats.** Register both `LiteRtLmEngine()` and
   `MediaPipeEngine()`, and the registry routes each model to the engine that
   handles its extension.
@@ -57,8 +58,11 @@ ships only the native weight it actually uses. All packages live in one monorepo
 | Transcribe audio, synthesize speech, or run a voice loop on-device (STT + TTS + voice) | `flutter_gemma_speech` |
 
 <Info>
-Desktop is served exclusively by `flutter_gemma_litertlm` and uses LiteRT-LM
-format only. There is no MediaPipe engine on desktop. See
+Desktop is served **primarily** by [`flutter_gemma_litertlm`](/docs/litertlm)
+(`.litertlm`) — the default engine. [`flutter_gemma_onnx`](/docs/onnx) also runs
+on all three desktop OSes (macOS/Windows/Linux), and on **macOS** the OS built-in
+model is available via [`flutter_gemma_builtin_ai`](/docs/builtin-ai) (Apple
+Foundation Models, macOS only). There is no MediaPipe engine on desktop. See
 [Desktop Support](/docs/desktop).
 </Info>
 

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -1,6 +1,6 @@
 ---
 title: Speech
-description: On-device speech for flutter_gemma — transcribe audio and synthesize speech fully offline: moonshine / Whisper / Parakeet STT + Matcha / Qwen3 / Inflect TTS, plus a voice loop, via the LiteRT C API and dart:ffi.
+description: On-device speech for flutter_gemma — transcribe audio and synthesize speech fully offline. moonshine / Whisper / Parakeet STT + Matcha / Qwen3 / Inflect TTS, plus a voice loop, via the LiteRT C API and dart:ffi.
 image: https://fluttergemma.dev/images/og-image.png
 ---
 

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -1,6 +1,6 @@
 ---
 title: Speech
-description: On-device speech for flutter_gemma — transcribe audio and synthesize speech fully offline (moonshine-tiny STT + Matcha TTS) via the LiteRT C API and dart:ffi.
+description: On-device speech for flutter_gemma — transcribe audio and synthesize speech fully offline: moonshine / Whisper / Parakeet STT + Matcha / Qwen3 / Inflect TTS, plus a voice loop, via the LiteRT C API and dart:ffi.
 image: https://fluttergemma.dev/images/og-image.png
 ---
 
@@ -30,7 +30,7 @@ inference.
 
 ```
 dependencies:
-  flutter_gemma: ^1.6.4
+  flutter_gemma: ^1.6.5
   flutter_gemma_speech: ^0.4.3
 ```
 

--- a/website/lib/landing/sections/features.dart
+++ b/website/lib/landing/sections/features.dart
@@ -60,14 +60,26 @@ const _features = [
     accent: Brand.orange,
   ),
   _FeatureData(
+    icon: '📱',
+    title: 'Built-in AI',
+    desc: 'Run Gemini Nano & Apple Intelligence — an OS-owned model, zero download',
+    accent: Brand.blue,
+  ),
+  _FeatureData(
     icon: '🔌',
-    title: 'Modular',
-    desc: 'Core + 8 opt-in packages — ship only what you use',
+    title: 'Pluggable Engines',
+    desc: 'LiteRT-LM, MediaPipe, ONNX Runtime & built-in OS AI — register the engine you need',
+    accent: Brand.orange,
+  ),
+  _FeatureData(
+    icon: '📦',
+    title: 'Opt-in Packages',
+    desc: 'Core + 11 opt-in packages — agent skills, speech, RAG & more; ship only what you use',
     accent: Brand.green,
   ),
 ];
 
-/// 8-card feature grid.
+/// Feature grid.
 class Features extends StatelessComponent {
   const Features({super.key});
 

--- a/website/lib/landing/sections/site_footer.dart
+++ b/website/lib/landing/sections/site_footer.dart
@@ -53,6 +53,14 @@ class SiteFooter extends StatelessComponent {
                 ]),
                 li([
                   a(
+                    href: 'https://pub.dev/packages/flutter_gemma_onnx',
+                    classes: 'footer-link',
+                    attributes: {'target': '_blank', 'rel': 'noopener'},
+                    [Component.text('flutter_gemma_onnx')],
+                  ),
+                ]),
+                li([
+                  a(
                     href: 'https://pub.dev/packages/flutter_gemma_embeddings',
                     classes: 'footer-link',
                     attributes: {'target': '_blank', 'rel': 'noopener'},

--- a/website/lib/main.server.dart
+++ b/website/lib/main.server.dart
@@ -106,6 +106,15 @@ void main() {
                   ],
                 ),
                 SidebarGroup(
+                  title: 'Engines',
+                  links: [
+                    SidebarLink(text: 'LiteRT-LM', href: '/docs/litertlm'),
+                    SidebarLink(text: 'MediaPipe', href: '/docs/mediapipe'),
+                    SidebarLink(text: 'ONNX Runtime', href: '/docs/onnx'),
+                    SidebarLink(text: 'Built-in AI', href: '/docs/builtin-ai'),
+                  ],
+                ),
+                SidebarGroup(
                   title: 'Features',
                   links: [
                     SidebarLink(text: 'Multimodal', href: '/docs/multimodal'),


### PR DESCRIPTION
## Summary

Website-only. A 7-agent content audit of fluttergemma.dev found factual errors, missing content, and structural gaps; this fixes them and adds a first-class **Built-in AI** page + a new **Engines** nav group.

### New pages (Engines group)
- **Built-in AI** — Gemini Nano (Android + Web) / Apple Foundation Models (iOS/macOS), no download, availability-probe → open-model fallback pattern.
- **LiteRT-LM**, **MediaPipe**, **ONNX Runtime** — one page each (previously only a packages-table row).

### Content fixes
- **getting-started**: What's-new filled in for 1.1–1.4 (+ builtin_ai under 1.6); Features gains Built-in AI + Pluggable Engines.
- **models/multimodal**: Gemma3n vision is Gemma-4-only on Web; FunctionGemma Web = yes; Phi → `ModelType.general`; Gemma 4 thinking not on Web; Type-3 links the new page.
- **desktop/installation/packages**: "desktop = litertlm only" corrected (ONNX on all 3 desktop OSes, Apple FM on macOS); Windows NPU documented; agent package added; routing list gains `builtIn`/`.onnx`.
- **function-calling**: built-in prompt-based FC, `Tool`/`ToolChoice`, parallel calls.
- **embeddings-and-rag**: embedding dim is backend-dependent (ONNX 384 ≠ 768), CPU-only scoped to LiteRT, qdrant vs sqlite-vec comparison table.
- **genkit**: `toolChoice`; **agent/speech**: install block + version pins.

### Landing
- Split the stale "Modular (8 opt-in)" card into **Built-in AI / Pluggable Engines / Opt-in Packages**; added `flutter_gemma_onnx` to the footer.

## Verification
- `dart analyze lib` — clean.
- `jaspr build` — completes without errors (content pipeline validated all markdown/frontmatter).
- All internal `/docs/*` links + nav hrefs resolve to existing pages; new-page frontmatter well-formed.
- Render is verified by the firebase-hosting build on merge.

migration.md intentionally untouched (it's the 0.x → 1.0 guide, not a live package catalog).