### PR TITLE
docs(rag_sqlite): the README promised a fetch the package never did

### DIFF
--- a/packages/flutter_gemma_rag_sqlite/README.md
+++ b/packages/flutter_gemma_rag_sqlite/README.md
@@ -131,6 +131,15 @@ already happened. Full write-up in the
 by this package's Native Assets hook (`hook/build.dart`), SHA256-verified, and
 loaded automatically before any database is opened.
 
+**New in 1.3.0:** that fetch is real. Until 1.2.0 the loadables were committed
+into the package, so every install carried all seven platforms' binaries to use
+one of them. They now come from this repository's `native-sqlite-vec-v*` GitHub
+Release, which means the **first** build of each platform needs `github.com`
+reachable; the library is cached under `~/.cache/flutter_gemma/native/`
+(`~/Library/Caches/…` on macOS, `%LOCALAPPDATA%\…` on Windows) and later builds
+do not go out again. `flutter_gemma_litertlm` has always worked this way. If you
+build in an air-gapped environment, pre-populate that cache directory.
+
 **Web** ships the custom `sqlite3.wasm` (with `sqlite-vec` linked in) as the
 package web asset `web/rag/sqlite3.wasm`. Copy it into your app's web root so it
 sits next to `index.html` at `rag/sqlite3.wasm` — that's the URL


### PR DESCRIPTION
`guard-release-docs.py` blocked the 1.3.0 publish — `lib/` changed and the
pub.dev-facing README did not. It was right, and for a sharper reason than the
rule itself states.

Since **1.1.0** (#340) the README's Setup section has read:

> the `vec0` loadable extension is fetched per platform by this package's Native
> Assets hook (`hook/build.dart`), SHA256-verified

None of that was true. The loadables were committed into the package and read
straight off disk — no download, no checksum, nothing to verify. The sentence
described an intended design and the code did something else for two minor
versions, which is the same failure mode #459 was about, in the one file that
becomes the package's landing page on pub.dev.

**1.3.0 is what makes it true.** So the paragraph now says that it is new, and
says what it costs — the part a reader actually needs: the first build of each
platform needs `github.com`, later builds do not, and an air-gapped build needs
the cache pre-populated.

No version bump — 1.3.0 is not published yet, so this rides into it.
