### PR TITLE
docs(changelog): name the web corpus bug and the Android minSdk floor

### DIFF
--- a/packages/flutter_gemma_onnx/CHANGELOG.md
+++ b/packages/flutter_gemma_onnx/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.1
 - Fix a rebuilt native library not reaching the build.
-- Fail the build when a runtime download or its checksum check fails, instead of bundling nothing.
+- Fail the build on an unusable runtime — a failed download, a checksum mismatch, or an Android minSdk below 24 — instead of bundling nothing.
 
 ## 0.3.0
 

--- a/packages/flutter_gemma_rag_sqlite/CHANGELOG.md
+++ b/packages/flutter_gemma_rag_sqlite/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fetch `vec0` from the `native-sqlite-vec-v*` release, so an updated library reaches the build.
 - Fix `isInitialized` reporting true after an `initialize()` that threw.
 - Fix re-initializing onto another database keeping the old vector size.
+- Fix the web store reporting an empty corpus, and a successful delete, over data it could not read.
 - Fix the iOS `vec0` declaring the wrong minimum OS (App Store ITMS-90208).
 - Document the 1.0.x index break and how to move the old rows.
 


### PR DESCRIPTION
Two entries from #459 did not describe what shipped. Caught while checking the
changelogs before publishing — which is the only moment this is cheap, since a
published line can only be corrected by the next version.

**`flutter_gemma_rag_sqlite`** — the `isInitialized` and vector-size entries
apply to both arms now that the web arm is fixed, so they need no web-specific
twin. But the web store had a third, distinct failure: it reported an **empty
corpus**, and a **successful delete**, over data it was holding and could not
read. That is what a web user whose RAG went quiet would search the changelog
for, and there was nothing there.

**`flutter_gemma_onnx`** — an app with `minSdk` below 24 now fails the build
instead of building green and dying at the first `dlopen`. Folded into the
existing line rather than given its own, because it is the same issue: refusing
to bundle a runtime that cannot load.

No code changes. Both packages are still unpublished, so this lands before
`dart pub publish`.
