### PR TITLE
feat(core): Hugging Face manifest-resolver seam (#454)

### DIFF
--- a/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
+++ b/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart'
+    show kIsWeb, defaultTargetPlatform, TargetPlatform, visibleForTesting;
 import 'package:flutter_gemma/core/api/inference_installation_builder.dart';
 import 'package:flutter_gemma/core/api/embedding_installation_builder.dart';
 import 'package:flutter_gemma/core/api/stt_installation_builder.dart';
@@ -15,6 +16,8 @@ import 'package:flutter_gemma/core/registry/embedding_registry.dart';
 import 'package:flutter_gemma/core/registry/stt_registry.dart';
 import 'package:flutter_gemma/core/registry/tts_registry.dart';
 import 'package:flutter_gemma/core/registry/skill_executor_registry.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/embedding_backend_provider.dart';
 import 'package:flutter_gemma/core/registry/stt_backend_provider.dart';
@@ -156,6 +159,12 @@ class FlutterGemma {
     // stays dependency-free (no webview_flutter / url_launcher). Empty default
     // is a no-op — existing apps are unaffected.
     List<SkillExecutorProvider> skillExecutors = const [],
+    // Opt-in resolvers that turn a Hugging Face repo id into a
+    // [ResolvedHfModel] by reading that repo's deployment metadata (e.g.
+    // flutter_gemma_litertlm reads `litertlm_manifest.json`). Consumed by
+    // [resolveHuggingFace]; empty default is a no-op (that call then throws a
+    // clear "no resolver registered" error).
+    List<HuggingFaceResolver> huggingFaceResolvers = const [],
     VectorStoreRepository? vectorStore,
     // Declares which metadata fields the configured [vectorStore] should make
     // filterable. Threaded to the store via `configure()` at registration,
@@ -216,6 +225,9 @@ class FlutterGemma {
     }
     if (skillExecutors.isNotEmpty) {
       SkillExecutorRegistry.instance.registerAll(skillExecutors);
+    }
+    if (huggingFaceResolvers.isNotEmpty) {
+      HuggingFaceResolverRegistry.instance.registerAll(huggingFaceResolvers);
     }
 
     // Single-flight model-manager init: restore the previously-active model
@@ -348,6 +360,13 @@ class FlutterGemma {
   /// - [supportImage]: Enable multimodal image support (default: false)
   /// - [supportAudio]: Enable audio input support for Gemma 3n E4B (default: false)
   /// - [maxNumImages]: Maximum number of images if supportImage is true
+  /// - [defaults]: overridable runtime defaults from a HF manifest (see
+  ///   [resolveHuggingFace] / [ResolvedHfModel.runtime]). Each explicit argument
+  ///   above wins over the matching field here, which in turn wins over the SDK
+  ///   default — so `getActiveModel(defaults: r.runtime)` applies the manifest's
+  ///   guidance and `getActiveModel()` behaves exactly as before. NOTE: the two
+  ///   session-level fields (`isThinking`, `minOutputTokens`) are NOT applied
+  ///   here — forward them to `createSession` yourself.
   ///
   /// Throws:
   /// - [StateError] if no active inference model is set
@@ -376,12 +395,13 @@ class FlutterGemma {
   /// );
   /// ```
   static Future<InferenceModel> getActiveModel({
-    int maxTokens = 1024,
+    ModelRuntimeDefaults? defaults,
+    int? maxTokens,
     PreferredBackend? preferredBackend,
     PreferredBackend? preferredVisionBackend,
     PreferredBackend? preferredAudioBackend,
-    bool supportImage = false,
-    bool supportAudio = false,
+    bool? supportImage,
+    bool? supportAudio,
     int? maxNumImages,
     bool? enableSpeculativeDecoding,
     int? maxConcurrentSessions,
@@ -402,20 +422,152 @@ class FlutterGemma {
       );
     }
 
+    // Merge precedence: explicit argument > manifest [defaults] > SDK default.
+    // maxTokens keeps its historical 1024 fallback, so an omitted arg with no
+    // defaults behaves exactly as before. The .litertlm engine still clamps
+    // this value downstream (clampLitertlmContextTokens) — a manifest cannot
+    // set a context window the engine rejects (guards #318).
+    final effMaxTokens = mergeRuntimeDefault(
+      maxTokens,
+      defaults?.maxTokens,
+      1024,
+    );
+    final effPreferredBackend = preferredBackend ?? defaults?.preferredBackend;
+    final effSupportImage = mergeRuntimeDefault(
+      supportImage,
+      defaults?.supportImage,
+      false,
+    );
+    final effSupportAudio = mergeRuntimeDefault(
+      supportAudio,
+      defaults?.supportAudio,
+      false,
+    );
+
+    // [defaults] also carries two SESSION-level fields (isThinking,
+    // minOutputTokens) that this model-level call cannot apply. Warn (debug
+    // builds) so a caller who passes `defaults:` here and forgets to forward
+    // them to createSession finds out, instead of a reasoning model silently
+    // truncating mid-<think>.
+    if (defaults != null &&
+        (defaults.isThinking != null || defaults.minOutputTokens != null)) {
+      gemmaLog(
+        '[flutter_gemma] getActiveModel: manifest defaults carry session-level '
+        'fields (isThinking/minOutputTokens) that getActiveModel does not apply '
+        '— forward them to createSession(enableThinking:, maxOutputTokens:).',
+      );
+    }
+
     // Create InferenceModel using identity from spec + runtime params
     return await FlutterGemmaPlugin.instance.createModel(
       modelType: activeSpec.modelType,
       fileType: activeSpec.fileType,
-      maxTokens: maxTokens,
-      preferredBackend: preferredBackend,
+      maxTokens: effMaxTokens,
+      preferredBackend: effPreferredBackend,
       preferredVisionBackend: preferredVisionBackend,
       preferredAudioBackend: preferredAudioBackend,
-      supportImage: supportImage,
-      supportAudio: supportAudio,
+      supportImage: effSupportImage,
+      supportAudio: effSupportAudio,
       maxNumImages: maxNumImages,
       enableSpeculativeDecoding: enableSpeculativeDecoding,
       maxConcurrentSessions: maxConcurrentSessions,
     );
+  }
+
+  /// Three-tier runtime-default merge used by [getActiveModel]: an explicit
+  /// argument wins over a manifest [ModelRuntimeDefaults] value, which wins over
+  /// the SDK default. Extracted so the precedence rule is stated — and tested —
+  /// in one place.
+  @visibleForTesting
+  static T mergeRuntimeDefault<T>(T? explicit, T? manifest, T sdkDefault) =>
+      explicit ?? manifest ?? sdkDefault;
+
+  /// Resolves a Hugging Face repo id into a [ResolvedHfModel] by reading that
+  /// repo's deployment metadata (e.g. `litertlm_manifest.json`), using the
+  /// resolver registered via `initialize(huggingFaceResolvers: [...])`.
+  ///
+  /// [fileType] tells the registry which resolver to pick (the litertlm
+  /// resolver claims `ModelFileType.litertlm`); it is the only deterministic
+  /// selection signal a resolver has before it fetches the manifest.
+  ///
+  /// The result carries install identity ([ResolvedHfModel.modelType] /
+  /// [ResolvedHfModel.fileType] for [installModel], and [ResolvedHfModel.url]
+  /// for the download) plus overridable [ResolvedHfModel.runtime] defaults.
+  /// Apply the model-level defaults with `getActiveModel(defaults:)`; forward
+  /// the two session-level fields to `createSession` yourself. Install from
+  /// [ResolvedHfModel.url] (not `fromHuggingFace(repo, file:)`) so a resolver's
+  /// pinned revision is honoured — the plugin still auto-applies the HF token
+  /// to `huggingface.co` hosts:
+  ///
+  /// ```dart
+  /// final r = await FlutterGemma.resolveHuggingFace(
+  ///     repo, fileType: ModelFileType.litertlm);
+  /// await FlutterGemma.installModel(
+  ///       modelType: r.modelType ?? ModelType.general,
+  ///       fileType: r.fileType,
+  ///     )
+  ///     .fromNetwork(r.url)
+  ///     .install();
+  /// final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
+  /// final session = await model.createSession(
+  ///   enableThinking: r.runtime.isThinking ?? false,
+  ///   maxOutputTokens: r.runtime.minOutputTokens,
+  /// );
+  /// ```
+  ///
+  /// [token] defaults to the token passed to [initialize]. Throws [StateError]
+  /// if no registered resolver handles [repo] — add the engine package that
+  /// provides one (e.g. flutter_gemma_litertlm for `.litertlm` manifests).
+  static Future<ResolvedHfModel> resolveHuggingFace(
+    String repo, {
+    ModelFileType? fileType,
+    String? token,
+    PreferredBackend? preferredBackend,
+  }) async {
+    final resolver = HuggingFaceResolverRegistry.instance.findFor(
+      repo,
+      fileType: fileType,
+    );
+    if (resolver == null) {
+      throw StateError(
+        'No Hugging Face resolver registered for "$repo". Pass one to '
+        'FlutterGemma.initialize(huggingFaceResolvers: [...]) — e.g. the '
+        'litertlm manifest resolver from flutter_gemma_litertlm.',
+      );
+    }
+    return resolver.resolve(
+      repo,
+      token: token ?? ServiceRegistry.instance.huggingFaceToken,
+      platform: _currentPlatformKey(),
+      preferredBackend: preferredBackend,
+    );
+  }
+
+  /// Lowercase platform key passed to [HuggingFaceResolver.resolve] so a
+  /// resolver can honour per-platform recommendations. Returns `'unknown'` for
+  /// any host not in the resolver contract's documented set (e.g. a future
+  /// `TargetPlatform`); resolvers treat that as "no per-platform hint".
+  static String _currentPlatformKey() {
+    if (kIsWeb) return 'web';
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.iOS:
+        return 'ios';
+      case TargetPlatform.macOS:
+        return 'macos';
+      case TargetPlatform.windows:
+        return 'windows';
+      case TargetPlatform.linux:
+        return 'linux';
+      default:
+        gemmaLog(
+          '[flutter_gemma] resolveHuggingFace: no platform key for '
+          '$defaultTargetPlatform — passing "unknown" to the resolver, which '
+          'will fall back to its default (no per-platform recommendation).',
+        );
+        return 'unknown';
+    }
   }
 
   /// Check if there's an active inference model

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -87,6 +87,43 @@ class InferenceInstallationBuilder {
     return this;
   }
 
+  /// Set model source from a file in a Hugging Face repo.
+  ///
+  /// Builds `https://huggingface.co/<repo>/resolve/<revision>/<file>` and
+  /// installs it via the network path — the plugin already applies the
+  /// configured HuggingFace token to `huggingface.co` URLs for gated repos, so
+  /// [token] is only needed to override it.
+  ///
+  /// Pass [file] explicitly, or take it from
+  /// [FlutterGemma.resolveHuggingFace] when the repo ships a deployment
+  /// manifest (`ResolvedHfModel.file`). [file] may contain `/` for a repo that
+  /// nests variants in subfolders (e.g. `int4/model.litertlm`); each segment is
+  /// URL-encoded independently so the path structure survives.
+  InferenceInstallationBuilder fromHuggingFace(
+    String repo, {
+    required String file,
+    String revision = 'main',
+    String? token,
+    bool? foreground,
+  }) {
+    // Fail loud at the seam — a resolver that returns an empty file, or an
+    // empty repo, would otherwise build a directory URL that only 404s (or,
+    // worse, saves a CDN error page as the model) far downstream.
+    if (repo.trim().isEmpty) {
+      throw ArgumentError.value(repo, 'repo', 'must be a non-empty "org/name"');
+    }
+    if (file.trim().isEmpty) {
+      throw ArgumentError.value(
+        file,
+        'file',
+        'must be a non-empty repo-relative path',
+      );
+    }
+    final encodedPath = file.split('/').map(Uri.encodeComponent).join('/');
+    final url = 'https://huggingface.co/$repo/resolve/$revision/$encodedPath';
+    return fromNetwork(url, token: token, foreground: foreground);
+  }
+
   /// Optional: Add LoRA weights from custom source
   InferenceInstallationBuilder withLora(ModelSource loraSource) {
     _loraSource = loraSource;

--- a/packages/flutter_gemma/lib/core/registry/hugging_face_resolver.dart
+++ b/packages/flutter_gemma/lib/core/registry/hugging_face_resolver.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/model.dart' show ModelFileType, ModelType;
+
+/// Runtime defaults resolved from a Hugging Face repo's deployment metadata
+/// (e.g. a `litertlm_manifest.json`), in flutter_gemma's own runtime vocabulary.
+///
+/// Every field is nullable: `null` means "the manifest is silent — use the SDK
+/// default". These are the *how-to-run* knobs the app passes to
+/// [FlutterGemma.getActiveModel] / `createSession`, NOT install-time identity.
+/// They are **overridable defaults**, never authoritative config baked into the
+/// model — an explicit argument at the call site always wins over the field
+/// here, which in turn wins over the SDK default.
+///
+/// Kept as its own value object (separate from [ResolvedHfModel]'s identity
+/// fields) so the identity record — [InferenceModelSpec] — never grows runtime
+/// fields, preserving flutter_gemma's install-vs-runtime separation. It also
+/// makes the merge a pure function: `explicit ?? defaults?.x ?? sdkDefault`.
+class ModelRuntimeDefaults {
+  /// Context-window size (`maxTokens`), if the manifest declares one
+  /// (`model.context_length`). Still clamped by the engine downstream — a
+  /// manifest cannot set a value the engine rejects.
+  final int? maxTokens;
+
+  /// Recommended text/decoder backend for this device.
+  final PreferredBackend? preferredBackend;
+
+  /// Declared vision capability (`capabilities.vision`).
+  final bool? supportImage;
+
+  /// Declared audio capability (`capabilities.audio`).
+  final bool? supportAudio;
+
+  /// Whether the model emits a thinking channel
+  /// (`capabilities.thinking.declared`). Apply as `createSession`'s
+  /// `enableThinking`.
+  final bool? isThinking;
+
+  /// The **minimum** output-token budget the model needs
+  /// (`session_defaults.max_output_tokens_min`) — e.g. a reasoning model is cut
+  /// off mid-`<think>` below this. This is a FLOOR, not a cap: when you set
+  /// `createSession(maxOutputTokens:)`, keep it at or above this value (or leave
+  /// the cap unset). Do NOT assume it is itself the cap to apply blindly —
+  /// passing a floor into a smaller cap would truncate output.
+  final int? minOutputTokens;
+
+  const ModelRuntimeDefaults({
+    this.maxTokens,
+    this.preferredBackend,
+    this.supportImage,
+    this.supportAudio,
+    this.isThinking,
+    this.minOutputTokens,
+  });
+}
+
+/// A model resolved from a Hugging Face repo's deployment metadata into
+/// flutter_gemma's install + runtime vocabulary.
+///
+/// Install identity — [modelType] / [fileType] for
+/// [FlutterGemma.installModel], and [url] for the download (install from [url]
+/// via `fromNetwork` so the resolver's revision is honoured; see [url]) — is
+/// kept apart from [runtime], the overridable defaults the app applies at
+/// `getActiveModel` / `createSession`. That split mirrors how Hugging Face
+/// ships model identity (`config.json`) and generation defaults
+/// (`generation_config.json`) as separate files.
+class ResolvedHfModel {
+  /// The variant filename chosen in the repo (e.g. `model.litertlm`). May
+  /// contain `/` for a repo that nests variants in subfolders. Prefer [url] for
+  /// the actual download — [file] is the variant's name / display value.
+  final String file;
+
+  /// The authoritative download URL (`…/resolve/<revision>/<file>`) — the
+  /// resolver builds it and MAY pin a non-`main` revision/commit for
+  /// reproducibility. Install from this via `installModel(...).fromNetwork(url)`
+  /// (the plugin still auto-applies the HF token to `huggingface.co` hosts);
+  /// `fromHuggingFace(repo, file:)` rebuilds a `main` URL and so would drop a
+  /// pinned revision.
+  final String url;
+
+  /// How to install/route the model.
+  final ModelFileType fileType;
+
+  /// The model family (`gemmaIt`/`gemma4`/`qwen3`/…), if the resolver can map
+  /// the repo's declared architecture to one. Pass to [FlutterGemma.installModel]'s
+  /// required `modelType`. Null when the resolver can't determine it — the app
+  /// must then supply it. Not cosmetic: `ModelType` drives runtime branching
+  /// (tool-call format, thinking-tag handling).
+  final ModelType? modelType;
+
+  /// Manifest-declared integrity metadata (`sha256` / `size_bytes`).
+  ///
+  /// ADVISORY — carried for a post-download integrity check that core does
+  /// **not** perform yet (the install path only asserts a non-empty file
+  /// landed). Wiring an actual expected-hash/size verification into the
+  /// download is a follow-up; until then a caller that needs integrity must
+  /// verify these itself.
+  final String? sha256;
+  final int? sizeBytes;
+
+  /// The overridable runtime defaults (see [ModelRuntimeDefaults]).
+  final ModelRuntimeDefaults runtime;
+
+  /// Advisory notes to surface (platform notes, known issues) — not acted on.
+  /// Read-only; resolvers should pass an unmodifiable list.
+  final List<String> notes;
+
+  const ResolvedHfModel({
+    required this.file,
+    required this.url,
+    required this.fileType,
+    this.modelType,
+    this.sha256,
+    this.sizeBytes,
+    this.runtime = const ModelRuntimeDefaults(),
+    this.notes = const [],
+  });
+}
+
+/// A pluggable resolver that turns a Hugging Face repo id into a
+/// [ResolvedHfModel] by reading that repo's deployment metadata.
+///
+/// Implemented in an engine package — e.g. `flutter_gemma_litertlm` reads
+/// `litertlm_manifest.json` — and passed to `FlutterGemma.initialize` via
+/// `huggingFaceResolvers:`. Core selects one via the same probe-chain shape as
+/// [InferenceEngineProvider] (highest [priority], first-registered breaks
+/// ties), but the discriminator differs: an engine's `canHandle` inspects an
+/// already-resolved [InferenceModelSpec], whereas a resolver has only a bare
+/// `org/repo` string and the caller's [ModelFileType] hint until it fetches the
+/// manifest. So [canResolve] selects on that declared [fileType] hint — the
+/// same "select by declared ModelFileType" rule the engine registry uses.
+///
+/// Core never fetches on the resolver's behalf: the resolver does its own IO
+/// inside [resolve].
+abstract class HuggingFaceResolver {
+  /// Human-readable name for diagnostics (e.g. 'litertlm-manifest').
+  String get name;
+
+  /// Selection precedence on overlap. Core-adjacent resolvers use 0; a third
+  /// party raises this to take precedence for a repo both could handle.
+  int get priority => 0;
+
+  /// Whether this resolver handles a repo whose model is declared as [fileType].
+  ///
+  /// A resolver should claim a **specific** [fileType] (the litertlm resolver
+  /// returns true only for `fileType == ModelFileType.litertlm`) and NOT match a
+  /// `null` hint — otherwise, with more than one resolver registered, a bare
+  /// `resolveHuggingFace(repo)` with no hint would route by registration order
+  /// and could send an `.onnx` repo to the litertlm resolver. Callers pass the
+  /// `fileType` they are installing (they know it), so requiring it is cheap.
+  /// [repo] is available for future host/owner-scoped rules but current
+  /// selection is by [fileType].
+  bool canResolve(String repo, {ModelFileType? fileType});
+
+  /// Read the repo's deployment metadata and resolve the variant + defaults for
+  /// the current device.
+  ///
+  /// [platform] is a lowercase platform key — `android`, `ios`, `macos`,
+  /// `windows`, `linux`, `web`, or `unknown` for an unmapped host — so the
+  /// resolver can honour per-platform recommendations. A resolver should treat
+  /// `unknown` as "no per-platform recommendation" and fall back to its
+  /// default. [preferredBackend] is an optional caller hint the resolver may
+  /// prefer when the metadata lists it.
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? token,
+    String? platform,
+    PreferredBackend? preferredBackend,
+  });
+}

--- a/packages/flutter_gemma/lib/core/registry/hugging_face_resolver_registry.dart
+++ b/packages/flutter_gemma/lib/core/registry/hugging_face_resolver_registry.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/model.dart' show ModelFileType;
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
+
+/// Holds Hugging Face manifest resolvers registered via
+/// `FlutterGemma.initialize`. Same probe-chain selection as [EngineRegistry]:
+/// the registered resolver with the highest [HuggingFaceResolver.priority] whose
+/// [HuggingFaceResolver.canResolve] is true wins (first-registered breaks ties).
+/// No central format map — a resolver self-selects.
+class HuggingFaceResolverRegistry {
+  HuggingFaceResolverRegistry._();
+  static final HuggingFaceResolverRegistry instance =
+      HuggingFaceResolverRegistry._();
+
+  final _registered = <HuggingFaceResolver>[];
+
+  void registerAll(List<HuggingFaceResolver> resolvers) {
+    for (final r in resolvers) {
+      if (!_registered.contains(r)) _registered.add(r);
+    }
+  }
+
+  /// First resolver (by descending priority, then registration order) whose
+  /// [HuggingFaceResolver.canResolve] accepts [repo]; null if none.
+  HuggingFaceResolver? findFor(String repo, {ModelFileType? fileType}) {
+    final matches = _registered
+        .where((r) => r.canResolve(repo, fileType: fileType))
+        .toList();
+    if (matches.isEmpty) return null;
+    // Composite-key sort (Dart's List.sort is NOT stable): descending priority,
+    // then ascending original index so first-registered wins on equal priority.
+    final indexed = [for (var i = 0; i < matches.length; i++) (i, matches[i])];
+    indexed.sort((a, b) {
+      final byPriority = b.$2.priority.compareTo(a.$2.priority);
+      return byPriority != 0 ? byPriority : a.$1.compareTo(b.$1);
+    });
+    if (kDebugMode &&
+        indexed.length > 1 &&
+        indexed[0].$2.priority == indexed[1].$2.priority) {
+      gemmaLog(
+        '[flutter_gemma] Ambiguous HF resolver: '
+        '${indexed.map((e) => e.$2.name).join(", ")} all handle "$repo" at '
+        'priority ${indexed[0].$2.priority}; using "${indexed[0].$2.name}" '
+        '(first registered).',
+      );
+    }
+    return indexed.first.$2;
+  }
+
+  List<HuggingFaceResolver> get registered => List.unmodifiable(_registered);
+
+  bool get hasAny => _registered.isNotEmpty;
+
+  void reset() => _registered.clear();
+}

--- a/packages/flutter_gemma/lib/flutter_gemma.dart
+++ b/packages/flutter_gemma/lib/flutter_gemma.dart
@@ -16,6 +16,15 @@ export 'core/services/vector_store_repository.dart'; // VectorStoreRepository + 
 // SkillExecutor implements this contract and is registered/resolved here.
 export 'core/registry/skill_executor_provider.dart'; // SkillExecutorProvider contract
 export 'core/registry/skill_executor_registry.dart'; // SkillExecutorRegistry (fromModel reads it)
+// Hugging Face manifest-resolver seam. Only the app-facing value types are
+// re-exported — [ResolvedHfModel] / [ModelRuntimeDefaults] are the result of
+// FlutterGemma.resolveHuggingFace. The [HuggingFaceResolver] contract itself is
+// implemented by engine packages, which import it directly from
+// core/registry/hugging_face_resolver.dart — as they do the inference / embedding
+// / stt / tts *Provider contracts (those are not barrel-exported either;
+// skill_executor_provider above is the lone exception).
+export 'core/registry/hugging_face_resolver.dart'
+    show ResolvedHfModel, ModelRuntimeDefaults;
 export 'core/domain/platform_types.dart'; // PreferredBackend + RAG value types
 export 'core/message.dart';
 export 'core/model.dart'; // Export ModelType and other model-related classes

--- a/packages/flutter_gemma/test/core/registry/hugging_face_resolver_registry_test.dart
+++ b/packages/flutter_gemma/test/core/registry/hugging_face_resolver_registry_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_gemma/core/api/flutter_gemma.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/model.dart' show ModelFileType, ModelType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Minimal fake resolver — probe-chain selection is what these tests exercise,
+/// so [resolve] is never called.
+class _R implements HuggingFaceResolver {
+  _R(this._n, this._pri, {this.accepts = true});
+  final String _n;
+  final int _pri;
+  final bool accepts;
+  @override
+  String get name => _n;
+  @override
+  int get priority => _pri;
+  @override
+  bool canResolve(String repo, {ModelFileType? fileType}) => accepts;
+  @override
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? token,
+    String? platform,
+    PreferredBackend? preferredBackend,
+  }) async => throw UnimplementedError();
+}
+
+void main() {
+  setUp(() => HuggingFaceResolverRegistry.instance.reset());
+
+  group('HuggingFaceResolverRegistry (mirrors EngineRegistry probe-chain)', () {
+    test('picks highest priority', () {
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _R('low', 0),
+        _R('high', 10),
+      ]);
+      expect(HuggingFaceResolverRegistry.instance.findFor('o/r')!.name, 'high');
+    });
+
+    test('first-registered breaks ties on equal priority', () {
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _R('first', 5),
+        _R('second', 5),
+      ]);
+      expect(
+        HuggingFaceResolverRegistry.instance.findFor('o/r')!.name,
+        'first',
+      );
+    });
+
+    test('findFor null when empty; hasAny false', () {
+      expect(HuggingFaceResolverRegistry.instance.findFor('o/r'), isNull);
+      expect(HuggingFaceResolverRegistry.instance.hasAny, isFalse);
+    });
+
+    test('skips resolvers that decline the repo', () {
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _R('declines', 10, accepts: false),
+        _R('accepts', 0),
+      ]);
+      expect(
+        HuggingFaceResolverRegistry.instance.findFor('o/r')!.name,
+        'accepts',
+      );
+    });
+
+    test('dedupes identical registrations', () {
+      final r = _R('a', 0);
+      HuggingFaceResolverRegistry.instance.registerAll([r, r]);
+      expect(HuggingFaceResolverRegistry.instance.registered.length, 1);
+    });
+  });
+
+  test(
+    'ResolvedHfModel keeps identity + overridable runtime defaults apart',
+    () {
+      const r = ResolvedHfModel(
+        file: 'model.litertlm',
+        url: 'https://huggingface.co/o/r/resolve/main/model.litertlm',
+        fileType: ModelFileType.litertlm,
+        modelType: ModelType.qwen3,
+        sha256: 'abc',
+        sizeBytes: 123,
+        runtime: ModelRuntimeDefaults(
+          maxTokens: 4096,
+          isThinking: true,
+          minOutputTokens: 2048,
+        ),
+      );
+      expect(r.file, 'model.litertlm');
+      expect(r.fileType, ModelFileType.litertlm);
+      expect(r.modelType, ModelType.qwen3);
+      expect(r.runtime.maxTokens, 4096);
+      expect(r.runtime.isThinking, true);
+      expect(r.runtime.minOutputTokens, 2048);
+      // A field the manifest was silent on stays null → falls back to the SDK
+      // default at the call site.
+      expect(r.runtime.preferredBackend, isNull);
+      expect(r.runtime.supportImage, isNull);
+      // Default identity/runtime is all-null (no manifest hints).
+      const bare = ResolvedHfModel(
+        file: 'm',
+        url: 'u',
+        fileType: ModelFileType.litertlm,
+      );
+      expect(bare.modelType, isNull);
+      expect(bare.runtime.maxTokens, isNull);
+      expect(bare.notes, isEmpty);
+    },
+  );
+
+  group('getActiveModel defaults merge (mergeRuntimeDefault)', () {
+    test('explicit argument wins over manifest default and SDK default', () {
+      expect(FlutterGemma.mergeRuntimeDefault(512, 2048, 1024), 512);
+      expect(FlutterGemma.mergeRuntimeDefault(true, false, false), isTrue);
+    });
+
+    test('manifest default wins when the explicit argument is omitted', () {
+      expect(FlutterGemma.mergeRuntimeDefault(null, 2048, 1024), 2048);
+      expect(FlutterGemma.mergeRuntimeDefault<bool>(null, true, false), isTrue);
+    });
+
+    test(
+      'SDK default applies when both are null (unchanged legacy behaviour)',
+      () {
+        expect(FlutterGemma.mergeRuntimeDefault<int>(null, null, 1024), 1024);
+        expect(
+          FlutterGemma.mergeRuntimeDefault<bool>(null, null, false),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  test(
+    'resolveHuggingFace throws a clear StateError when nothing registered',
+    () {
+      HuggingFaceResolverRegistry.instance.reset();
+      expect(
+        FlutterGemma.resolveHuggingFace('org/repo'),
+        throwsA(isA<StateError>()),
+      );
+    },
+  );
+}

--- a/packages/flutter_gemma/test/mobile/concurrent_get_active_model_test.dart
+++ b/packages/flutter_gemma/test/mobile/concurrent_get_active_model_test.dart
@@ -355,6 +355,39 @@ void main() {
       await modelA.close();
     },
   );
+
+  test(
+    'getActiveModel(defaults:) threads the merged runtime into RuntimeConfig',
+    () async {
+      // Guards the actual wiring, not just the pure mergeRuntimeDefault helper:
+      // a refactor that computes eff* and then passes the raw params to
+      // createModel would keep the unit test green but be caught here.
+      final engine = await installWithGatedEngine();
+      engine.release();
+
+      // Manifest defaults with no explicit args → merged values reach the engine.
+      final m1 = await FlutterGemma.getActiveModel(
+        defaults: const ModelRuntimeDefaults(
+          maxTokens: 2048,
+          supportImage: true,
+          preferredBackend: PreferredBackend.gpu,
+        ),
+      );
+      expect(engine.configs.last.maxTokens, 2048);
+      expect(engine.configs.last.supportImage, isTrue);
+      expect(engine.configs.last.preferredBackend, PreferredBackend.gpu);
+
+      // Explicit argument wins over the manifest default (and rebuilds).
+      final m2 = await FlutterGemma.getActiveModel(
+        maxTokens: 512,
+        defaults: const ModelRuntimeDefaults(maxTokens: 2048),
+      );
+      expect(engine.configs.last.maxTokens, 512);
+      expect(identical(m1, m2), isFalse);
+
+      await FlutterGemmaPlugin.instance.initializedModel?.close();
+    },
+  );
 }
 
 /// An engine whose createModel blocks until [release] is called, so a test can


### PR DESCRIPTION
Stub seam for manifest-driven install of `.litertlm` models from Hugging Face repos that ship a `litertlm_manifest.json` (proposal #454). The resolver that actually reads the manifest lands in a **separate follow-up PR** (by @john-rocky); this PR is only the core-side interface it builds on, so the shape is stable before that work starts.

## What this adds (core, `flutter_gemma`)

- **`HuggingFaceResolver`** contract + **`ResolvedHfModel`** / **`ModelRuntimeDefaults`** value types (`core/registry/`), probed by a **`HuggingFaceResolverRegistry`** that mirrors `EngineRegistry` (descending priority, first-registered tiebreak, dedup).
- **`FlutterGemma.initialize(huggingFaceResolvers:)`** registration (a 6th opt-in provider list, alongside engines/backends/stt/tts/skills).
- **`FlutterGemma.resolveHuggingFace(repo, fileType:)`** — selects a resolver by the declared `ModelFileType` and returns the resolved variant (`modelType` / `fileType` / `url`) plus overridable runtime defaults.
- **`InferenceInstallationBuilder.fromHuggingFace(repo, file:)`** — a thin loader over `fromNetwork` (per-segment URL encoding for nested variant paths; validates non-empty repo/file).
- **`getActiveModel(defaults:)`** — an optional `ModelRuntimeDefaults`; the previously non-nullable defaulted params are made nullable so the merge is **explicit arg > manifest default > SDK default**. `getActiveModel()` with no args is unchanged for every existing caller.

## Install vs runtime separation preserved

Runtime defaults come back as a `ModelRuntimeDefaults` the app applies at `getActiveModel` / `createSession` — never stored on `InferenceModelSpec`, which stays identity-only. This mirrors how Hugging Face ships model identity (`config.json`) and generation defaults (`generation_config.json`) as separate files.

## Not in this PR (deliberate follow-ups)

- The `litertlm` manifest reader itself (the follow-up PR).
- Actual post-download **sha256 / size verification** — those fields are carried on `ResolvedHfModel` and documented as advisory; wiring the check into the download path is a focused follow-up.
- **`createSession(defaults:)`** — the two session-level fields (`isThinking` / `minOutputTokens`) are forwarded manually for now; adding a `defaults:` param there touches the `InferenceModel` interface and every engine's session factory.

## Review

Reviewed for architecture fit and correctness; findings addressed — `minOutputTokens` as a floor (not a cap), `modelType` on the result so the resolve→install handoff is complete, an authoritative `url` that honours a resolver's pinned revision, empty-input validation on the loader, honest advisory docs for the integrity metadata, and an end-to-end test that `getActiveModel(defaults:)` threads the merged config into the engine. `flutter analyze` is clean; the new and affected tests pass.
