### PR TITLE
docs(changelog): name the mustNot filter fix in 1.3.1

### DIFF
--- a/packages/flutter_gemma_rag_sqlite/CHANGELOG.md
+++ b/packages/flutter_gemma_rag_sqlite/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.1
 - Fix web inserts failing on a numeric metadata value or a missing number field.
+- Fix web filters with a `mustNot` upper bound returning the negative values they exclude.
 
 ## 1.3.0
 - Fetch `vec0` from the `native-sqlite-vec-v*` release, so an updated library reaches the build.


### PR DESCRIPTION
1.3.1 fixes two distinct things and the entry described one.

The missing half is the worse of the two. An insert that fails is loud — the app
sees an exception. A filter that returns rows it was told to exclude is not: under
dart2js the lower guard of a one-sided `mustNot` range wrapped to `0`, so the
browser ran `NOT BETWEEN 0 AND lte` and every document with a **negative** value
came back from a filter that excludes it.

Caught in the review round on #464, fixed there, and left out of the entry.

```
- Fix web filters with a `mustNot` upper bound returning the negative values they exclude.
```

No code changes. Opened before publishing rather than after, because a published
changelog line can only be corrected by the next version — the same reason #462
existed.
