### PR TITLE
fix(example): a failed setUpAll made the web suite report "All tests passed"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@
 - If `flutter test` hangs on "Dart VM Service was not discovered" or fails with "Cannot start app on wirelessly tethered iOS device", fix iPhone/macOS USB tunnel (Personal Hotspot off, iPhone USB enabled in Network settings, Trust dialog) — do NOT switch to `flutter drive` as a workaround
 - **Exception: web** — Flutter SDK does NOT support `flutter test -d chrome/web-server` for `integration_test` (only `flutter test --platform chrome`, which is deprecated for app-level tests per Flutter docs). The **only** officially supported web integration test runner is `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/<file>.dart -d chrome` (or `-d web-server` headless). On web `flutter drive` is the canonical Flutter-supported path, not a workaround — use it.
 
+## Rule 6b: NO `setUp` IN A SUITE THAT RUNS UNDER `flutter drive` ⛔
+- A `setUp`/`setUpAll` that THROWS under `flutter drive` is reported as **"All tests passed"**, exit 0 — not an error, not a skip. `package:integration_test` writes a result only from inside `runTest`, a failed setUp means `runTest` never runs, so the test is **absent** from the report — and absent reads as "no failure".
+- **Measured, both ways.** `flutter drive` on `-d web-server`: green over a corpus that failed to insert. `flutter test integration_test/<file>.dart -d macos` with the same throwing setUp: `+0 -1: Some tests failed`, exit **1**. So the 40-odd native suites here are safe *because* Rule 6 keeps them off `flutter drive`; only the web ones are exposed.
+- Put anything that can fail **inside the test body** (a guarded `_ensure…()` helper called first thing). `example/integration_test/rag_sqlite_web_parity_test.dart` and `litertlm_web_test.dart` are the pattern.
+- This is not hypothetical: a web suite here was green twice over a corpus it had never inserted, and only a mutation of its expectations exposed it. If a `flutter drive` run says "All tests passed", confirm the suite is not empty before believing it.
+
 ## Rule 7: CHANGELOG ENTRIES ARE ONE LINE ⛔
 - **ONE line per ISSUE**, not per change. A fix that touched nine things is still one bullet
 - Every `## X.Y.Z` bullet must fit on a single short line (~10-15 words)

--- a/packages/flutter_gemma/example/integration_test/litertlm_web_test.dart
+++ b/packages/flutter_gemma/example/integration_test/litertlm_web_test.dart
@@ -40,7 +40,27 @@ const _hfToken = String.fromEnvironment('HUGGINGFACE_TOKEN');
 
 InferenceModel? _model;
 
+/// Guards [registerTestEngines] so it can be called from every test body.
+bool _enginesRegistered = false;
+
 Future<InferenceModel> _ensureModel() async {
+  // Engine registration lives HERE, not in a setUpAll, and that is not style.
+  //
+  // Under `flutter drive` a setUp/setUpAll that THROWS is reported as "All
+  // tests passed": package:integration_test only ever writes a result from
+  // inside `runTest`, and a failed setUp means `runTest` never runs, so the
+  // test is absent from the report rather than failed — and an absent test
+  // reads as no failure. Measured; `flutter test -d <device>` does NOT have
+  // this problem (package:test's own reporter sees the error), which is why the
+  // 42 native suites here can keep their setUp.
+  //
+  // This suite is the one that runs under drive, so anything that can fail has
+  // to fail inside a test body.
+  if (!_enginesRegistered) {
+    await registerTestEngines();
+    _enginesRegistered = true;
+  }
+
   if (_model != null) return _model!;
 
   // Install via the network path — `WebStorageMode.cacheApi` (default) puts
@@ -67,9 +87,6 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('LiteRT-LM web (.litertlm via @litert-lm/core)', () {
-    setUpAll(() async {
-      await registerTestEngines();
-    });
     tearDownAll(_disposeModel);
 
     testWidgets('text generation produces a non-empty response', (


### PR DESCRIPTION
Under `flutter drive`, a `setUp`/`setUpAll` that **throws** is not an error and
not a skip — the suite reports **"All tests passed"** and exits 0.
`package:integration_test` writes a result only from inside `runTest`; a failed
setUp means `runTest` never runs, so the test is **absent** from the report, and
absent reads as no failure.

Proven on this suite — same throw, two placements:

| where | result |
|---|---|
| in the test body | 7 tests fail, `Bad state: PROBE: registration failed` |
| in `setUpAll` | **All tests passed** |

`litertlm_web_test.dart`'s `setUpAll` called `registerTestEngines()`, so a
failure there was invisible. Worse than plain silence: `FlutterGemma.initialize`
registers the engines *before* awaiting `ensureInitialized()`, so a throw from
the await left the engines registered and the tests could still pass — over an
initialize that never completed.

Registration moves into the guarded `_ensureModel()` every test already calls
first. The two suites added in #464 never used `setUp` for exactly this reason;
this is the third and last web suite in the repo.

## The 40-odd native suites are fine, and now it is written down

Measured: `flutter test integration_test/<file>.dart -d macos` with the same
throwing setUp reports `+0 -1: Some tests failed` and exits **1** —
`package:test`'s own reporter sees the error independently of the binding. So
Rule 6, which keeps native targets off `flutter drive`, is what makes them safe.
That is now **Rule 6b** in CLAUDE.md instead of folklore, because the next web
suite would otherwise walk into it — this one did, and a mutation of its
expectations was the only thing that noticed.

## Verified / not verified

Verified: the mechanism, by the two-placement probe. **Not** verified: a full
green run of this suite, which needs the ~600 MB `gemma-4-E2B-it-web` model. The
probe throws before any download, which is what made it cheap.
