### PR TITLE
feat(litertlm): LitertlmManifestResolver — manifest-driven Hugging Face install (#454)

### DIFF
--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.0
+- Add `LitertlmManifestResolver`: manifest-driven Hugging Face install for repos shipping `litertlm_manifest.json` (#454).
+
 ## 1.5.3
 - Fix a rebuilt native library not reaching the build.
 

--- a/packages/flutter_gemma_litertlm/README.md
+++ b/packages/flutter_gemma_litertlm/README.md
@@ -27,6 +27,42 @@ await FlutterGemma.initialize(
 other engines (e.g. `MediaPipeEngine` from `flutter_gemma_mediapipe`) if your app
 uses both formats.
 
+## Install from a Hugging Face repo (`litertlm_manifest.json`)
+
+Repos that ship a
+[`litertlm_manifest.json`](https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md)
+deployment manifest describe every `.litertlm` file they contain — which
+backends each is verified on, which file a given platform should pick, sha256/
+size identity, and session guidance. `LitertlmManifestResolver` reads it so an
+app installs "the right file for this device" without hardcoding filenames:
+
+```dart
+await FlutterGemma.initialize(
+  inferenceEngines: [LiteRtLmEngine()],
+  huggingFaceResolvers: [const LitertlmManifestResolver()],
+);
+
+final r = await FlutterGemma.resolveHuggingFace(
+    'litert-community/Qwen3-4B-Thinking-2507',
+    fileType: ModelFileType.litertlm);
+await FlutterGemma.installModel(
+      modelType: r.modelType ?? ModelType.general,
+      fileType: r.fileType,
+    )
+    .fromNetwork(r.url) // authoritative: carries the resolver's revision pin
+    .install();
+final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
+final session = await model.createSession(
+  enableThinking: r.runtime.isThinking ?? false,
+  maxOutputTokens: r.runtime.minOutputTokens, // a floor — see the field docs
+);
+```
+
+Everything the manifest returns is an overridable default (explicit argument >
+manifest > SDK default); `r.notes` carries platform caveats and known issues
+worth surfacing to developers. Repos without a manifest keep working through
+`installModel(...).fromHuggingFace(repo, file: ...)`.
+
 ## Embeddings
 
 ```dart

--- a/packages/flutter_gemma_litertlm/README.md
+++ b/packages/flutter_gemma_litertlm/README.md
@@ -37,6 +37,8 @@ size identity, and session guidance. `LitertlmManifestResolver` reads it so an
 app installs "the right file for this device" without hardcoding filenames:
 
 ```dart
+import 'dart:math' show max;
+
 await FlutterGemma.initialize(
   inferenceEngines: [LiteRtLmEngine()],
   huggingFaceResolvers: [const LitertlmManifestResolver()],
@@ -54,7 +56,9 @@ await FlutterGemma.installModel(
 final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
 final session = await model.createSession(
   enableThinking: r.runtime.isThinking ?? false,
-  maxOutputTokens: r.runtime.minOutputTokens, // a floor — see the field docs
+  // minOutputTokens is a floor, not a cap: keep the app's own budget unless
+  // the manifest asks for more.
+  maxOutputTokens: max(1024, r.runtime.minOutputTokens ?? 0),
 );
 ```
 

--- a/packages/flutter_gemma_litertlm/lib/flutter_gemma_litertlm.dart
+++ b/packages/flutter_gemma_litertlm/lib/flutter_gemma_litertlm.dart
@@ -26,3 +26,12 @@ export 'src/ffi/litert_bindings_stub.dart'
 // the LiteRT.js-backed `WebEmbeddingModel` directly.
 export 'src/embedding/litert_embedding_backend_web.dart'
     if (dart.library.ffi) 'src/embedding/litert_embedding_backend.dart';
+
+// Hugging Face resolver for repos that ship a `litertlm_manifest.json`
+// deployment manifest. Register with
+// `FlutterGemma.initialize(huggingFaceResolvers: [LitertlmManifestResolver()])`
+// and drive it via `FlutterGemma.resolveHuggingFace(repo,
+// fileType: ModelFileType.litertlm)`. All six platforms (its IO arm picks
+// dart:io or browser fetch internally).
+export 'src/manifest/litertlm_manifest_resolver.dart'
+    show LitertlmManifestResolver, ManifestFetch, ManifestFetchException;

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest.dart
@@ -1,0 +1,381 @@
+/// Reader for `litertlm_manifest.json` — the deployment manifest shipped at
+/// the root of `.litertlm` model repos on Hugging Face.
+///
+/// Vendored from the reference reader at
+/// https://github.com/john-rocky/hf-to-litertlm/tree/main/readers/dart (same
+/// author); the resolution algorithm here and there must stay identical, so a
+/// repo resolves to the same file no matter which integration reads it.
+/// Spec: https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md
+///
+/// IO-free by design: pass a parsed manifest map (or JSON string). The HTTP
+/// lives in [LitertlmManifestResolver] so this stays a pure, unit-testable
+/// mirror of the reference implementation. No imports beyond dart:convert.
+library;
+
+import 'dart:convert';
+
+/// The model's thinking-channel markers, exact strings, whitespace included
+/// (e.g. Qwen3 ships `'<think>\n'` / `'\n</think>'`, LFM2.5 bare tags).
+class ThinkingChannel {
+  final String start;
+  final String end;
+  const ThinkingChannel(this.start, this.end);
+}
+
+/// One entry of the bundle's declared channel set (manifest 0.1.1+) —
+/// thinking, tool-call, or anything else a model declares.
+class DeclaredChannel {
+  final String name;
+  final String start;
+  final String end;
+  final bool isReasoning;
+  const DeclaredChannel(
+    this.name,
+    this.start,
+    this.end, {
+    this.isReasoning = false,
+  });
+}
+
+/// `model.capabilities` — declared (bundle-derived) capability flags.
+class Capabilities {
+  final bool vision;
+  final bool audio;
+  final bool thinkingDeclared;
+  final ThinkingChannel? thinkingChannel;
+
+  /// Full bundle-declared channel set (0.1.1+). Empty for 0.1.0 manifests;
+  /// fall back to [thinkingChannel] plus your runtime's default channels.
+  final List<DeclaredChannel> channels;
+
+  const Capabilities({
+    this.vision = false,
+    this.audio = false,
+    this.thinkingDeclared = false,
+    this.thinkingChannel,
+    this.channels = const [],
+  });
+
+  factory Capabilities.fromJson(Map<String, dynamic>? j) {
+    if (j == null) return const Capabilities();
+    final t = j['thinking'] as Map<String, dynamic>?;
+    final ch = t?['channel'] as Map<String, dynamic>?;
+    return Capabilities(
+      vision: j['vision'] == true,
+      audio: j['audio'] == true,
+      thinkingDeclared: t?['declared'] == true,
+      thinkingChannel: ch == null
+          ? null
+          : ThinkingChannel(
+              ch['start'] as String? ?? '',
+              ch['end'] as String? ?? '',
+            ),
+      channels: ((j['channels'] as List?) ?? const [])
+          .map((e) => e as Map<String, dynamic>)
+          .map(
+            (e) => DeclaredChannel(
+              e['name'] as String? ?? '',
+              e['start'] as String? ?? '',
+              e['end'] as String? ?? '',
+              isReasoning: e['is_reasoning'] == true,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+/// One `recommended[]` row: the verified-fastest choice for a platform (and
+/// optionally a free-string device class — no vocabulary is defined in v0.1).
+class Recommendation {
+  final String platform;
+  final String? deviceClass;
+  final String backend;
+  final String? reason;
+  const Recommendation(
+    this.platform,
+    this.deviceClass,
+    this.backend,
+    this.reason,
+  );
+
+  factory Recommendation.fromJson(Map<String, dynamic> j) => Recommendation(
+    j['platform'] as String,
+    j['device_class'] as String?,
+    j['backend'] as String,
+    j['reason'] as String?,
+  );
+}
+
+/// One `variants[]` entry — a single `.litertlm` file in the repo.
+class Variant {
+  final String file;
+  final String? sha256;
+  final int? sizeBytes;
+  final String quantization;
+
+  /// Backends this file is *verified to generate* on — not merely load.
+  final List<String> backends;
+  final String? defaultBackend;
+  final String? minRuntimeVersion;
+  final List<Recommendation> recommended;
+  final List<String> platformNotes;
+  final List<String> knownIssues;
+
+  /// The raw variant JSON, for fields the typed surface doesn't consume
+  /// (`measured[]`, `sections`, `requirements.peak_ram_mb`).
+  final Map<String, dynamic> raw;
+
+  Variant.fromJson(Map<String, dynamic> j)
+    : file = j['file'] as String,
+      sha256 = j['sha256'] as String?,
+      sizeBytes = j['size_bytes'] as int?,
+      quantization = j['quantization'] as String? ?? '',
+      backends = _requireBackends(j),
+      defaultBackend = j['default_backend'] as String?,
+      minRuntimeVersion = j['min_runtime_version'] as String?,
+      recommended = ((j['recommended'] as List?) ?? const [])
+          .map((e) => Recommendation.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      platformNotes =
+          (((j['requirements'] as Map<String, dynamic>?)?['platform_notes'])
+                  as List?)
+              ?.cast<String>() ??
+          const [],
+      knownIssues = (j['known_issues'] as List?)?.cast<String>() ?? const [],
+      raw = j;
+
+  static List<String> _requireBackends(Map<String, dynamic> j) {
+    final b = (j['backends'] as List?)?.cast<String>();
+    if (b == null || b.isEmpty) {
+      throw FormatException(
+        'variant ${j['file']} lists no backends (schema requires minItems: 1)',
+      );
+    }
+    return b;
+  }
+}
+
+/// A parsed `litertlm_manifest.json`.
+class LitertlmManifest {
+  final String schemaVersion;
+  final String repo;
+  final String displayName;
+
+  /// `model.context_length` — on the model, not the variant (bundle
+  /// `max_num_tokens`, identical across a repo's variants).
+  final int? contextLength;
+  final Capabilities capabilities;
+
+  /// `model.session_defaults` — an OPEN object: the JSON Schema declares no
+  /// properties for it, so treat the object and every key as optional. Keys in
+  /// shipped manifests today: `max_output_tokens_min` (int), `notes` (string),
+  /// and sampler hints (`temperature`, `top_k`, `top_p`).
+  final Map<String, dynamic>? sessionDefaults;
+  final List<Variant> variants;
+
+  /// Not part of the file: the revision the manifest was fetched at (the
+  /// caller does its own HTTP), so [resolve] URLs follow a pinned fetch.
+  /// Defaults to `main`.
+  final String? revision;
+
+  LitertlmManifest._(
+    this.schemaVersion,
+    this.repo,
+    this.displayName,
+    this.contextLength,
+    this.capabilities,
+    this.sessionDefaults,
+    this.variants,
+    this.revision,
+  );
+
+  factory LitertlmManifest.fromJson(dynamic input, {String? revision}) {
+    final m =
+        (input is String ? jsonDecode(input) : input) as Map<String, dynamic>;
+    final schema = m['manifest_schema'] as String?;
+    final vs = m['variants'] as List?;
+    if (schema == null || vs == null || vs.isEmpty) {
+      throw const FormatException(
+        'not a litertlm_manifest.json (missing manifest_schema or variants)',
+      );
+    }
+    // While the schema is 0.x the minor version is the compatibility line:
+    // refuse anything outside 0.1.x rather than half-parse it.
+    if (!schema.startsWith('0.1.')) {
+      throw FormatException(
+        'unsupported manifest_schema $schema (reader supports 0.1.x)',
+      );
+    }
+    final model = m['model'] as Map<String, dynamic>? ?? const {};
+    return LitertlmManifest._(
+      schema,
+      m['repo'] as String,
+      model['display_name'] as String? ?? m['repo'] as String,
+      model['context_length'] as int?,
+      Capabilities.fromJson(model['capabilities'] as Map<String, dynamic>?),
+      model['session_defaults'] as Map<String, dynamic>?,
+      vs.map((e) => Variant.fromJson(e as Map<String, dynamic>)).toList(),
+      revision,
+    );
+  }
+
+  /// The model's declared thinking markers (exact strings, whitespace
+  /// included); null when no thinking channel is declared.
+  ThinkingChannel? get thinkingMarkers =>
+      capabilities.thinkingDeclared ? capabilities.thinkingChannel : null;
+
+  /// The bundle's full declared channel set (manifest 0.1.1+). Empty for
+  /// 0.1.0 manifests — fall back to [thinkingMarkers] plus the runtime's
+  /// default channels.
+  List<DeclaredChannel> get declaredChannels => capabilities.channels;
+
+  /// Pick the variant + backend for a device. v0.1 algorithm, deterministic —
+  /// identical to the TypeScript and Dart reference readers:
+  ///
+  /// 1. An explicit [backend] request is a filter, not a score: only variants
+  ///    listing it compete, the result keeps that backend, and resolve()
+  ///    returns null when no variant lists it — it never substitutes another
+  ///    backend.
+  /// 2. A variant with a `recommended` entry matching [platform] wins;
+  ///    matching [deviceClass] too ranks higher. When a backend was requested,
+  ///    only recommendations naming that backend count.
+  /// 3. Otherwise the smallest variant (by size_bytes), on the requested
+  ///    backend (else its `default_backend`, else the first listed backend).
+  ///
+  /// Ties break toward the smaller file. Never returns a backend absent from
+  /// the variant's verified `backends` list — recommendations naming an
+  /// unlisted backend are ignored.
+  Resolution? resolve({
+    String? platform,
+    String? backend,
+    String? deviceClass,
+    String? revision,
+  }) {
+    final candidates = backend != null
+        ? variants.where((v) => v.backends.contains(backend)).toList()
+        : variants;
+    if (candidates.isEmpty) return null;
+
+    final scored = <_Scored>[];
+    for (final v in candidates) {
+      var score = 0;
+      String? chosen = backend;
+      var reason = backend != null
+          ? 'supports requested backend $backend'
+          : 'fallback: smallest variant';
+      if (platform != null && v.recommended.isNotEmpty) {
+        final recs = v.recommended
+            .where(
+              (r) =>
+                  r.platform == platform &&
+                  v.backends.contains(r.backend) &&
+                  (backend == null || r.backend == backend),
+            )
+            .toList();
+        Recommendation? classRec;
+        if (deviceClass != null) {
+          for (final r in recs) {
+            if (r.deviceClass == deviceClass) {
+              classRec = r;
+              break;
+            }
+          }
+        }
+        Recommendation? classFree;
+        for (final r in recs) {
+          if (r.deviceClass == null || deviceClass == null) {
+            classFree = r;
+            break;
+          }
+        }
+        final rec =
+            classRec ?? classFree ?? (recs.isNotEmpty ? recs.first : null);
+        if (rec != null) {
+          score = classRec != null ? 300 : 200;
+          chosen = backend ?? rec.backend;
+          final classNote =
+              classRec == null && deviceClass != null && rec.deviceClass != null
+              ? ' (no $deviceClass entry; using the ${rec.deviceClass} '
+                    'recommendation)'
+              : '';
+          reason =
+              'recommended for $platform'
+              '${classRec != null ? "/$deviceClass" : ""}$classNote: '
+              '${rec.reason ?? ""}';
+        }
+      }
+      chosen ??=
+          (v.defaultBackend != null && v.backends.contains(v.defaultBackend))
+          ? v.defaultBackend!
+          : (v.backends.isNotEmpty ? v.backends.first : 'cpu');
+      scored.add(_Scored(v, chosen, score, reason.trim()));
+    }
+    scored.sort((a, b) {
+      final s = b.score.compareTo(a.score);
+      if (s != 0) return s;
+      return (a.variant.sizeBytes ?? 1 << 62).compareTo(
+        b.variant.sizeBytes ?? 1 << 62,
+      );
+    });
+    final best = scored.first;
+    final v = best.variant;
+    final rev = Uri.encodeComponent(revision ?? this.revision ?? 'main');
+    return Resolution(
+      file: v.file,
+      // Per-segment encoding so a nested variant path keeps its structure —
+      // same rule as the reference readers and fromHuggingFace.
+      url:
+          'https://huggingface.co/$repo/resolve/$rev/${v.file.split('/').map(Uri.encodeComponent).join('/')}',
+      backend: best.backend,
+      variant: v,
+      sessionDefaults: sessionDefaults,
+      capabilities: capabilities,
+      thinkingChannel: thinkingMarkers,
+      contextLength: contextLength,
+      notes: [...v.platformNotes, ...v.knownIssues],
+      reason: best.reason,
+    );
+  }
+}
+
+class _Scored {
+  final Variant variant;
+  final String backend;
+  final int score;
+  final String reason;
+  _Scored(this.variant, this.backend, this.score, this.reason);
+}
+
+/// The answer to "given this device, which file, on which backend, with which
+/// settings" — in the manifest's own (string) vocabulary.
+/// [LitertlmManifestResolver] maps this onto flutter_gemma's `ResolvedHfModel`.
+class Resolution {
+  final String file;
+
+  /// Reader URL, following the revision the manifest was fetched at
+  /// (`fromJson(revision:)`, else `main`) and anchored to the manifest's own
+  /// `repo` field. The resolver builds its own authoritative URL instead,
+  /// anchored to the repo id the caller actually asked for.
+  final String url;
+  final String backend;
+  final Variant variant;
+  final Map<String, dynamic>? sessionDefaults;
+  final Capabilities capabilities;
+  final ThinkingChannel? thinkingChannel;
+  final int? contextLength;
+  final List<String> notes;
+  final String reason;
+  const Resolution({
+    required this.file,
+    required this.url,
+    required this.backend,
+    required this.variant,
+    this.sessionDefaults,
+    required this.capabilities,
+    this.thinkingChannel,
+    this.contextLength,
+    required this.notes,
+    required this.reason,
+  });
+}

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest.dart
@@ -137,16 +137,21 @@ class Variant {
       recommended = ((j['recommended'] as List?) ?? const [])
           .map((e) => Recommendation.fromJson(e as Map<String, dynamic>))
           .toList(),
+      // `.toList()` after `.cast<String>()` on purpose: the cast alone is
+      // lazy, so a non-string element would surface as a TypeError at first
+      // use (inside resolve()) instead of failing here, at parse.
       platformNotes =
           (((j['requirements'] as Map<String, dynamic>?)?['platform_notes'])
                   as List?)
-              ?.cast<String>() ??
+              ?.cast<String>()
+              .toList() ??
           const [],
-      knownIssues = (j['known_issues'] as List?)?.cast<String>() ?? const [],
+      knownIssues =
+          (j['known_issues'] as List?)?.cast<String>().toList() ?? const [],
       raw = j;
 
   static List<String> _requireBackends(Map<String, dynamic> j) {
-    final b = (j['backends'] as List?)?.cast<String>();
+    final b = (j['backends'] as List?)?.cast<String>().toList();
     if (b == null || b.isEmpty) {
       throw FormatException(
         'variant ${j['file']} lists no backends (schema requires minItems: 1)',

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest_resolver.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest_resolver.dart
@@ -1,0 +1,317 @@
+import 'dart:convert';
+
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/model.dart' show ModelFileType, ModelType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/utils/gemma_log.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+import 'litertlm_manifest.dart';
+import 'manifest_fetch_types.dart';
+import 'manifest_fetch_web.dart' if (dart.library.io) 'manifest_fetch_io.dart';
+
+export 'manifest_fetch_types.dart' show ManifestFetch, ManifestFetchException;
+
+/// [HuggingFaceResolver] for repos that ship a `litertlm_manifest.json` —
+/// the deployment manifest at the root of `.litertlm` model repos
+/// (spec: https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md).
+///
+/// The manifest carries what the `.litertlm` bundle cannot: which of the
+/// repo's files fits which platform (with verified-fastest recommendations),
+/// sha256/size identity, and curated session guidance. Everything it returns
+/// is an *overridable default* — the bundle header stays authoritative for the
+/// conversation contract, and an explicit argument at the call site always
+/// wins (core's `explicit arg > manifest > SDK default` merge).
+///
+/// ```dart
+/// await FlutterGemma.initialize(
+///   inferenceEngines: [LiteRtLmEngine()],
+///   huggingFaceResolvers: [const LitertlmManifestResolver()],
+/// );
+///
+/// final r = await FlutterGemma.resolveHuggingFace(
+///     'litert-community/Qwen3-4B-Thinking-2507',
+///     fileType: ModelFileType.litertlm);
+/// await FlutterGemma.installModel(
+///       modelType: r.modelType ?? ModelType.general,
+///       fileType: r.fileType,
+///     )
+///     .fromNetwork(r.url) // r.url honours this resolver's [revision] pin
+///     .install();
+/// final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
+/// final session = await model.createSession(
+///   enableThinking: r.runtime.isThinking ?? false,
+///   maxOutputTokens: r.runtime.minOutputTokens,
+/// );
+/// ```
+///
+/// Throws [ManifestFetchException] when the repo does not ship a manifest
+/// (HTTP 404 — install with `fromHuggingFace(repo, file:)` instead), when
+/// auth is missing or rejected (401/403 carry gated-repo guidance), or the
+/// GET fails otherwise; and [FormatException] when the file exists but is
+/// not a supported `0.1.x` manifest.
+class LitertlmManifestResolver implements HuggingFaceResolver {
+  /// Git revision (branch, tag, or commit) the manifest AND the resolved file
+  /// URL are pinned to. Defaults to `main`; pin a commit for reproducible
+  /// installs — the returned `url` carries it, which is why installs go
+  /// through `fromNetwork(r.url)`.
+  final String revision;
+
+  /// Test/app seam for the HTTP GET; null uses the platform default
+  /// (`dart:io` [HttpClient] natively, the browser's `fetch` on web).
+  final ManifestFetch? fetch;
+
+  const LitertlmManifestResolver({this.revision = 'main', this.fetch});
+
+  @override
+  String get name => 'litertlm-manifest';
+
+  @override
+  int get priority => 0;
+
+  /// Claims exactly [ModelFileType.litertlm] — never a null hint. With more
+  /// than one resolver registered, a bare `resolveHuggingFace(repo)` must not
+  /// route by registration order (it could send an `.onnx` repo here); the
+  /// caller knows which file type it is installing, so it declares it.
+  @override
+  bool canResolve(String repo, {ModelFileType? fileType}) =>
+      fileType == ModelFileType.litertlm;
+
+  @override
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? token,
+    String? platform,
+    PreferredBackend? preferredBackend,
+  }) async {
+    // Fail loud at the seam (same stance as fromHuggingFace): an empty repo
+    // would otherwise become a URL that 404s far downstream.
+    if (repo.trim().isEmpty) {
+      throw ArgumentError.value(repo, 'repo', 'must be a non-empty "org/name"');
+    }
+
+    // The revision is one path segment (a slash-bearing ref like `refs/pr/1`
+    // must be percent-encoded on Hugging Face `/resolve/` paths) — same rule
+    // as the vendored reader's Resolution.url.
+    final rev = Uri.encodeComponent(revision);
+    final manifestUrl = Uri.parse(
+      'https://huggingface.co/$repo/resolve/$rev/litertlm_manifest.json',
+    );
+    // The URL is always huggingface.co (built two lines up), so the token —
+    // core passes its configured HF token by default — is safe to attach.
+    final headers = <String, String>{
+      if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+    };
+
+    String body;
+    try {
+      body = await (fetch ?? defaultManifestFetch)(manifestUrl, headers);
+    } on ManifestFetchException catch (e) {
+      // Measured Hugging Face behaviour: a PUBLIC repo missing the file is a
+      // real 404, but an unauthenticated request to a gated, private, or
+      // NONEXISTENT repo is answered 401 (repo existence is not revealed) —
+      // so each gets its own guidance.
+      switch (e.statusCode) {
+        case 404:
+          throw ManifestFetchException(
+            manifestUrl,
+            '"$repo" does not ship a litertlm_manifest.json at revision '
+            '"$revision". Install a specific file instead: '
+            'installModel(...).fromHuggingFace(repo, file: ...).',
+            statusCode: 404,
+          );
+        case 401:
+          throw ManifestFetchException(
+            manifestUrl,
+            'Hugging Face answered 401 for "$repo" — it does that for gated '
+            'and private repos without a valid token, and for repo ids that '
+            'do not exist. Pass a token '
+            '(FlutterGemma.initialize(huggingFaceToken:) or '
+            'resolveHuggingFace(token:)), or check the repo id.',
+            statusCode: 401,
+          );
+        case 403:
+          throw ManifestFetchException(
+            manifestUrl,
+            'Hugging Face rejected the token for "$repo" (403). A gated repo '
+            'also needs its license accepted on huggingface.co first.',
+            statusCode: 403,
+          );
+        default:
+          rethrow;
+      }
+    }
+
+    final LitertlmManifest manifest;
+    final Map<String, dynamic> rawModel;
+    try {
+      final decoded = jsonDecode(body) as Map<String, dynamic>;
+      manifest = LitertlmManifest.fromJson(decoded, revision: revision);
+      rawModel = decoded['model'] as Map<String, dynamic>? ?? const {};
+    } on FormatException {
+      rethrow;
+    } catch (e) {
+      // TypeError from a malformed field — surface as the same parse-error
+      // family instead of an opaque cast failure.
+      throw FormatException('malformed litertlm_manifest.json in "$repo": $e');
+    }
+
+    // Core sends 'unknown' for hosts outside its documented set; the
+    // manifest vocabulary has no such platform, so treat it as "no hint"
+    // rather than a key that can never match a recommendation.
+    final platformKey = platform == 'unknown' ? null : platform;
+    final requestedBackend = _wireName(preferredBackend);
+    var resolution = manifest.resolve(
+      platform: platformKey,
+      backend: requestedBackend,
+      // v1 resolves on platform only: `device_class` values in published
+      // manifests are free strings with no defined vocabulary, and
+      // flutter_gemma has no device-class detection to feed one from.
+    );
+    if (resolution == null) {
+      // Only an explicit backend request can filter to nothing: the spec's
+      // resolution rule makes it a filter, and the reader returns null rather
+      // than substituting a backend the caller didn't ask for. At this seam
+      // [preferredBackend] is a hint (core's contract: prefer it "when the
+      // metadata lists it"), so drop it and resolve without — the returned
+      // runtime.preferredBackend then carries the manifest's own choice,
+      // never a silent claim of the requested backend.
+      gemmaLog(
+        '[LitertlmManifestResolver] no variant of $repo is verified on '
+        '"$requestedBackend" — dropping the backend hint.',
+      );
+      // Never null without a backend filter: a parsed manifest has >= 1
+      // variant and every variant >= 1 backend.
+      resolution = manifest.resolve(platform: platformKey)!;
+    }
+
+    gemmaLog(
+      '[LitertlmManifestResolver] $repo → ${resolution.file} '
+      '(${resolution.backend}; ${resolution.reason})',
+    );
+
+    return ResolvedHfModel(
+      file: resolution.file,
+      url: _fileUrl(repo, resolution.file),
+      fileType: ModelFileType.litertlm,
+      modelType: mapModelType(
+        baseModel: rawModel['base_model'] as String? ?? '',
+        displayName: manifest.displayName,
+        architecture: rawModel['architecture'] as String? ?? '',
+      ),
+      sha256: resolution.variant.sha256,
+      sizeBytes: resolution.variant.sizeBytes,
+      runtime: ModelRuntimeDefaults(
+        maxTokens: resolution.contextLength,
+        preferredBackend: _fromWireName(resolution.backend, repo),
+        supportImage: resolution.capabilities.vision,
+        supportAudio: resolution.capabilities.audio,
+        isThinking: resolution.capabilities.thinkingDeclared,
+        minOutputTokens: _minOutputTokens(resolution.sessionDefaults),
+      ),
+      notes: List.unmodifiable([
+        ...resolution.notes,
+        // `session_defaults` is an open object; its optional `notes` string is
+        // curated guidance (e.g. why a reasoning model needs the output
+        // floor) — surface it with the platform notes.
+        if (resolution.sessionDefaults?['notes'] is String)
+          resolution.sessionDefaults!['notes'] as String,
+      ]),
+    );
+  }
+
+  /// `…/resolve/<revision>/<file>`, every segment encoded independently so a
+  /// repo that nests variants in subfolders keeps its path structure — same
+  /// rule as core's `fromHuggingFace`. The revision is a single segment.
+  String _fileUrl(String repo, String file) {
+    final encoded = file.split('/').map(Uri.encodeComponent).join('/');
+    return 'https://huggingface.co/$repo/resolve/'
+        '${Uri.encodeComponent(revision)}/$encoded';
+  }
+
+  String? _wireName(PreferredBackend? backend) => switch (backend) {
+    null => null,
+    PreferredBackend.cpu => 'cpu',
+    PreferredBackend.gpu => 'gpu',
+    PreferredBackend.npu => 'npu',
+  };
+
+  PreferredBackend? _fromWireName(String backend, String repo) {
+    switch (backend) {
+      case 'cpu':
+        return PreferredBackend.cpu;
+      case 'gpu':
+        return PreferredBackend.gpu;
+      case 'npu':
+        return PreferredBackend.npu;
+      default:
+        // A backend name this plugin has no enum for (schema `backends` is
+        // open). Null = "manifest is silent" — the SDK default applies.
+        gemmaLog(
+          '[LitertlmManifestResolver] $repo recommends backend "$backend", '
+          'which flutter_gemma has no PreferredBackend for — leaving the '
+          'backend to the SDK default.',
+        );
+        return null;
+    }
+  }
+
+  /// `session_defaults.max_output_tokens_min`, tolerantly: the schema
+  /// declares `session_defaults` as an open object, so the key is read by
+  /// name, must be an int, and anything else means "not declared".
+  int? _minOutputTokens(Map<String, dynamic>? sessionDefaults) {
+    final v = sessionDefaults?['max_output_tokens_min'];
+    return v is int ? v : null;
+  }
+
+  /// Maps the manifest's model identity onto a [ModelType], or null when no
+  /// mapping is certain — the app then supplies one (`r.modelType ??
+  /// ModelType.general`).
+  ///
+  /// Deliberately conservative: on iOS `.litertlm` chats are formatted
+  /// manually by [ModelType] (Android/desktop read the template from the
+  /// bundle), so a wrong guess breaks conversations there. The manifest's
+  /// `architecture` is free prose that names *compute* lineage — e.g.
+  /// granite-docling says "Llama-architecture granite decoder", which must NOT
+  /// become [ModelType.llama] — so family words match only the curated
+  /// `base_model` + `display_name` ids, and `architecture` is consulted for
+  /// exactly two machine-precise `*ForCausalLM` class tokens (they catch
+  /// finetunes whose ids drop the family name, e.g. an ASR normalizer built
+  /// on Qwen3).
+  ///
+  /// Qwen3.5 maps to [ModelType.qwen], not `qwen3`: same ChatML handling,
+  /// but `qwen3` also appends ` /no_think` to user turns when thinking is
+  /// off, which Qwen3.5 does not understand and would read as literal text.
+  @visibleForTesting
+  static ModelType? mapModelType({
+    required String baseModel,
+    required String displayName,
+    required String architecture,
+  }) {
+    final id = '$baseModel $displayName'.toLowerCase();
+    final arch = architecture.toLowerCase();
+    if (id.contains('deepseek')) return ModelType.deepSeek;
+    if (id.contains('functiongemma') ||
+        id.contains('function-gemma') ||
+        id.contains('function_gemma')) {
+      return ModelType.functionGemma;
+    }
+    // The lookahead keeps size-suffixed ids ("gemma-4b") out of gemma4 —
+    // that enum value is the Gemma 4 E2B/E4B generation, not a 4B Gemma 3.
+    if (RegExp(r'gemma[ _-]?4(?![0-9b])').hasMatch(id)) {
+      return ModelType.gemma4;
+    }
+    if (id.contains('gemma')) return ModelType.gemmaIt;
+    if (id.contains('qwen3.5')) return ModelType.qwen;
+    if (id.contains('qwen3') || arch.contains('qwen3forcausallm')) {
+      return ModelType.qwen3;
+    }
+    if (id.contains('qwen') || arch.contains('qwen2forcausallm')) {
+      return ModelType.qwen;
+    }
+    if (RegExp(r'(^|[^a-z])phi[ _-]?\d').hasMatch(id)) return ModelType.phi;
+    if (RegExp(r'(^|[^a-z])llama').hasMatch(id)) return ModelType.llama;
+    return null;
+  }
+}

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest_resolver.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest_resolver.dart
@@ -42,7 +42,9 @@ export 'manifest_fetch_types.dart' show ManifestFetch, ManifestFetchException;
 /// final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
 /// final session = await model.createSession(
 ///   enableThinking: r.runtime.isThinking ?? false,
-///   maxOutputTokens: r.runtime.minOutputTokens,
+///   // minOutputTokens is a FLOOR, not a cap: keep the app's own budget
+///   // unless the manifest asks for more (`max` from dart:math).
+///   maxOutputTokens: max(1024, r.runtime.minOutputTokens ?? 0),
 /// );
 /// ```
 ///
@@ -50,7 +52,8 @@ export 'manifest_fetch_types.dart' show ManifestFetch, ManifestFetchException;
 /// (HTTP 404 — install with `fromHuggingFace(repo, file:)` instead), when
 /// auth is missing or rejected (401/403 carry gated-repo guidance), or the
 /// GET fails otherwise; and [FormatException] when the file exists but is
-/// not a supported `0.1.x` manifest.
+/// not a supported `0.1.x` manifest — including any wrong-typed field, which
+/// never escapes as a raw `TypeError`.
 class LitertlmManifestResolver implements HuggingFaceResolver {
   /// Git revision (branch, tag, or commit) the manifest AND the resolved file
   /// URL are pinned to. Defaults to `main`; pin a commit for reproducible
@@ -144,11 +147,22 @@ class LitertlmManifestResolver implements HuggingFaceResolver {
     }
 
     final LitertlmManifest manifest;
-    final Map<String, dynamic> rawModel;
+    final String baseModel;
+    final String architecture;
+    final bool capabilitiesDeclared;
     try {
       final decoded = jsonDecode(body) as Map<String, dynamic>;
       manifest = LitertlmManifest.fromJson(decoded, revision: revision);
-      rawModel = decoded['model'] as Map<String, dynamic>? ?? const {};
+      // Every raw field the mapping reads is read HERE, so a wrong-typed one
+      // (`"base_model": 3`) is a parse error like any other rather than a
+      // TypeError thrown later from the mapping.
+      final rawModel = decoded['model'] as Map<String, dynamic>? ?? const {};
+      baseModel = rawModel['base_model'] as String? ?? '';
+      architecture = rawModel['architecture'] as String? ?? '';
+      // The converter derives `capabilities` from the bundle header, so a
+      // manifest without the block never looked: that is "silent", which the
+      // seam spells `null` — not "declared unsupported", which is `false`.
+      capabilitiesDeclared = rawModel['capabilities'] != null;
     } on FormatException {
       rethrow;
     } catch (e) {
@@ -162,6 +176,7 @@ class LitertlmManifestResolver implements HuggingFaceResolver {
     // rather than a key that can never match a recommendation.
     final platformKey = platform == 'unknown' ? null : platform;
     final requestedBackend = _wireName(preferredBackend);
+    String? droppedHint;
     var resolution = manifest.resolve(
       platform: platformKey,
       backend: requestedBackend,
@@ -177,6 +192,7 @@ class LitertlmManifestResolver implements HuggingFaceResolver {
       // metadata lists it"), so drop it and resolve without — the returned
       // runtime.preferredBackend then carries the manifest's own choice,
       // never a silent claim of the requested backend.
+      droppedHint = requestedBackend;
       gemmaLog(
         '[LitertlmManifestResolver] no variant of $repo is verified on '
         '"$requestedBackend" — dropping the backend hint.',
@@ -196,19 +212,25 @@ class LitertlmManifestResolver implements HuggingFaceResolver {
       url: _fileUrl(repo, resolution.file),
       fileType: ModelFileType.litertlm,
       modelType: mapModelType(
-        baseModel: rawModel['base_model'] as String? ?? '',
+        baseModel: baseModel,
         displayName: manifest.displayName,
-        architecture: rawModel['architecture'] as String? ?? '',
+        architecture: architecture,
       ),
       sha256: resolution.variant.sha256,
       sizeBytes: resolution.variant.sizeBytes,
       runtime: ModelRuntimeDefaults(
         maxTokens: resolution.contextLength,
         preferredBackend: _fromWireName(resolution.backend, repo),
-        supportImage: resolution.capabilities.vision,
-        supportAudio: resolution.capabilities.audio,
-        isThinking: resolution.capabilities.thinkingDeclared,
-        minOutputTokens: _minOutputTokens(resolution.sessionDefaults),
+        supportImage: capabilitiesDeclared
+            ? resolution.capabilities.vision
+            : null,
+        supportAudio: capabilitiesDeclared
+            ? resolution.capabilities.audio
+            : null,
+        isThinking: capabilitiesDeclared
+            ? resolution.capabilities.thinkingDeclared
+            : null,
+        minOutputTokens: _minOutputTokens(resolution.sessionDefaults, repo),
       ),
       notes: List.unmodifiable([
         ...resolution.notes,
@@ -217,6 +239,12 @@ class LitertlmManifestResolver implements HuggingFaceResolver {
         // floor) — surface it with the platform notes.
         if (resolution.sessionDefaults?['notes'] is String)
           resolution.sessionDefaults!['notes'] as String,
+        // A dropped backend hint is a downgrade the app should see in a
+        // release build too (gemmaLog is debug-only), so it also lands in the
+        // notes the app already surfaces.
+        if (droppedHint != null)
+          'No variant of "$repo" is verified on the requested $droppedHint '
+              'backend; resolved without that hint (${resolution.backend}).',
       ]),
     );
   }
@@ -259,10 +287,19 @@ class LitertlmManifestResolver implements HuggingFaceResolver {
 
   /// `session_defaults.max_output_tokens_min`, tolerantly: the schema
   /// declares `session_defaults` as an open object, so the key is read by
-  /// name, must be an int, and anything else means "not declared".
-  int? _minOutputTokens(Map<String, dynamic>? sessionDefaults) {
+  /// name. A value outside the schema's `integer, minimum: 1` is logged and
+  /// treated as "not declared" — an advisory knob must not fail the whole
+  /// manifest.
+  int? _minOutputTokens(Map<String, dynamic>? sessionDefaults, String repo) {
     final v = sessionDefaults?['max_output_tokens_min'];
-    return v is int ? v : null;
+    if (v == null) return null;
+    if (v is int && v >= 1) return v;
+    gemmaLog(
+      '[LitertlmManifestResolver] $repo declares '
+      'session_defaults.max_output_tokens_min = $v, which is not a positive '
+      'integer (schema: integer, minimum 1) — ignoring it.',
+    );
+    return null;
   }
 
   /// Maps the manifest's model identity onto a [ModelType], or null when no

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_io.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_io.dart
@@ -18,15 +18,30 @@ Future<String> defaultManifestFetch(
     final request = await client.getUrl(url);
     headers.forEach(request.headers.set);
     final response = await request.close();
-    final body = await response.transform(utf8.decoder).join();
-    if (response.statusCode != HttpStatus.ok) {
+    final status = response.statusCode;
+    // Status before body: an error page's bytes are not the signal, and one
+    // that fails to decode must not turn a 404 into a status-less failure.
+    // Any 2xx is success, as on web (`Response.ok`).
+    if (status < 200 || status >= 300) {
+      try {
+        // Consume the error body so the connection is released; the bytes
+        // themselves are irrelevant.
+        await response.drain<void>();
+      } catch (_) {
+        // A body that cannot even be read changes nothing: the status is
+        // the answer, and the client is closed below.
+      }
       throw ManifestFetchException(
         url,
-        'GET failed with HTTP ${response.statusCode}',
-        statusCode: response.statusCode,
+        'GET failed with HTTP $status',
+        statusCode: status,
       );
     }
-    return body;
+    // Decode with replacement, as the browser's `Response.text()` does, so
+    // both arms hand the parser the same body for the same bytes.
+    return await response
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
   } on ManifestFetchException {
     rethrow;
   } on Exception catch (e) {

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_io.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_io.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'manifest_fetch_types.dart';
+
+/// Default manifest GET on `dart:io` platforms.
+///
+/// A plain [HttpClient] — deliberately not the plugin's model-download stack
+/// (background_downloader is sized for multi-GB files, not a few KB of JSON).
+/// [HttpClient] follows redirects for GET by default, which matters here:
+/// Hugging Face answers `/resolve/` paths with a 307 to its CDN.
+Future<String> defaultManifestFetch(
+  Uri url,
+  Map<String, String> headers,
+) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(url);
+    headers.forEach(request.headers.set);
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+    if (response.statusCode != HttpStatus.ok) {
+      throw ManifestFetchException(
+        url,
+        'GET failed with HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    return body;
+  } on ManifestFetchException {
+    rethrow;
+  } on Exception catch (e) {
+    throw ManifestFetchException(url, 'GET failed: $e');
+  } finally {
+    client.close();
+  }
+}

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_types.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_types.dart
@@ -4,8 +4,10 @@
 /// `manifest_fetch_io.dart` / `manifest_fetch_web.dart`.
 ///
 /// Contract: follow redirects (Hugging Face answers `/resolve/` paths with a
-/// 307 to its CDN), send [headers] verbatim, return the body on HTTP 200, and
-/// throw [ManifestFetchException] on any other status.
+/// 307 to its CDN), send [headers] verbatim, return the body on any 2xx, and
+/// throw [ManifestFetchException] carrying the status on any other status —
+/// check the status before touching the body, so an unreadable error page
+/// never loses it.
 typedef ManifestFetch =
     Future<String> Function(Uri url, Map<String, String> headers);
 

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_types.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_types.dart
@@ -1,0 +1,25 @@
+/// A GET returning the response body as text. [LitertlmManifestResolver]
+/// accepts one so tests (and apps with their own HTTP stack, proxies, or
+/// timeout policy) can replace the default; the defaults live in
+/// `manifest_fetch_io.dart` / `manifest_fetch_web.dart`.
+///
+/// Contract: follow redirects (Hugging Face answers `/resolve/` paths with a
+/// 307 to its CDN), send [headers] verbatim, return the body on HTTP 200, and
+/// throw [ManifestFetchException] on any other status.
+typedef ManifestFetch =
+    Future<String> Function(Uri url, Map<String, String> headers);
+
+/// A manifest GET that failed — carries the status so the resolver can tell
+/// "repo ships no manifest" (404) apart from auth/network trouble.
+class ManifestFetchException implements Exception {
+  final Uri url;
+  final int? statusCode;
+  final String message;
+
+  const ManifestFetchException(this.url, this.message, {this.statusCode});
+
+  @override
+  String toString() =>
+      'ManifestFetchException'
+      '${statusCode != null ? " (HTTP $statusCode)" : ""}: $message [$url]';
+}

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_web.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/manifest_fetch_web.dart
@@ -1,0 +1,49 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'manifest_fetch_types.dart';
+
+/// Default manifest GET on web: the browser's `fetch`, same interop shape as
+/// core's `WebJsInterop`. The browser follows the Hugging Face `/resolve/` 307
+/// itself; `huggingface.co` serves CORS headers on these endpoints (the web
+/// model-download path relies on that already).
+Future<String> defaultManifestFetch(
+  Uri url,
+  Map<String, String> headers,
+) async {
+  final options = JSObject();
+  if (headers.isNotEmpty) {
+    final jsHeaders = JSObject();
+    headers.forEach((k, v) => jsHeaders.setProperty(k.toJS, v.toJS));
+    options.setProperty('headers'.toJS, jsHeaders);
+  }
+  _Response response;
+  try {
+    response =
+        (await _fetchJs(url.toString().toJS, options).toDart) as _Response;
+  } catch (e) {
+    throw ManifestFetchException(url, 'GET failed: $e');
+  }
+  final status = response.status.toDartInt;
+  if (!response.ok.toDart) {
+    throw ManifestFetchException(
+      url,
+      'GET failed with HTTP $status',
+      statusCode: status,
+    );
+  }
+  try {
+    return (await response.text().toDart).toDart;
+  } catch (e) {
+    throw ManifestFetchException(url, 'reading response body failed: $e');
+  }
+}
+
+@JS('fetch')
+external JSPromise<JSAny> _fetchJs(JSString url, JSAny options);
+
+extension type _Response(JSObject _) implements JSObject {
+  external JSBoolean get ok;
+  external JSNumber get status;
+  external JSPromise<JSString> text();
+}

--- a/packages/flutter_gemma_litertlm/pubspec.yaml
+++ b/packages/flutter_gemma_litertlm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma_litertlm
 description: "LiteRT-LM (.litertlm) on-device inference engine for flutter_gemma via dart:ffi (5 native platforms) + web. Opt-in InferenceEngineProvider. Also ships the LiteRT C API embedding backend (LiteRtEmbeddingBackend)."
-version: 1.5.3
+version: 1.6.0
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/flutter_gemma_litertlm
 topics: [gemma, llm, litert, on-device, ffi]

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/README.md
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/README.md
@@ -1,0 +1,17 @@
+# Shipped-manifest fixtures
+
+Snapshots of every live `litertlm_manifest.json` the
+[hf-to-litertlm](https://github.com/john-rocky/hf-to-litertlm) converter had
+shipped as of 2026-08-27 — 21 repos, 35 variants. The regression sweep in
+`../shipped_manifests_regression_test.dart` runs the resolver over all of them,
+so the resolver is tested against the real published data, not just synthetic
+shapes.
+
+Regenerate (the dataset-shape counts in the sweep test then need updating):
+
+```sh
+for repo in $(ls *.json | sed 's/__/\//; s/\.json//'); do
+  curl -sL "https://huggingface.co/$repo/resolve/main/litertlm_manifest.json" \
+    -o "$(echo "$repo" | sed 's/\//__/').json"
+done
+```

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__DeepSeek-R1-Distill-Qwen-7B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__DeepSeek-R1-Distill-Qwen-7B.json
@@ -1,0 +1,95 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/DeepSeek-R1-Distill-Qwen-7B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "DeepSeek-R1-Distill-Qwen-7B",
+    "base_model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "architecture": "Qwen2 dense decoder (Qwen2ForCausalLM, shallow-wide 28 layers); reasoning model that emits a <think>...</think> chain before the answer",
+    "parameters_b": 7,
+    "license": "mit",
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Reasoning model emitting a <think>...</think> chain before the answer; the card's GSM8K accuracy run uses max_new_tokens=2048 to fit the reasoning chain."
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "DeepSeek-R1-Distill-Qwen-7B_q4_block32_ekv4096.litertlm",
+      "sha256": "8eb98a628709eb02e31c2880fc4d2e2b78746f289bd6ffaf373a142412a54502",
+      "size_bytes": 4531978224,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 566
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2142167
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 3981133856,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 548650992,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "int4 weights - blockwise (block 32) + OCTAV optimal-clipping, symmetric; embedding INT8",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "Desktop (Mac) and high-RAM (12 GB+) Android only; iPhone / 8 GB phones are excluded - at ~4.2-4.5 GB the build exceeds the budget and its weights section exceeds the iOS mmap budget, so there is no on-device row"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 64,
+          "decode_tps": 18.2,
+          "ttft_s": 4.69,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 644,
+          "decode_tps": 65.9,
+          "ttft_s": 0.43,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-1.2B-Instruct.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-1.2B-Instruct.json
@@ -1,0 +1,235 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/LFM2.5-1.2B-Instruct",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "LFM2.5-1.2B-Instruct",
+    "base_model": "LiquidAI/LFM2.5-1.2B-Instruct",
+    "architecture": "lfm2-hybrid (short-conv + attention)",
+    "parameters_b": 1.2,
+    "license": "see LICENSE file in repo",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "LFM2.5-1.2B-Instruct_int4.litertlm",
+      "sha256": "a28b5c59ac204e2e51c1f98d2d6db6982f0e12da59a268fe498edcb33237e906",
+      "size_bytes": 736015744,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 735049088,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "dynamic int4 block-32 linears, fp32 activations (CPU-lineage export)",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "min_runtime_version": "0.15.0",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "midrange",
+          "backend": "cpu",
+          "reason": "on phone-class memory bandwidth int4 decodes ~1.7x faster than int8 and is 41% smaller"
+        },
+        {
+          "platform": "ios",
+          "backend": "cpu",
+          "reason": "iOS CPU is the verified path for this family"
+        }
+      ],
+      "known_issues": [
+        "This export lineage emits INT64 ops + GATHER_ND in the short-conv patch: GPU engine creation fails — use the _int4_gpu re-export for GPU backends"
+      ]
+    },
+    {
+      "file": "LFM2.5-1.2B-Instruct_int4_gpu.litertlm",
+      "sha256": "36f7f0221bcc42c75291da1d7e3422901024a5b06b9bfa3c02d7feface04f70a",
+      "size_bytes": 736220768,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 735254112,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "dynamic int4 block-32 linears, fp32 activations; GPU-capable re-export (no INT64/GATHER_ND in the short-conv patch)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "min_runtime_version": "0.15.0",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "midrange-2023+",
+          "backend": "gpu",
+          "reason": "3-6x prefill and TTFT vs CPU on Tensor G3; decode is bandwidth-bound and roughly a wash"
+        },
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "~11x prefill, ~4x decode vs CPU on the same file"
+        },
+        {
+          "platform": "ios",
+          "backend": "cpu",
+          "reason": "the Metal GPU engine fails on this model family at runtime (tracked upstream); CPU is verified"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Large --max-num-tokens costs decode speed on this family (~-24% at 4096 vs 1024)",
+          "GPU backends keep a compiled-model cache (~2x model size) next to the model until the OS purges it"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0 (pip CLI benchmark)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 3765.0,
+          "decode_tps": 318.3,
+          "ttft_s": 0.071,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-12",
+          "source": "ship-lane Mac bench log; model card Performance table"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0 (pip CLI benchmark)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 337.0,
+          "decode_tps": 80.5,
+          "ttft_s": 0.77,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-12",
+          "source": "ship-lane Mac bench log; model card Performance table"
+        },
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "os": "Android",
+          "backend": "gpu",
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag (OpenCL)",
+          "prompt_tokens": 263,
+          "decode_tokens": 115,
+          "prefill_tps": "188.3-192.6",
+          "decode_tps": "21.0-21.2",
+          "ttft_s": "1.41-1.44",
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-12",
+          "source": "ship-lane Pixel 8a bench log; model card Performance table"
+        },
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "os": "Android",
+          "backend": "cpu",
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag",
+          "prompt_tokens": 263,
+          "decode_tokens": 205,
+          "prefill_tps": "38.2-53.9",
+          "decode_tps": "15.2-24.3",
+          "ttft_s": "4.9-7.0",
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-12",
+          "source": "ship-lane Pixel 8a bench log (CPU rows spread with thermal throttling); model card Performance table"
+        }
+      ],
+      "known_issues": [
+        "iPhone Metal: engine fails on this family at runtime (Mac WebGPU passes the same file) — use CPU on iOS; tracked upstream"
+      ]
+    },
+    {
+      "file": "LFM2.5-1.2B-Instruct_int8.litertlm",
+      "sha256": "e002a91545cec6328be2a86e9b8b4fccb2dd9dde7e6c8b29d730f915a0a697fe",
+      "size_bytes": 1247091440,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1246124784,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 linears only (wi8), fp32 activations (CPU-lineage export)",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "min_runtime_version": "0.15.0",
+      "recommended": [
+        {
+          "platform": "macos",
+          "backend": "cpu",
+          "reason": "highest-fidelity variant; on desktop CPU it prefills ~3x faster than int4 — pick it when quality outranks size"
+        }
+      ],
+      "known_issues": [
+        "Same CPU-lineage export as _int4: GPU engine creation fails on this file"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-1.2B-JP.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-1.2B-JP.json
@@ -1,0 +1,415 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/LFM2.5-1.2B-JP",
+  "generated": "2026-08-25",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "LFM2.5-1.2B-JP",
+    "base_model": "LiquidAI/LFM2.5-1.2B-JP",
+    "architecture": "Liquid AI hybrid conv-attention decoder (LFM2 ShortConv + attention); Japanese-optimized chat variant",
+    "parameters_b": 1.2,
+    "license": "other (lfm-open-license-v1.0, LFM Open License v1.0)",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "LFM2.5-1.2B-JP_int4.litertlm",
+      "sha256": "97909ba9e275470b69a202b506fa347a2b92dfef69ac7048f771e375319dee2e",
+      "size_bytes": 736015744,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 735049088,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int4 blockwise-32 + OCTAV linears, int8 embedding, convs float",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "midrange",
+          "backend": "cpu",
+          "reason": "~1.7x faster than int8 on a Pixel 8a CPU and 41% smaller"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.14 / a recent AI Edge Gallery; files were updated in place 2026-08-04 to add the ExecutorMetadata section litert-lm >= 0.15 requires (weights and graph byte-identical, still runs on 0.14)",
+          "In the Gallery select the CPU backend",
+          "First device load compiles the graph and can take about a minute; later loads are instant"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 387,
+          "decode_tps": 119.0,
+          "ttft_s": 0.67,
+          "max_num_tokens": 1024,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 340,
+          "decode_tps": 79.3,
+          "ttft_s": 0.76,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Cannot create a GPU engine: pre-0.9.2 ShortConv export carries INT64 ADD/CAST/SUM, GATHER_ND and a const-input GREATER_EQUAL; the GPU delegate takes 536 of 579 ops and the runtime refuses the partial split - use the CPU backend, or the _int4_gpu file for the same weights on GPU"
+      ],
+      "min_runtime_version": "0.14.0"
+    },
+    {
+      "file": "LFM2.5-1.2B-JP_int4_gpu.litertlm",
+      "sha256": "2c826a9cdeefc614c9b7de1d1c5565c9a64f704e5f3291ad2cd5d7da396790d5",
+      "size_bytes": 736220768,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 735254112,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "same int4 recipe and weights as the int4 file (int4 blockwise-32 + OCTAV linears, int8 embedding, convs float), re-exported with litert-torch 0.9.3 + litert-converter 0.3.1 so it runs on the GPU",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "midrange",
+          "backend": "gpu",
+          "reason": "3-6x the prefill and time-to-first-token of the same file on CPU; 41% smaller than int8_gpu and faster to decode, at 10 fewer GSM8K points"
+        },
+        {
+          "platform": "ios",
+          "backend": "gpu",
+          "reason": "verified by generation on an iPhone 17 Pro at maxNumTokens 1024 - decode 70.0 tok/s, peak ~560 MB"
+        }
+      ],
+      "requirements": {
+        "peak_ram_mb": 617,
+        "platform_notes": [
+          "GPU needs litert-lm >= 0.16.0 (verified by generation on Android OpenCL, macOS and iOS Metal, not just by a benchmark table); the Gallery bundles its own runtime which may lag that version - if its GPU toggle fails there, use CPU",
+          "On iOS Metal set maxNumTokens to 1024: the Metal delegate compiles kernels against the KV cache maxNumTokens pre-allocates, and a mismatched value fails engine creation with a shader-compile error",
+          "Delegates fully on Android OpenCL - 501/501 and 519/519 nodes, zero rejected ops",
+          "Includes the ExecutorMetadata section litert-lm >= 0.15 needs"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "backend": "gpu",
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag",
+          "prompt_tokens": 263,
+          "decode_tokens": 256,
+          "prefill_tps": "190-194",
+          "decode_tps": "19.8-21.2",
+          "ttft_s": "1.40-1.44",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Galaxy S26 (SM-S942Q, SM8850, Adreno)",
+          "backend": "gpu",
+          "runtime": "litert_lm_advanced_main, litert-lm v0.16.0 release kit",
+          "prompt_tokens": 205,
+          "prefill_tps": 919.0,
+          "decode_tps": 54.63,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 2,
+          "date": "2026-08-24",
+          "source": "GPU gate sweep of the shipped catalog on this device"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.16.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 3682,
+          "decode_tps": 316.0,
+          "ttft_s": 0.07,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "gpu",
+          "runtime": "litert-lm v0.16.0 xcframework",
+          "decode_tps": 70.0,
+          "ttft_s": 0.091,
+          "max_num_tokens": 1024,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card iPhone section; single run, device charging, short prompt"
+        }
+      ],
+      "min_runtime_version": "0.16.0"
+    },
+    {
+      "file": "LFM2.5-1.2B-JP_int8.litertlm",
+      "sha256": "8fc5367c35a4771cb60784a86be5eb1f358e94cc71eb2eaf15ad006205339001",
+      "size_bytes": 1244594224,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1243627568,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic (linears + embedding; convs float)",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.14 / a recent AI Edge Gallery; files were updated in place 2026-08-04 to add the ExecutorMetadata section litert-lm >= 0.15 requires (weights and graph byte-identical, still runs on 0.14)",
+          "In the Gallery select the CPU backend",
+          "First device load compiles the graph and can take about a minute; later loads are instant"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1526,
+          "decode_tps": 98.5,
+          "ttft_s": 0.18,
+          "max_num_tokens": 1024,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1071,
+          "decode_tps": 82.5,
+          "ttft_s": 0.25,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Cannot create a GPU engine: pre-0.9.2 ShortConv export carries INT64 ADD/CAST/SUM, GATHER_ND and a const-input GREATER_EQUAL; the GPU delegate takes 536 of 579 ops and the runtime refuses the partial split - use the CPU backend, or the _int8_gpu file for the same weights on GPU"
+      ],
+      "min_runtime_version": "0.14.0"
+    },
+    {
+      "file": "LFM2.5-1.2B-JP_int8_gpu.litertlm",
+      "sha256": "1316b5381a45f01b1a06da6ebe1a99bb55b430653e6a7ee19d50a6d0ad01d869",
+      "size_bytes": 1244763648,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1243796992,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "same int8 recipe and weights as the int8 file (post-hoc int8 on FULLY_CONNECTED + channelwise EMBEDDING_LOOKUP; convs left float), re-exported with litert-torch 0.9.3 + litert-converter 0.3.1 so it runs on the GPU",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "flagship",
+          "backend": "gpu",
+          "reason": "delegates fully on Adreno OpenCL and is 10 GSM8K points more accurate than the int4_gpu file; choose int4_gpu instead when decode speed or the 41% smaller download matters more"
+        },
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "~10x the prefill and ~3.4x the decode of the same file on CPU"
+        }
+      ],
+      "requirements": {
+        "peak_ram_mb": 571,
+        "platform_notes": [
+          "GPU needs litert-lm >= 0.16.0, verified by generation (not merely by a benchmark table) on Adreno OpenCL and macOS Metal; the Gallery bundles its own runtime which may lag that version - if its GPU toggle fails there, use CPU",
+          "Delegates fully on Adreno OpenCL - 542/542 nodes across all ten prefill signatures, 501/501 prefill_1 and 519/519 decode, zero rejected ops",
+          "Includes the ExecutorMetadata section litert-lm >= 0.15 needs",
+          "Not gated on iOS Metal; the sibling _int4_gpu file of the same export lineage is iPhone-verified at maxNumTokens 1024, but that measurement does not transfer to this file"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Galaxy S26 (SM-S942Q, SM8850, Adreno)",
+          "backend": "gpu",
+          "runtime": "litert_lm_advanced_main, litert-lm v0.16.0 release kit",
+          "prompt_tokens": 205,
+          "decode_tokens": 108,
+          "prefill_tps": "940.4-978.8",
+          "decode_tps": "41.9-41.9",
+          "ttft_s": "0.23-0.24",
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 2,
+          "date": "2026-08-25",
+          "source": "device gate log, 205-token prompt file with --benchmark and no token-count flags"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.16.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 3708.1,
+          "decode_tps": 248.2,
+          "ttft_s": 0.073,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "cardbench harness, idle machine"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 4626.7,
+          "decode_tps": 271.9,
+          "ttft_s": 0.059,
+          "max_num_tokens": 1024,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "cardbench harness, idle machine"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 409.7,
+          "decode_tps": 85.5,
+          "ttft_s": 0.637,
+          "max_num_tokens": 1024,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "cardbench harness, idle machine"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 364.8,
+          "decode_tps": 71.1,
+          "ttft_s": 0.716,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "cardbench harness, idle machine"
+        }
+      ],
+      "min_runtime_version": "0.16.0"
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-1.2B-Thinking.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-1.2B-Thinking.json
@@ -1,0 +1,430 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/LFM2.5-1.2B-Thinking",
+  "generated": "2026-08-25",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "LFM2.5-1.2B-Thinking",
+    "base_model": "LiquidAI/LFM2.5-1.2B-Thinking",
+    "architecture": "Liquid AI hybrid conv-attention decoder (LFM2 ShortConv + attention); reasoning variant that works problems inside <think>...</think>, thought channel declared in bundle metadata",
+    "parameters_b": 1.2,
+    "license": "other (lfm-open-license-v1.0, LFM Open License v1.0)",
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Card: give it a generous token budget (>=2048) - a reasoning model truncated mid-thought produces no final answer; Gallery guidance is to set max tokens high (2048-4096), and size --max-num-tokens so thinking turns complete."
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "LFM2.5-1.2B-Thinking_int4.litertlm",
+      "sha256": "f4f091503ef33c9ad70e2a58f9cbad03a71b3d4d9fe4266b684e8889ec371669",
+      "size_bytes": 736015744,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 735049088,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int4 blockwise-32 + OCTAV linears, int8 embedding, convs float",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "midrange",
+          "backend": "cpu",
+          "reason": "~1.7x faster than int8 on a Pixel 8a CPU and 41% smaller"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.14 / a recent AI Edge Gallery; files were updated in place 2026-08-04 to add the ExecutorMetadata section litert-lm >= 0.15 requires (weights and graph byte-identical, still runs on 0.14)",
+          "In the Gallery select the CPU backend and set max tokens high (2048-4096)",
+          "First device load compiles the graph and can take about a minute; later loads are instant"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 386,
+          "decode_tps": 118.9,
+          "ttft_s": 0.67,
+          "max_num_tokens": 1024,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 342,
+          "decode_tps": 77.4,
+          "ttft_s": 0.76,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Cannot create a GPU engine: pre-0.9.2 ShortConv export carries INT64 ADD/CAST, GATHER_ND and a const-input GREATER_EQUAL; the GPU delegate takes 536 of 579 ops and the runtime refuses the partial split - use the CPU backend (the _int4_gpu file is the GPU re-export)",
+        "Multi-turn conversations on litert-lm >= 0.15 can drift: context retains previous turns' <think> reasoning while the model was trained with it stripped (observed at turn 3 of a 3-turn probe); start a fresh conversation per task"
+      ],
+      "min_runtime_version": "0.14.0"
+    },
+    {
+      "file": "LFM2.5-1.2B-Thinking_int4_gpu.litertlm",
+      "sha256": "75408d4047f15f054403e3d29826b2324c4b8709648c99221daab571f70a6bfd",
+      "size_bytes": 736220768,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 735254112,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "same int4 recipe and weights as the int4 file (int4 blockwise-32 + OCTAV linears, int8 embedding, convs float), re-exported with litert-torch 0.9.3 + litert-converter 0.3.1 so it runs on the GPU",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "GPU needs litert-lm >= 0.16.0 (verified by generation on Android OpenCL and macOS, not just by a benchmark table); the Gallery bundles its own runtime which may lag that version - if its GPU toggle fails there, use CPU",
+          "On iOS Metal set maxNumTokens to 1024; for a thinking model budget the context so the thinking phase completes",
+          "Delegates fully on Android OpenCL - 501/501 and 519/519 nodes, zero rejected ops",
+          "Includes the ExecutorMetadata section litert-lm >= 0.15 needs"
+        ],
+        "peak_ram_mb": 618
+      },
+      "measured": [
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "backend": "gpu",
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag",
+          "prompt_tokens": 263,
+          "decode_tokens": 256,
+          "prefill_tps": "189-192",
+          "decode_tps": "21.8-22.4",
+          "ttft_s": "1.41-1.44",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "backend": "cpu",
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag",
+          "prompt_tokens": 263,
+          "decode_tokens": 256,
+          "prefill_tps": "31.3-31.7",
+          "decode_tps": "16.3-16.7",
+          "ttft_s": "8.4-8.5",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.16.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 3734,
+          "decode_tps": 317.9,
+          "ttft_s": 0.07,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.16.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 334.4,
+          "decode_tps": 79.2,
+          "ttft_s": 0.78,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "gpu",
+          "runtime": "litert-lm v0.16.0 xcframework",
+          "decode_tps": 69.7,
+          "max_num_tokens": 1024,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card iPhone section; single run, device charging, TTFT 6.5 s including the thinking phase"
+        },
+        {
+          "device": "Galaxy S26 (SM-S942Q, SM8850, Adreno)",
+          "backend": "gpu",
+          "runtime": "litert_lm_advanced_main, litert-lm v0.16.0 release kit",
+          "prompt_tokens": 205,
+          "prefill_tps": 1020.4,
+          "decode_tps": 48.14,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 2,
+          "date": "2026-08-24",
+          "source": "GPU gate sweep of the shipped catalog on this device"
+        }
+      ],
+      "known_issues": [
+        "iOS Metal needs maxNumTokens set to 1024: the Metal delegate compiles kernels against the KV cache maxNumTokens pre-allocates, and a mismatched value fails engine creation with a shader-compile error (this is what LiteRT-LM#3129 turned out to be - integration-side sizing, not a runtime bug)",
+        "Multi-turn conversations on litert-lm >= 0.15 can drift: context retains previous turns' <think> reasoning while the model was trained with it stripped; start a fresh conversation per task"
+      ],
+      "min_runtime_version": "0.16.0",
+      "recommended": [
+        {
+          "platform": "ios",
+          "backend": "gpu",
+          "reason": "verified by generation on an iPhone 17 Pro at maxNumTokens 1024 - decode 69.7 tok/s, peak ~680 MB"
+        }
+      ]
+    },
+    {
+      "file": "LFM2.5-1.2B-Thinking_int8.litertlm",
+      "sha256": "91c044a117066c16e4e318ffc0ac0b2976b4a0af7fbd464054589c34e9220b28",
+      "size_bytes": 1244594224,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1243627568,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic (linears + embedding; convs float)",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.14 / a recent AI Edge Gallery; files were updated in place 2026-08-04 to add the ExecutorMetadata section litert-lm >= 0.15 requires (weights and graph byte-identical, still runs on 0.14)",
+          "In the Gallery select the CPU backend and set max tokens high (2048-4096)",
+          "First device load compiles the graph and can take about a minute; later loads are instant"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1536,
+          "decode_tps": 98.8,
+          "ttft_s": 0.18,
+          "max_num_tokens": 1024,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1121,
+          "decode_tps": 83.2,
+          "ttft_s": 0.24,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Cannot create a GPU engine: pre-0.9.2 ShortConv export carries INT64 ADD/CAST, GATHER_ND and a const-input GREATER_EQUAL; the GPU delegate takes 536 of 579 ops and the runtime refuses the partial split - use the CPU backend, or the _int8_gpu file for the same weights on GPU",
+        "Multi-turn conversations on litert-lm >= 0.15 can drift: context retains previous turns' <think> reasoning while the model was trained with it stripped (observed at turn 3 of a 3-turn probe); start a fresh conversation per task"
+      ],
+      "min_runtime_version": "0.14.0"
+    },
+    {
+      "file": "LFM2.5-1.2B-Thinking_int8_gpu.litertlm",
+      "sha256": "11faec13dca0699dae1a43da30f0b5d57c64627edf6c4a6fa16b45b716db1a92",
+      "size_bytes": 1244763648,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1856
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 1421
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 906962
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1243796992,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "same int8 recipe and weights as the int8 file (post-hoc int8 on FULLY_CONNECTED + channelwise EMBEDDING_LOOKUP; convs left float), re-exported with litert-torch 0.9.3 + litert-converter 0.3.1 so it runs on the GPU",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "recommended": [
+        {
+          "platform": "android",
+          "device_class": "flagship",
+          "backend": "gpu",
+          "reason": "delegates fully on Adreno OpenCL and is 5 GSM8K points more accurate than the int4_gpu file; choose int4_gpu instead when decode speed or the 41% smaller download matters more"
+        },
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "~10x the prefill and ~3.4x the decode of the same file on CPU"
+        }
+      ],
+      "requirements": {
+        "peak_ram_mb": 530,
+        "platform_notes": [
+          "GPU needs litert-lm >= 0.16.0, verified by generation (not merely by a benchmark table) on Adreno OpenCL and macOS Metal; the Gallery bundles its own runtime which may lag that version - if its GPU toggle fails there, use CPU",
+          "Delegates fully on Adreno OpenCL - 542/542 nodes on each of the ten multi-token prefill signatures, 501/501 prefill_1 and 519/519 decode, zero rejected ops",
+          "Includes the ExecutorMetadata section litert-lm >= 0.15 needs",
+          "Give it a generous output budget (>=2048): a reasoning model truncated mid-thought produces no final answer",
+          "Not gated on iOS Metal; the sibling _int4_gpu file of the same export lineage is iPhone-verified at maxNumTokens 1024, but that measurement does not transfer to this file"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Galaxy S26 (SM-S942Q, SM8850, Adreno)",
+          "backend": "gpu",
+          "runtime": "litert_lm_advanced_main, litert-lm v0.16.0 release kit",
+          "prompt_tokens": 205,
+          "decode_tokens": 3058,
+          "prefill_tps": "860.3-951.7",
+          "decode_tps": "28.8-40.8",
+          "ttft_s": "0.24-0.27",
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 2,
+          "date": "2026-08-25",
+          "source": "205-token prompt file with --benchmark and no token-count flags; run 2 is thermally degraded at 3058 decode tokens, quote run 1"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.16.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 5102.1,
+          "decode_tps": 269.8,
+          "ttft_s": 0.054,
+          "max_num_tokens": 1024,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "cardbench harness, machine rested 300 s before the reading"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.16.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 3673.2,
+          "decode_tps": 251.5,
+          "ttft_s": 0.074,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "cardbench harness, machine rested 300 s before the reading"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 413.7,
+          "decode_tps": 86.8,
+          "ttft_s": 0.649,
+          "max_num_tokens": 1024,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "measured back to back against the published int8 file (412.9 / 86.8)"
+        }
+      ],
+      "min_runtime_version": "0.16.0",
+      "known_issues": [
+        "Multi-turn conversations on litert-lm >= 0.15 can drift: context retains previous turns' <think> reasoning while the model was trained with it stripped; start a fresh conversation per task"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-2.6B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LFM2.5-2.6B.json
@@ -1,0 +1,229 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/LFM2.5-2.6B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "LFM2.5-2.6B",
+    "base_model": "LiquidAI/LFM2.5-2.6B",
+    "architecture": "Hybrid: 22 gated short-convolution blocks + 8 grouped-query attention layers; thinking model (reasons in a <think> block, thought channel declared)",
+    "parameters_b": 2.6,
+    "license": "lfm-open-license-v1.0",
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Thinking model — reasoning turns are long; give at least 2048 tokens of budget for math/complex questions or the think block may not close. Decode speed drops as the token budget grows, so don't set it higher than needed."
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "LFM2.5-2.6B_int4.litertlm",
+      "sha256": "f4797d5a16812231deb6d505b4f417dd835b9b3dc47bb74d9ec71facfd0c91a4",
+      "size_bytes": 1668151680,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1310
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 2465
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2574159
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1665513856,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int4 blockwise-32 + OCTAV linears, int8 embedding, convs float",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "recommended": [
+        {
+          "platform": "android",
+          "backend": "gpu",
+          "reason": "at this size the GPU wins across the board on-device (needs litert-lm >= 0.16.0)"
+        },
+        {
+          "platform": "ios",
+          "backend": "cpu",
+          "reason": "int4 is the recommended phone variant; iOS Metal fails at engine creation (upstream LiteRT-LM#3129) — CPU on iOS"
+        },
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "~12x prefill, ~3.7x decode vs CPU on the same file"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.14; GPU requires litert-lm >= 0.16.0 (Android OpenCL and macOS, verified by generation)",
+          "AI Edge Gallery bundles its own runtime which may lag 0.16.0 — if its GPU toggle fails, use CPU there",
+          "Context (KV cache): 4096 max"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Mac M4 Max",
+          "backend": "cpu",
+          "prompt_tokens": 256,
+          "prefill_tps": 156,
+          "decode_tps": 43.7,
+          "ttft_s": 1.66,
+          "max_num_tokens": 1024,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)",
+          "runtime": "litert-lm (version not stated on card)"
+        },
+        {
+          "device": "Mac M4 Max",
+          "backend": "cpu",
+          "prompt_tokens": 1024,
+          "prefill_tps": 193,
+          "max_num_tokens": 2048,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)",
+          "runtime": "litert-lm (version not stated on card)"
+        },
+        {
+          "device": "Mac M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "prefill_tps": 1972,
+          "decode_tps": 161.6,
+          "cache": "no",
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "backend": "gpu",
+          "runtime": "litert_lm_main v0.16.0 built from the release tag",
+          "prompt_tokens": 261,
+          "decode_tokens": 256,
+          "prefill_tps": "87.8-88.4",
+          "decode_tps": "11.0-11.2",
+          "ttft_s": "3.04-3.06",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "backend": "cpu",
+          "runtime": "litert_lm_main v0.16.0 built from the release tag",
+          "prompt_tokens": 261,
+          "decode_tokens": 256,
+          "prefill_tps": "16.2-30.2",
+          "decode_tps": "7.4-10.2",
+          "ttft_s": "8.7-16.3",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "iOS Metal still fails at engine creation (tracked upstream in LiteRT-LM#3129)",
+        "Multi-turn: the conversation context retains previous turns' reasoning, so long chats fill the context faster than the visible text suggests — prefer fresh conversations for unrelated questions"
+      ],
+      "min_runtime_version": "0.14.0"
+    },
+    {
+      "file": "LFM2.5-2.6B_int8.litertlm",
+      "sha256": "36299f191c5ad447b148b78f9d965748598aca52786096c3e0de802b47eeca59",
+      "size_bytes": 2868199040,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1310
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 2465
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2574159
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 2865561216,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic (linears + convs + embedding)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.14; GPU requires litert-lm >= 0.16.0 (Android OpenCL and macOS, verified by generation)",
+          "iPhone 17 Pro: loads and runs only when the host app carries the extended-virtual-addressing / increased-memory entitlements (the 2.87 GB single weight section exceeds what a default-entitlement app will memory-map); int4 is the recommended phone variant",
+          "AI Edge Gallery bundles its own runtime which may lag 0.16.0 — if its GPU toggle fails, use CPU there",
+          "Context (KV cache): 4096 max"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Mac M4 Max",
+          "backend": "cpu",
+          "prompt_tokens": 256,
+          "prefill_tps": 169,
+          "decode_tps": 38.0,
+          "ttft_s": 1.54,
+          "max_num_tokens": 1024,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)",
+          "runtime": "litert-lm (version not stated on card)"
+        },
+        {
+          "device": "Mac M4 Max",
+          "backend": "cpu",
+          "prompt_tokens": 1024,
+          "prefill_tps": 434,
+          "max_num_tokens": 2048,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)",
+          "runtime": "litert-lm (version not stated on card)"
+        },
+        {
+          "device": "Mac M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "prefill_tps": 1893,
+          "decode_tps": 125.6,
+          "cache": "no",
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "iOS Metal still fails at engine creation (tracked upstream in LiteRT-LM#3129)",
+        "Multi-turn: the conversation context retains previous turns' reasoning, so long chats fill the context faster than the visible text suggests — prefer fresh conversations for unrelated questions"
+      ],
+      "min_runtime_version": "0.14.0"
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LLaVA-OneVision-0.5B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__LLaVA-OneVision-0.5B.json
@@ -1,0 +1,107 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/LLaVA-OneVision-0.5B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "LLaVA-OneVision-0.5B (LiteRT-LM)",
+    "base_model": "llava-hf/llava-onevision-qwen2-0.5b-ov-hf",
+    "architecture": "Compact vision-language model: SigLIP vision encoder (384x384) + MLP projector + Qwen2-0.5B decoder, LiteRT-LM fast_vlm bundle",
+    "parameters_b": 0.5,
+    "license": "apache-2.0",
+    "context_length": 2048,
+    "capabilities": {
+      "vision": true,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "LLaVA-OneVision-0.5B.litertlm",
+      "sha256": "7311912ada952c1905de6496193678117abd3b88fc82c319a30c167eb47ba97c",
+      "size_bytes": 829262144,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1090
+        },
+        {
+          "type": "SP_Tokenizer",
+          "size_bytes": 2647700
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 138018208,
+          "model_type": "tf_lite_embedder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 281761472,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 404903056,
+          "model_type": "tf_lite_vision_encoder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1870144,
+          "model_type": "tf_lite_vision_adapter"
+        }
+      ],
+      "quantization": "decoder int4 (symmetric, blockwise-32 + OCTAV); SigLIP vision encoder + MLP projector int8; tied embedding INT8 (externalized)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Context (KV cache) 2048; image input resized to 384x384",
+          "iPhone/macOS (Swift runtime / LiteRTDemo): load with the vision tower enabled (Modality.textImage / [.vision]); vision-only bundle, no audio tower",
+          "Android: Google AI Edge Gallery import must check 'Support image' (required for image input); pick GPU (fast) or CPU; v1.0.16+ imports directly from Hugging Face",
+          "Best for single-image VQA: ask about one image per chat and start a new conversation for a different image"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 955,
+          "decode_tps": 113.7,
+          "ttft_s": 0.31,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 7030,
+          "decode_tps": 239.3,
+          "ttft_s": 0.04,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Becomes unreliable when a second image is added to the same conversation (the answer truncates) — single-image VQA only, new conversation per image"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Ministral-3-3B-Instruct-2512.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Ministral-3-3B-Instruct-2512.json
@@ -1,0 +1,106 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Ministral-3-3B-Instruct-2512",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Ministral-3-3B-Instruct-2512",
+    "base_model": "mistralai/Ministral-3-3B-Instruct-2512",
+    "architecture": "Standard dense decoder (Ministral3ForCausalLM, YaRN RoPE); text-only conversion, Pixtral vision tower dropped",
+    "parameters_b": 3,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Ministral-3-3B-Instruct-2512_q4_block32_ekv4096.litertlm",
+      "sha256": "e68fcf0d52e5e9d86663c819b8ab53998694a633190b9102b456e12de4f16270",
+      "size_bytes": 2340982768,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 87
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2806689
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1932325376,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 405802992,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "int4 weights - blockwise (block 32), symmetric, OCTAV clipping; tied embedding/lm_head at INT8",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "Gallery on Android offers GPU only on ~12 GB+ devices (GPU needs roughly 2x the model size incl. the ML Drift GPU weight cache); on an 8 GB phone only CPU is selectable in the Gallery and ~4 GB RAM must be free or the app is OOM-killed on load",
+          "Gallery import needs package com.google.ai.edge.gallery 1.0.15+ (older 1.0.x builds only accept the legacy .task format and reject .litertlm)",
+          "Embedding externalized so every section is <2 GiB, which is what lets the ~2.3 GB file load on iOS (Metal GPU) under the ~2 GiB single-section mmap limit",
+          "The Gallery's accelerator choice is fixed at import time from device RAM; driving litert_lm_main directly on a Pixel 8a (8 GB) this file runs entirely on the OpenCL delegate (1187/1187 prefill, 1087/1087 decode nodes) and answers correctly"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 123,
+          "decode_tps": 22.3,
+          "ttft_s": 2.39,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1234,
+          "decode_tps": 95.4,
+          "ttft_s": 0.23,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS 27.0",
+          "backend": "gpu",
+          "runtime": "LiteRTDemo harness (Metal GPU backend)",
+          "prefill_tps": 41,
+          "decode_tps": "14-18",
+          "ttft_s": 0.4,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Nanbeige4.2-3B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Nanbeige4.2-3B.json
@@ -1,0 +1,89 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Nanbeige4.2-3B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Nanbeige4.2-3B",
+    "base_model": "Nanbeige/Nanbeige4.2-3B",
+    "architecture": "Looped transformer: 22 layers run twice per token (num_loops=2), unrolled at export to 44 layer executions over shared weights; reasoning model",
+    "parameters_b": 3,
+    "license": "apache-2.0",
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Reasoning model — the chat template auto-opens the <think> block and the visible answer follows </think>. Sampling is required: official recipe temperature 0.6, top_k 20, top_p 0.95; the model collapses under greedy decoding (do not run at temperature 0).",
+      "temperature": 0.6,
+      "top_k": 20,
+      "top_p": 0.95
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "model.litertlm",
+      "sha256": "4b4adfe6fd794451116bca61db58f0e2fb9fc3542da8d04d11ba4635693f4533",
+      "size_bytes": 2579277808,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 139
+        },
+        {
+          "type": "SP_Tokenizer",
+          "size_bytes": 2783410
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 2062065968,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 514385904,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "int4 weights — blockwise (block 32) + OCTAV optimal-clipping, symmetric; embedding INT8",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "The loop makes this ~2x the per-token compute of a normal 3B — expect roughly 8B-class decode rates on CPU",
+          "Android: push the file and import it in Google AI Edge Gallery (+ -> import, keep CPU)",
+          "Context (KV cache): 4096 (44 KV slots: 22 layers x 2 loops)",
+          "iPhone 17 Pro CPU decode was observed at ~3.2 tok/s in an earlier on-device note; its run log is not retained, so it is not listed as a measured row"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 56,
+          "decode_tps": 12.5,
+          "ttft_s": 4.74,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Sampling is required — the model collapses under greedy decoding (official recipe: temperature 0.6, top_k 20, top_p 0.95)",
+        "The current GPU delegate produces incorrect output on this 44-layer unrolled graph — run on CPU; this build is CPU-only on device"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Nemotron-3-Nano-4B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Nemotron-3-Nano-4B.json
@@ -1,0 +1,98 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Nemotron-3-Nano-4B",
+  "generated": "2026-08-27",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Nemotron-3-Nano-4B",
+    "base_model": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+    "architecture": "Three-kind hybrid (NemotronHForCausalLM, 42L, 3.97B): 21 Mamba2 selective-scan + 17 plain-MLP + 4 GQA attention layers; hidden 3136, 40 query / 8 KV heads, mamba 96 heads x 80 dim (state 128, conv 4, 8 groups), vocab 131072, untied embeddings. Reasoning model: ChatML turns, answers open with a <think> block",
+    "parameters_b": 3.97,
+    "license": "nvidia-nemotron-open-model-license",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Nemotron-3-Nano-4B_int8.litertlm",
+      "sha256": "3696e8934b2b1fc61abba0a3a7507189ce5f9894c57c11e27917e4c07125ee77",
+      "size_bytes": 4126697184,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 10543
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 3365
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2806488
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 4123829984,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "dynamic int8 (linears + embedding; convolutions and the selective scan stay float), fp32 activations declared, reduced 7-signature prefill ladder",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.15",
+          "GPU requires --cache no on this bundle: with the compiled-graph cache, litert-lm run --backend gpu fails with WebGPU Invalid BindGroup validation errors and an 8-question sweep through litert-mac-verify returns token soup (0/8); the same file with --cache no answers 8/8. Isolated as a one-variable comparison (same runner, same file, cache flag flipped); root cause not isolated further",
+          "Thinking model: answers open with a <think> block - budget max output tokens >= 2048 (the 8-question gate used 3200)",
+          "Metadata start token deliberately dropped: the source tokenizer sets add_bos_token False and the template never renders a leading BOS. At this scale the model is robust either way (gate 7/8 with and without), so this aligns the runtime stream with the training stream rather than fixing a failure",
+          "Not measured on a phone. A 4B of this family did not fit an 8 GB Android phone when the sibling Nemotron-H-4B was measured"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 99.57,
+          "decode_tps": 22.73,
+          "ttft_s": 2.6432,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-27",
+          "source": "litertlm-convert reports/shiplogs_20260827/bench_nano4b_protocol.log; litert-lm benchmark -p 256 -d 256 --runs 3 --cache no. Host was NOT idle (a concurrent export); a second protocol run in bench_nano4b_run2.log gave prefill 113.29 / decode 22.47 / ttft 2.3049, so CPU prefill spreads ~13%"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 803.37,
+          "decode_tps": 83.3,
+          "ttft_s": 0.3307,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-27",
+          "source": "litertlm-convert reports/shiplogs_20260827/bench_nano4b_protocol.log; litert-lm benchmark -p 256 -d 256 --runs 3 --cache no. Backend gated on real generations first (8-question gate 8/8 via litert-lm run --backend gpu --cache no). Second run: prefill 792.07 / decode 82.37 / ttft 0.3354 (~1.4% spread)"
+        }
+      ],
+      "known_issues": [
+        "GPU is unusable with the compiled-graph cache enabled (WebGPU Invalid BindGroup); pass --cache no. The exit gate's verifier (litert-mac-verify) takes no cache flag, so the routed convert.py CPU gate certifies nothing about GPU for this family",
+        "CPU 8-question gate scores 7/8: the miss is the rhyme-completion item (answers 'violets are purple'); the GPU run answers 'blue'. Every arithmetic, factual and translation item is correct on both backends"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen2-VL-2B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen2-VL-2B.json
@@ -1,0 +1,109 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Qwen2-VL-2B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Qwen2-VL-2B-Instruct (LiteRT-LM)",
+    "base_model": "Qwen/Qwen2-VL-2B-Instruct",
+    "architecture": "Vision-language model: Qwen2-VL ViT vision encoder (made static 672x672) + PatchMerger adapter + Qwen2-1.5B decoder, LiteRT-LM fast_vlm bundle",
+    "parameters_b": 2,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": true,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Qwen2-VL-2B.litertlm",
+      "sha256": "a9fd50536f8c521ae7cc1d56a3c58b405b2be83b3899ea8dfca9858eee9a4296",
+      "size_bytes": 1784096288,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1120
+        },
+        {
+          "type": "SP_Tokenizer",
+          "size_bytes": 2648115
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 235199136,
+          "model_type": "tf_lite_embedder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 874259104,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 637714480,
+          "model_type": "tf_lite_vision_encoder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 34203168,
+          "model_type": "tf_lite_vision_adapter"
+        }
+      ],
+      "quantization": "decoder int4 (symmetric, blockwise-32 + OCTAV); vision encoder int8; adapter int8; int8 externalized embedder",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Context (KV cache) 4096; image input resized to 672x672",
+          "iPhone/macOS (Swift runtime): load with the vision modality only (Modality.textImage) — requesting .all fails at session creation on bundles without an audio section",
+          "Android: recent Google AI Edge Gallery; import with 'Support image' enabled",
+          "Device-verified on Pixel 8a via Gallery with vision on GPU + decoder on CPU",
+          "Send one image per chat — start a fresh conversation for each image"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 141,
+          "decode_tps": 42.7,
+          "ttft_s": 1.96,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1753,
+          "decode_tps": 139.1,
+          "ttft_s": 0.16,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "Cross-cell comparison/ranking over 2-D structures (e.g. 'which row has the highest value') can pick the wrong cell: the fast_vlm runtime supplies 1-D positions instead of M-RoPE; reading/OCR of tables is unaffected",
+        "One image per chat: a second image in the same conversation degrades (context bleed from the first turn observed on CPU)"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3-4B-Thinking-2507.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3-4B-Thinking-2507.json
@@ -1,0 +1,150 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Qwen3-4B-Thinking-2507",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Qwen3-4B-Thinking-2507",
+    "base_model": "Qwen/Qwen3-4B-Thinking-2507",
+    "architecture": "qwen3-dense (36 layers)",
+    "parameters_b": 4.0,
+    "license": "apache-2.0",
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Reasoning model: it emits a <think>...</think> chain before the answer. At a short output budget it is cut off mid-thought and never answers."
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>\n",
+          "end": "\n</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Qwen3_4b_thinking_dynamic_wi4b32_afp32.litertlm",
+      "sha256": "a1efbbd887016ec3e930cf24a97d6590bffbbc155b3b3e8600ae647884bc1ebd",
+      "size_bytes": 2274193168,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 3321
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 4967
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2142162
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 2271997712,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "dynamic int4 block-32 weights, fp32 activations; GPU graph optimizations (RoPE/fused-QKV/fused-GateUp composites), static prefill allocation",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "min_runtime_version": "0.15.0",
+      "known_issues": [
+        "Block-32 int4 can corrupt output on iPhone Metal while staying coherent on desktop verify paths — device-verify before recommending iPhone GPU; the block-128 file is the iPhone-safe choice"
+      ]
+    },
+    {
+      "file": "model.litertlm",
+      "sha256": "647730a8723ee4ee218d67c4cb1c1d219d221ebb3d0679606271dca29669a911",
+      "size_bytes": 2474357680,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 183
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2142162
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 2079558192,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 392606640,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "int4 block-128 symmetric weights + OCTAV optimal clipping; int8 embeddings (externalized section)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "min_runtime_version": "0.15.0",
+      "recommended": [
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "~9x prefill and ~3.8x decode vs CPU on the same file"
+        },
+        {
+          "platform": "ios",
+          "backend": "gpu",
+          "reason": "block-128 is the iPhone-safe int4 recipe for this family; prefer this file over the block-32 variant on iPhone GPU"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "4B-class file (2.47 GB): budget device RAM accordingly; on Android import via AI Edge Gallery and enable the GPU toggle at import",
+          "iPhone 17 Pro Metal decode was observed at ~14 tok/s in an earlier on-device note; its run log is not retained, so it is not listed as a measured row"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.15.0 (pip CLI benchmark)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 999.3,
+          "decode_tps": 68.5,
+          "ttft_s": 0.28,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-11",
+          "source": "cardbench Mac LLM sweep; model card Performance table"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0 (pip CLI benchmark)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 111.0,
+          "decode_tps": 17.8,
+          "ttft_s": 2.49,
+          "max_num_tokens": 4096,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-11",
+          "source": "cardbench Mac LLM sweep; model card Performance table"
+        }
+      ],
+      "known_issues": []
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3.5-0.8B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3.5-0.8B.json
@@ -1,0 +1,151 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Qwen3.5-0.8B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Qwen3.5-0.8B (LiteRT-LM)",
+    "base_model": "Qwen/Qwen3.5-0.8B",
+    "architecture": "Hybrid gated-delta-net: 18 GatedDeltaNet linear-attention layers + 6 gated full-attention layers (KV budget 4096 on the 6 attention layers); text decoder only, vision tower and MTP heads dropped",
+    "parameters_b": 0.8,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Qwen3.5-0.8B_int8.litertlm",
+      "sha256": "684d4d34adf7176eb47f6026ff65c33d42584737254e5524a8d1ad62edc21b98",
+      "size_bytes": 963184864,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 362
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 3201
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 3913268
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 959219936,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic on linears + embedding (convs and the delta rule stay float)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "cpu",
+      "recommended": [
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "verified on macOS (Metal); GPU decode ~3.5x CPU on M4 Max"
+        },
+        {
+          "platform": "ios",
+          "backend": "gpu",
+          "reason": "verified on iPhone 17 Pro (Metal); GPU decode ~2.8x CPU — watch the 5.48 GB GPU peak memory"
+        },
+        {
+          "platform": "android",
+          "backend": "cpu",
+          "reason": "GPU not verified on Qualcomm Adreno; Pixel 8a GPU compile exceeds device memory (fp32 activations)"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.15 (both backends gated on 0.15.0 and 0.16.0)",
+          "GPU inference runs with fp32 activations (declared in the bundle) — high GPU memory: 5.48 GB peak vs 1.21 GB on CPU on iPhone 17 Pro",
+          "Pixel 8a cannot compile this file on its GPU: fp32-expanded weights plus the full prefill-ladder exceed the phone's ~3.8 GB available memory (limit is memory, not ops); CPU works on Android",
+          "Card's GPU usage example runs with --backend gpu --cache no",
+          "Ships a simplified ChatML template (thinking disabled, non-thinking mode); tool-calling and vision sections not included"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1972,
+          "decode_tps": 161.8,
+          "ttft_s": 0.14,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 666,
+          "decode_tps": 46.7,
+          "ttft_s": 0.41,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "gpu",
+          "runtime": "LiteRT-LM Swift runtime (version not stated on card)",
+          "prompt_tokens": 138,
+          "prefill_tps": 387,
+          "decode_tps": 41.4,
+          "ttft_s": 0.47,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "cpu",
+          "runtime": "LiteRT-LM Swift runtime (version not stated on card)",
+          "prompt_tokens": 138,
+          "prefill_tps": 170,
+          "decode_tps": 14.6,
+          "ttft_s": 0.93,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Pixel 8a (Tensor G3)",
+          "backend": "cpu",
+          "runtime": "litert_lm_main built from the v0.16.0 tag",
+          "prompt_tokens": 260,
+          "prefill_tps": "50-134",
+          "decode_tps": "8.0-13.6",
+          "ttft_s": "2.0-5.3",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "GPU execution not verified on Qualcomm Adreno devices",
+        "An fp16-activation GPU formulation is unfinished (real-weight fp16 range overflow in one layer-0 head — a property of the checkpoint, not the conversion), hence fp32 activations and the GPU memory cost",
+        "On a harder composite probe (8 questions in one 138-token prompt) the int8 quantization measurably costs answers at this 0.8B scale; the per-question sanity gate is word-for-word identical to HF fp32",
+        "On low-end Android GPUs decode is memory-bandwidth-bound and does not beat the CPU"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3.5-2B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3.5-2B.json
@@ -1,0 +1,198 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Qwen3.5-2B",
+  "generated": "2026-08-25",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Qwen3.5-2B",
+    "base_model": "Qwen/Qwen3.5-2B",
+    "architecture": "Hybrid linear-attention LLM: 18 GatedDeltaNet (gated delta rule) blocks + 6 gated full-attention blocks, 2048-dim, 248320 vocab, tied embeddings. The upstream checkpoint is multimodal; this repo ships the text decoder and, separately, a fast_vlm build that adds the checkpoint's own 24-layer 1024-dim ViT (no DeepStack)",
+    "parameters_b": 2.27,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": true,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Qwen3.5-2B-VL_int8.litertlm",
+      "sha256": "f8821e403dcfc939a033f6b2c9633a5d6b78c29a380ca825e0b90a62df61afe5",
+      "size_bytes": 3148905040,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1286
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 3201
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 3614174
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 511541472,
+          "model_type": "tf_lite_embedder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1996488720,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 611886768,
+          "model_type": "tf_lite_vision_encoder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 25279056,
+          "model_type": "tf_lite_vision_adapter"
+        }
+      ],
+      "quantization": "Decoder as above (int8 dynamic linears + embedding, fp32 activations declared) + vision encoder fp16 / vision adapter int8; fast_vlm, static 512x512",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "min_runtime": "litert-lm 0.15.0",
+        "platform_notes": [
+          "Text + one 512x512 image per turn (fast_vlm: 1024 patches merged 2x2 into 256 soft tokens). Pass --vision-backend to run the tower on the GPU as well as the decoder",
+          "SIX prefill signatures (1024,256,64,16,4,1), not the text build's eleven: with the vision tower attached the full ladder is killed by jetsam on a 12 GB iPhone after initialising 11 of 12 signatures. The cut also tripled CPU decode (3.8 -> 14.1 tok/s) because the XNNPACK repack is charged per signature",
+          "Positions are 1-D (the fast_vlm contract), so the checkpoint's M-RoPE collapses to plain RoPE; against the full M-RoPE reference on 9 image/prompt pairs, 1 generation is identical and 8 are same-content paraphrases",
+          "Vision encoder ships fp16 because int8 costs the tower 0.9999999992 -> 0.97-0.98 correlation on real photographs",
+          "Android NOT gated for this build; on Mali an fp16 vision encoder is known to crash devices of this class, so an int8-vision build would be the Android path"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1594,
+          "decode_tps": 109.1,
+          "ttft_s": 0.18,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-21",
+          "source": "qwen35vl_work/bench_vl.log, litert-lm benchmark -p 256 -d 256 --cache no, quiet machine (text path)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "decode_tps": 33.9,
+          "ttft_s": 4.9,
+          "peak_memory_mb": 4641,
+          "max_num_tokens": 4096,
+          "runs": 1,
+          "date": "2026-08-25",
+          "source": "qwen35vl_work/iphone_results/*vision-has-text*.json — real image turn, decoder and vision both on Metal, cold start"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "decode_tps": 14.1,
+          "ttft_s": 5.1,
+          "peak_memory_mb": 1203,
+          "max_num_tokens": 4096,
+          "runs": 1,
+          "date": "2026-08-25",
+          "source": "qwen35vl_work/iphone_results/*quality_2026-08-25T13-30-34Z.json"
+        }
+      ],
+      "known_issues": [
+        "Composite 8-question probe: on Mac this file answers 7 of 8, missing 17+25 identically on GPU and CPU — that miss is the model, and the text build records the same slip. On iPhone Metal two further answers degrade that do not degrade on Mac. Individual questions gate 8/8 on both Mac backends",
+        "Android unverified for this file"
+      ]
+    },
+    {
+      "file": "Qwen3.5-2B_int8.litertlm",
+      "sha256": "86c97baba6d3fb4109588562f0b9411e502c883be7fc2479f93ce3a6ea3efb6b",
+      "size_bytes": 2116592816,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 362
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 3201
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 3913268
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 2112627888,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic on linears + embedding (convs and the delta rule stay float); prefer_activation_type fp32 declared in-bundle",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "min_runtime": "litert-lm 0.15.0",
+        "platform_notes": [
+          "Text only. Full 1-1024 prefill signature ladder (11 prefill signatures + decode); peaks ~5.33 GB on iPhone 17 Pro Metal, which fits a 12 GB phone",
+          "GPU runs with fp32 activations (declared in-bundle) — that is where the GPU memory multiple over CPU comes from",
+          "GPU execution verified on macOS Metal, iPhone 17 Pro Metal and Pixel 8a Mali/OpenCL; NOT verified on Qualcomm Adreno",
+          "Pixel-class 8 GB Android: the OpenCL delegate accepts the whole graph but engine creation exhausts memory — use CPU there"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1486,
+          "decode_tps": 114.3,
+          "ttft_s": 0.18,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-14",
+          "source": "qwen35_work/ card bench, litert-lm benchmark -p 256 -d 256 --cache no, quiet machine"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prefill_tps": 237.7,
+          "decode_tps": 24.3,
+          "ttft_s": 0.73,
+          "peak_memory_mb": 5330,
+          "max_num_tokens": 4096,
+          "runs": 1,
+          "date": "2026-08-14",
+          "source": "dmbench yardstick quality task, 138-token prompt, cold start"
+        }
+      ],
+      "known_issues": [
+        "On the composite 8-question probe the CPU int8 path answers only 3 of 8 (deterministic, identical on Mac and iPhone); GPU reproduces the fp32 reference. Individual questions gate 8/8 on every backend"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3.5-4B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__Qwen3.5-4B.json
@@ -1,0 +1,254 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/Qwen3.5-4B",
+  "generated": "2026-08-27",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Qwen3.5-4B",
+    "base_model": "Qwen/Qwen3.5-4B",
+    "architecture": "Hybrid GatedDeltaNet: 24 linear-attention + 8 gated full-attention layers; text decoder only (vision tower and MTP heads dropped)",
+    "parameters_b": 4,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Qwen3.5-4B_int8.litertlm",
+      "sha256": "f0abbbc69b4126ddcb208a75e8904ecadff87aa24202e3de6ffd518c198af1ec",
+      "size_bytes": 4407428464,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 362
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 4293
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 3913268
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 4403463536,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic on linears + embedding (convs and the delta rule stay float), fp32 activations declared",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "recommended": [
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "Metal verified on macOS; ~2.8x prefill, ~3.1x decode vs CPU on M4 Max"
+        },
+        {
+          "platform": "ios",
+          "backend": "gpu",
+          "reason": "Metal verified on iPhone 17 Pro; watch the ~4.98 GB GPU peak memory"
+        },
+        {
+          "platform": "android",
+          "backend": "cpu",
+          "reason": "Adreno GPU unverified — use CPU unless confirmed on your own device"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.15 (both backends gated on 0.15.0 and 0.16.0)",
+          "GPU inference runs with fp32 activations; iPhone 17 Pro GPU peak ~4.98 GB, model load 66 s on first launch",
+          "Pixel 8a and 8 GB-class Android phones: not attempted and not expected to fit — Apple-hardware-first release; an Android row can follow on 12 GB+ devices",
+          "Reduced prefill signature ladder (1024/256/64/16/4/1) keeps iPhone GPU engine creation under the 12 GB jetsam ceiling",
+          "Ships a simplified ChatML template with thinking disabled; tool-calling and vision sections not included"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 672,
+          "decode_tps": 62.0,
+          "ttft_s": 0.4,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 243,
+          "decode_tps": 19.9,
+          "ttft_s": 1.11,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "gpu",
+          "prompt_tokens": 138,
+          "prefill_tps": 87.1,
+          "decode_tps": 9.3,
+          "ttft_s": 1.93,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)",
+          "runtime": "LiteRT-LM Swift runtime (version not stated on card)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "cpu",
+          "prompt_tokens": 138,
+          "prefill_tps": 24.0,
+          "decode_tps": 5.4,
+          "ttft_s": 6.88,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)",
+          "runtime": "LiteRT-LM Swift runtime (version not stated on card)"
+        }
+      ],
+      "known_issues": [
+        "GPU execution not verified on Qualcomm Adreno devices — use CPU there unless confirmed",
+        "On the harder composite 8-question probe the CPU int8 path answers 6 of 8 (every answer it gives is correct — it skips two); GPU matches HF fp32 word-for-word"
+      ],
+      "min_runtime_version": "0.15.0"
+    },
+    {
+      "file": "Qwen3.5-4B_mixed_int4.litertlm",
+      "sha256": "176b5a2b6c20bde7739fba98e653a04f5d5b4a753a4b9dd0ff529aba7c35be99",
+      "size_bytes": 2754365536,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 362
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 4293
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 3913268
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 2750400608,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "Mixed INT4: int4 blockwise-32 min-max on linears, int8 channelwise on embedding + lm_head (convs and the delta rule stay float), fp32 activations declared",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "recommended": [
+        {
+          "platform": "macos",
+          "backend": "gpu",
+          "reason": "Metal verified on macOS; 669 tok/s prefill / 68.5 tok/s decode on M4 Max"
+        },
+        {
+          "platform": "ios",
+          "backend": "gpu",
+          "reason": "Metal verified on iPhone 17 Pro (8/8 composite probe); watch the ~5.7 GB GPU peak memory"
+        },
+        {
+          "platform": "android",
+          "backend": "cpu",
+          "reason": "Adreno GPU unverified; the 2.57 GB file + ~1.7 GB CPU working set is the RAM-constrained-device path (8 GB-class not yet device-verified)"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.15 (both backends gated on 0.15.0 and 0.16.0)",
+          "GPU inference runs with fp32 activations; iPhone 17 Pro GPU peak ~5.74 GB, model load ~65 s on first launch",
+          "CPU prefill is slower than the int8 file on desktop (Mac 100 vs 243 tok/s); decode equal or faster everywhere",
+          "GSM8K n=100 (0-shot CoT, greedy, 2048-token budget): 93/100 vs the int8 file's 97/100 on the same export and harness",
+          "Same reduced prefill ladder (1024/256/64/16/4/1), simplified ChatML template, thinking disabled"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 669.3,
+          "decode_tps": 68.5,
+          "ttft_s": 0.4,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-27",
+          "source": "qwen35_work/bench_int4_mac.log (litert-lm benchmark, quiet machine, 300 s GPU rest)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 100.1,
+          "decode_tps": 20.1,
+          "ttft_s": 2.61,
+          "cache": "no",
+          "runs": 3,
+          "date": "2026-08-27",
+          "source": "qwen35_work/bench_int4_mac.log"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "gpu",
+          "prompt_tokens": 138,
+          "prefill_tps": 88.7,
+          "decode_tps": 11.38,
+          "ttft_s": 1.89,
+          "runs": 1,
+          "date": "2026-08-27",
+          "source": "qwen35_work/device_gate_int4_20260826/final_qwen35-4b-mixed-int4-b32_gpu.log (cold, unplugged)",
+          "runtime": "LiteRT-LM Swift runtime (CLiteRTLM.xcframework v0.16.0)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "backend": "cpu",
+          "prompt_tokens": 138,
+          "prefill_tps": 46.7,
+          "decode_tps": 8.87,
+          "ttft_s": 3.12,
+          "runs": 1,
+          "date": "2026-08-27",
+          "source": "qwen35_work/device_gate_int4_20260826/final_qwen35-4b-mixed-int4-b32_cpu.log (cold, unplugged)",
+          "runtime": "LiteRT-LM Swift runtime (CLiteRTLM.xcframework v0.16.0)"
+        }
+      ],
+      "known_issues": [
+        "GPU execution not verified on Qualcomm Adreno devices - use CPU there unless confirmed",
+        "GSM8K accuracy 4 points below the int8 file (93 vs 97, n=100) - the int4 cost is real on math word problems though invisible to sanity gates",
+        "Not yet run on an 8 GB Android phone; the CPU numbers above are the sizing evidence"
+      ],
+      "min_runtime_version": "0.15.0"
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__SmolLM3-3B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__SmolLM3-3B.json
@@ -1,0 +1,134 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/SmolLM3-3B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "SmolLM3-3B",
+    "base_model": "HuggingFaceTB/SmolLM3-3B",
+    "architecture": "Fully-open 3B decoder with GQA and a NoPE attention schedule (SmolLM3ForCausalLM, rotary disabled every 4th layer), multilingual, long-context trained",
+    "parameters_b": 3,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "SmolLM3-3B.litertlm",
+      "sha256": "a34da46f5697896c98a4d3b3dacddbc50487f8e35432b37b72e4fe38ed264bb4",
+      "size_bytes": 3108978688,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 268
+        },
+        {
+          "type": "SP_Tokenizer",
+          "size_bytes": 2260840
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 3106673904,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int4 (recipe not stated on card)",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "measured": [],
+      "known_issues": [
+        "File is present in the repo tree (3.11 GB) but not documented anywhere on the model card"
+      ]
+    },
+    {
+      "file": "SmolLM3-3B_q4_block32_ekv4096.litertlm",
+      "sha256": "38d7bf55e243f5a95d8b16c21b1f7ef7debe6ce6bb2ddb66eb54f4bc2be8e6eb",
+      "size_bytes": 2002257840,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 142
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2608153
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1733852544,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 265750448,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "int4 weights - blockwise (block 32) + OCTAV optimal-clipping, symmetric; embedding INT8",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "Gallery import needs package com.google.ai.edge.gallery 1.0.15+ (older 1.0.x builds reject .litertlm); Gallery v1.0.16+ can import litert-lm models directly from Hugging Face inside the app",
+          "Embedding externalized into its own bundle section so the main weights section stays under the iOS ~2 GiB single-mmap limit",
+          "On a Pixel 8a (Tensor G3, 8 GB) litert_lm_main runs the graph entirely on the OpenCL delegate (1476/1476 prefill, 1308/1308 decode nodes, zero rejected ops) and answers correctly"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 141,
+          "decode_tps": 24.1,
+          "ttft_s": 2.14,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm benchmark (litert-lm 0.15.0)",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1354,
+          "decode_tps": 93.2,
+          "ttft_s": 0.21,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS 27.0",
+          "backend": "gpu",
+          "runtime": "LiteRTDemo harness (Metal GPU backend)",
+          "prefill_tps": 30.8,
+          "decode_tps": 22.5,
+          "ttft_s": 0.63,
+          "runs": 1,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__SmolVLM2-500M.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__SmolVLM2-500M.json
@@ -1,0 +1,95 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/SmolVLM2-500M",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "SmolVLM2-500M",
+    "base_model": "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+    "architecture": "VLM (fast_vlm bundle): SigLIP vision encoder + pixel-shuffle x4 connector feeding a SmolLM2-360M (Llama) decoder; image path only",
+    "parameters_b": 0.5,
+    "license": "apache-2.0",
+    "context_length": 2048,
+    "capabilities": {
+      "vision": true,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "SmolVLM2-500M.litertlm",
+      "sha256": "0dfb6fb881eb16e5ef2b2be04de5476caf939b7d9ae601fdee308bbc5462fd55",
+      "size_bytes": 361052336,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 663
+        },
+        {
+          "type": "SP_Tokenizer",
+          "size_bytes": 881974
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 47902368,
+          "model_type": "tf_lite_embedder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 208930496,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 91469200,
+          "model_type": "tf_lite_vision_encoder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 11810992,
+          "model_type": "tf_lite_vision_adapter"
+        }
+      ],
+      "quantization": "vision encoder + connector int8; decoder int4 (blockwise-32 + OCTAV); tied embedding int8 (externalized)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Best for single-image VQA — ask about one image per chat (start a new conversation for a different image)",
+          "Use the CPU backend on the desktop (macOS GPU unusable on litert-lm 0.15.0)",
+          "Android: Gallery v1.0.16+ imports directly from Hugging Face; in the Import Model dialog check 'Support image' (required for image input), set a sensible max tokens, pick GPU (fast) or CPU",
+          "iPhone/macOS Swift runtime: load with the vision tower enabled (Modality.textImage / [.vision]) — vision-only bundle, no audio tower",
+          "Image input resized to 512x512; context (KV cache) 2048; benchmark figures cover the text path only (the vision encoder runs once per image and is not included)"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 409,
+          "decode_tps": 63.9,
+          "ttft_s": 0.64,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "macOS GPU backend not usable on litert-lm 0.15.0 — returns a stream of <|endoftext|> tokens instead of a caption (desktop-runtime observation; says nothing about the iPhone or Android GPU paths)",
+        "On the GPU backend a second image in the same conversation may degrade (a GPU-delegate trait shared across fast_vlm models); CPU handles multi-image",
+        "Very small (500M) model — can be repetitive/verbose at pure greedy; use sampling (e.g. top-p) and keep a sensible max_tokens"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__VibeThinker-3B.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__VibeThinker-3B.json
@@ -1,0 +1,106 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/VibeThinker-3B",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "VibeThinker-3B (LiteRT-LM)",
+    "base_model": "WeiboAI/VibeThinker-3B",
+    "architecture": "Dense 3B math/reasoning model, Qwen2ForCausalLM, 36 layers, inline chain-of-thought",
+    "parameters_b": 3,
+    "license": "mit",
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Reasoning model: solves with a step-by-step chain-of-thought then a \\boxed{} answer; card says run with max_tokens >= 2048 or it gets cut off before the answer (all quality numbers measured at 2048)."
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "model.litertlm",
+      "sha256": "27878159e84014b66709b5b26ac204ff74dc1e87134eeb4bccb8c6146c16ca38",
+      "size_bytes": 2057106352,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 181
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2142143
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 1740096624,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 314815408,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "int4 block 32 (symmetric) + OCTAV optimal-clipping; embeddings INT8 (externalized section)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "Context (KV cache) 4096",
+          "Android: Google AI Edge Gallery 1.0.15+ supports .litertlm (v1.0.16+ imports directly from Hugging Face); choose the GPU backend and raise max-tokens to >= 2048",
+          "iPhone 17 Pro verified (Swift runtime): the block-32 build's 1.62 GiB section is under the iOS limit; loads and generates correct answers (no on-device timing quoted)",
+          "Pixel 8a (Tensor G3, Mali-G715, 8 GB): graph runs entirely on the OpenCL delegate — 1603/1603 prefill and 1452/1452 decode nodes, zero rejected ops (no throughput numbers quoted)"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 139,
+          "decode_tps": 28.4,
+          "ttft_s": 2.15,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1386,
+          "decode_tps": 94.1,
+          "ttft_s": 0.2,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "model card Performance table (cardbench harness)"
+        }
+      ],
+      "known_issues": [
+        "CPU benchmark rows are noisy (treat as roughly +/-7%; GPU rows repeat within ~1%)",
+        "Math-specialised model: on general-knowledge prompts it reasons at length and can settle on a wrong answer — identically on CPU and GPU (a model-domain property, not a backend issue)"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__granite-docling-258M.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/litert-community__granite-docling-258M.json
@@ -1,0 +1,94 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "litert-community/granite-docling-258M",
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "granite-docling-258M",
+    "base_model": "ibm-granite/granite-docling-258M",
+    "architecture": "VLM (fast_vlm bundle): SigLIP-base-512 vision encoder + pixel-shuffle x4 connector feeding a Llama-architecture granite decoder (576-dim/30L, 100k vocab); DocTags document-conversion output (Docling's model)",
+    "parameters_b": 0.26,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": true,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "granite-docling-258M.litertlm",
+      "sha256": "11a14f547dda752d35c222b2a781d277fa499d94d14a3b575f719bb16391e113",
+      "size_bytes": 337946336,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 761
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 1404486
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 59009312,
+          "model_type": "tf_lite_embedder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 178906944,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 91480080,
+          "model_type": "tf_lite_vision_encoder"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 7087840,
+          "model_type": "tf_lite_vision_adapter"
+        }
+      ],
+      "quantization": "vision encoder + connector int8 (dynamic); decoder int8 weights with FLOAT compute (integer-compute int8/int4 corrupt DocTags structure); prefer_activation_type fp32_fp16 declared in-bundle",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Input contract: pre-resize the page to exactly 512x512 with BILINEAR resampling in the app before sending — the runtime's own downscale from larger images uses a different filter and the model hallucinates the page (base-model trait of the single-global-512 path, present in eager too)",
+          "Scope: pages legible at 512^2 (report pages, tables, layout). Dense multi-column pages and small formulas degrade in single-512 mode — also in the original model run this way",
+          "Prompt 'Convert this page to docling.' -> DocTags markup; convert to Markdown/HTML with docling-core. One page per conversation",
+          "Device-verified (Galaxy S26 / SM8850, CPU, LiteRT-LM v0.16.1 CLI): synthetic 5x6 table page -> exact title, complete OTSL grid, 25/25 cells, clean stop, 35.4 s/page (1025 output tokens), two runs byte-identical",
+          "macOS CPU (litert-lm 0.15.0): same gate perfect at 5.2 s/page (~240 output tokens); the vision encoder runs once per image (~0.5 s M4 Max CPU) and is outside the benchmark figures",
+          "iPhone/macOS Swift runtime: load with the vision tower enabled (Modality.textImage) — vision-only bundle, no audio tower; context (KV cache) 4096"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.15.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 912,
+          "decode_tps": 63.96,
+          "ttft_s": 0.57,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-24",
+          "source": "docling_work/FINDINGS.md device-gate section; litert-lm benchmark -p 256 -d 256 --cache no, backend gated on a real docling generation"
+        }
+      ],
+      "known_issues": [
+        "GPU engine creation fails on the shipped bundle: the ML Drift delegate rejects the quantized 576x576 FC at kernel init (Shape mismatch {576,1,1,576} vs {1,1,576,576}) — identical on macOS WebGPU and Android OpenCL. An fp16-decoder variant runs correctly on Android OpenCL but ~4x slower than CPU, so CPU-only ships",
+        "Feeding images larger than 512 without app-side BILINEAR pre-resize degrades output to a hallucinated page (see input contract)"
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/mlboydaisuke__Mordant-3B-Think-LiteRT.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/mlboydaisuke__Mordant-3B-Think-LiteRT.json
@@ -1,0 +1,99 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "mlboydaisuke/Mordant-3B-Think-LiteRT",
+  "generated": "2026-08-25",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Mordant-3B-Think",
+    "base_model": "Kezmark/Mordant-3B-Think",
+    "architecture": "Dense granite-4.1 (GraniteForCausalLM, 40L, 3.40B) full SFT for image-prompt composition with chain-of-thought; thinking-form chat template opens the assistant turn with <think>",
+    "parameters_b": 3.4,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Mordant-3B-Think_int8.litertlm",
+      "sha256": "85205709015e412915ca86ca1e790177f204d438fbee288317b2c7cc2deb484e",
+      "size_bytes": 3762196400,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 1816
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 1404545
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 3501434512,
+          "model_type": "tf_lite_prefill_decode"
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 259313584,
+          "model_type": "tf_lite_embedder"
+        }
+      ],
+      "quantization": "dynamic int8 (linears + embedding), externalized int8 embedder, reduced 7-signature prefill ladder",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "gpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.16",
+          "Thinking model: answers open with a <think> block - budget max output tokens >= 2048",
+          "Metadata start token deliberately dropped: family declares bos == eos (<|end_of_text|>) and the template never renders a leading BOS; a prepended start token flips greedy output into a code-fence loop (measured on this checkpoint)",
+          "GPU gated on a real generation (correct answer with think block) before benching"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 97.25,
+          "decode_tps": 20.18,
+          "ttft_s": 2.68,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "litertlm-convert reports/shiplogs_20260825/bench_mordant_tashkeel.log; litert-lm benchmark -p 256 -d 256 --runs 3 --cache no"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 1128.98,
+          "decode_tps": 71.85,
+          "ttft_s": 0.24,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "litertlm-convert reports/shiplogs_20260825/bench_mordant_tashkeel.log; backend gated on a real generation first"
+        }
+      ],
+      "known_issues": []
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/mlboydaisuke__S1-mini-LiteRT.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/mlboydaisuke__S1-mini-LiteRT.json
@@ -1,0 +1,159 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "mlboydaisuke/S1-mini-LiteRT",
+  "generated": "2026-08-25",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "S1-mini (LiteRT-LM)",
+    "base_model": "superwhisper/s1-mini",
+    "architecture": "Dense 0.6B ASR-transcript normalizer, Qwen3ForCausalLM finetune, 28 layers, GQA 16Q:8KV, tied embeddings",
+    "parameters_b": 0.6,
+    "license": "other",
+    "session_defaults": {
+      "notes": "Single-task text normalizer, NOT a chat model — it rewrites a question instead of answering it. Greedy is the trained behaviour (upstream generation_config sets do_sample=false): use top-k 1 / temperature 0. Every input is a control line '[Styling: casual|semi-casual|semi-formal|formal] [Structure: prose|lists] [Context: general|email]', a newline, then one raw transcript; values outside those sets are out of contract. The required system prompt is baked into the bundle template, so callers send only the control line and transcript. English only, inputs up to ~1000 tokens. License carries a naming term: distribution must keep identifying it as \"S1-mini\" by \"Superwhisper\"."
+    },
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": true,
+        "channel": {
+          "start": "<think>",
+          "end": "</think>"
+        }
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "S1-mini_int8.litertlm",
+      "sha256": "0376f042102cd1409055374d3e823faaaf3a66c5f61c6c744ffe01193d0ae397",
+      "size_bytes": 688157792,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 770
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 2142162
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 685978720,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "int8 dynamic on linears + embedding (dynamic_wi8_afp32)",
+      "backends": [
+        "cpu",
+        "gpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Context (KV cache) 4096; prefill signatures 1..1024",
+          "int8 is the only variant: an int4 block-32 build was measured and rejected — it drops commas and discourse words and decodes slower at this size",
+          "Pixel 8a (Tensor G3): graph runs entirely on the OpenCL delegate — 1247/1247 decode nodes, zero XNNPACK fallback",
+          "iPhone 17 Pro verified (Metal): loads and generates, peak ~1.7 GB",
+          "Android: Google AI Edge Gallery imports the file, but Gallery builds current as of 2026-08 give imported models no accelerator choice and run them on the CPU; set TopK 1 / temperature 0.00 in the import dialog (its defaults are sampling values)"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "gpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 3673,
+          "decode_tps": 144.6,
+          "ttft_s": 0.077,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "litert-lm benchmark, -p 256 -d 256 --runs 3 --cache no, quiet machine"
+        },
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 427,
+          "decode_tps": 33.3,
+          "ttft_s": 0.63,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "litert-lm benchmark, -p 256 -d 256 --runs 3 --cache no, quiet machine"
+        },
+        {
+          "device": "Pixel 8a",
+          "os": "Android",
+          "backend": "gpu",
+          "runtime": "litert_lm_advanced_main v0.16.0 kit (LiteRT CompiledModel, LITERT_CL)",
+          "prompt_tokens": 205,
+          "prefill_tps": 434,
+          "decode_tps": 12.3,
+          "ttft_s": 0.67,
+          "max_num_tokens": 4096,
+          "runs": 1,
+          "date": "2026-08-25",
+          "source": "on-device benchmark run, 205-token prompt"
+        },
+        {
+          "device": "Pixel 8a",
+          "os": "Android",
+          "backend": "cpu",
+          "runtime": "litert_lm_advanced_main v0.16.0 kit (XNNPACK)",
+          "prompt_tokens": 205,
+          "prefill_tps": 40.4,
+          "decode_tps": 5.8,
+          "ttft_s": 6.46,
+          "max_num_tokens": 4096,
+          "runs": 1,
+          "date": "2026-08-25",
+          "source": "on-device benchmark run, 205-token prompt"
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS",
+          "backend": "gpu",
+          "runtime": "litert-lm (Swift, yardstick harness)",
+          "prompt_tokens": 180,
+          "prefill_tps": 801,
+          "decode_tps": 32.0,
+          "ttft_s": 0.31,
+          "max_num_tokens": 4096,
+          "runs": 2,
+          "date": "2026-08-25",
+          "source": "on-device harness; the two runs that agreed (32.02 / 32.01 tok/s). An earlier run of the same build read 30.2. Device reported thermal state 'serious' throughout — read as a floor."
+        },
+        {
+          "device": "iPhone 17 Pro",
+          "os": "iOS",
+          "backend": "cpu",
+          "runtime": "litert-lm (Swift, yardstick harness)",
+          "prompt_tokens": 180,
+          "prefill_tps": 281,
+          "decode_tps": 15.5,
+          "ttft_s": 0.74,
+          "max_num_tokens": 4096,
+          "runs": 1,
+          "date": "2026-08-25",
+          "source": "on-device harness, single run; device reported thermal state 'serious' — read as a floor.",
+          "peak_mem_mb": 1427
+        }
+      ],
+      "known_issues": [
+        "Pixel 8a GPU: on number-dense input a date separator can be lost ('March 3rd, 2026.' -> 'March 32026.'), deterministic on repeat runs; the CPU backend on the same phone is byte-identical to macOS across all 12 test cases. Prefer CPU on this phone when exactness matters, GPU when time-to-first-token matters.",
+        "The released checkpoint itself drifts from its own upstream card's example table (it keeps 'Hmm,' / 'So' discourse markers the card drops); parity here is stated against HF fp32, not against those published examples.",
+        "All iPhone 17 Pro rows were measured with the device reporting a 'serious' thermal state; they are floors, not peaks."
+      ]
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/fixtures/mlboydaisuke__Tashkeel-350M-v2-LiteRT.json
+++ b/packages/flutter_gemma_litertlm/test/manifest/fixtures/mlboydaisuke__Tashkeel-350M-v2-LiteRT.json
@@ -1,0 +1,133 @@
+{
+  "manifest_schema": "0.1.0",
+  "repo": "mlboydaisuke/Tashkeel-350M-v2-LiteRT",
+  "generated": "2026-08-25",
+  "generator": "make_manifest.py",
+  "model": {
+    "display_name": "Tashkeel-350M-v2",
+    "base_model": "Etherll/Tashkeel-350M-v2",
+    "architecture": "granite-4.0-h Mamba2/attention hybrid (32L: 28 mamba + 4 attention, 0.34B) SFT for Arabic diacritization (Misraj/Sadeed_Tashkeela)",
+    "parameters_b": 0.34,
+    "license": "apache-2.0",
+    "context_length": 4096,
+    "capabilities": {
+      "vision": false,
+      "audio": false,
+      "thinking": {
+        "declared": false
+      }
+    }
+  },
+  "variants": [
+    {
+      "file": "Tashkeel-350M-v2_fp16.litertlm",
+      "sha256": "02034a77bd178608eb9da106c95cb7e2dead2507424969bef8e8bc8788d5af67",
+      "size_bytes": 768502912,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 6457
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 4285
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 1404724
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 767044736,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "fp16 weights on linears + embedding (convs/SSM fp32) - exact-parity build: task gate 10/10 byte-identical to HF fp32 greedy",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.15 (hybrid state binds via ExecutorMetadata)",
+          "CPU only: Mamba2 selective-scan ops exceed the mobile GPU delegate's rank limit (family trait)",
+          "Prompt contract: user message 'قم بتشكيل هذا النص :\\n' + text (the checkpoint's trained form)",
+          "Start token dropped: at 350M scale a prepended <|end_of_text|> flips diacritization to garbage (measured)",
+          "On phones the CPU runtime unpacks fp16 to fp32 in RAM - prefer int8 on mobile"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 661.63,
+          "decode_tps": 58.18,
+          "ttft_s": 0.4,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "litertlm-convert reports/shiplogs_20260825/bench_mordant_tashkeel.log; litert-lm benchmark -p 256 -d 256 --runs 3 --cache no"
+        }
+      ],
+      "known_issues": []
+    },
+    {
+      "file": "Tashkeel-350M-v2_int8.litertlm",
+      "sha256": "e962e6287a3b1e109498d1bca09d20fe55131bb1cd7431165bf255cfd2de1cd7",
+      "size_bytes": 481214000,
+      "sections": [
+        {
+          "type": "LlmMetadataProto",
+          "size_bytes": 6457
+        },
+        {
+          "type": "ExecutorMetadataProto",
+          "size_bytes": 4285
+        },
+        {
+          "type": "HF_Tokenizer_Zlib",
+          "size_bytes": 1404724
+        },
+        {
+          "type": "TFLiteModel",
+          "size_bytes": 479755824,
+          "model_type": "tf_lite_prefill_decode"
+        }
+      ],
+      "quantization": "dynamic int8 (linears + embedding; convs/SSM fp32) - task gate 8/10 vs HF fp32: two single-diacritic greedy flips, both byte-exact on the float parent (quantization cost, the base 350m's documented int8 sensitivity)",
+      "backends": [
+        "cpu"
+      ],
+      "default_backend": "cpu",
+      "requirements": {
+        "platform_notes": [
+          "Requires litert-lm >= 0.15",
+          "CPU only (family trait)",
+          "38% of the fp16 size - the practical mobile choice"
+        ]
+      },
+      "measured": [
+        {
+          "device": "Apple M4 Max",
+          "os": "macOS",
+          "backend": "cpu",
+          "runtime": "litert-lm 0.16.0",
+          "prompt_tokens": 256,
+          "decode_tokens": 256,
+          "prefill_tps": 761.25,
+          "decode_tps": 97.21,
+          "ttft_s": 0.35,
+          "max_num_tokens": 4096,
+          "runs": 3,
+          "date": "2026-08-25",
+          "source": "litertlm-convert reports/shiplogs_20260825/bench_mordant_tashkeel.log"
+        }
+      ],
+      "known_issues": []
+    }
+  ]
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/litertlm_manifest_resolver_test.dart
+++ b/packages/flutter_gemma_litertlm/test/manifest/litertlm_manifest_resolver_test.dart
@@ -212,6 +212,8 @@ void main() {
             .resolver(m)
             .resolve('org/name', preferredBackend: PreferredBackend.gpu);
         expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+        // Honoured, so nothing to report.
+        expect(r.notes, isEmpty);
       },
     );
 
@@ -264,6 +266,24 @@ void main() {
             );
         expect(r.file, 'LFM2.5-1.2B-Instruct_int4_gpu.litertlm');
         expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+        // The downgrade is on the record for release builds too (gemmaLog is
+        // debug-only): last note, naming the dropped hint and the outcome.
+        expect(
+          r.notes.last,
+          allOf(
+            contains('litert-community/LFM2.5-1.2B-Instruct'),
+            contains('requested npu'),
+            contains('(gpu)'),
+          ),
+        );
+        // ...and only there: the variant's own notes come first, untouched.
+        final noHint = await f
+            .resolver(lfmFixture())
+            .resolve(
+              'litert-community/LFM2.5-1.2B-Instruct',
+              platform: 'macos',
+            );
+        expect(r.notes.sublist(0, r.notes.length - 1), noHint.notes);
       },
     );
 
@@ -275,6 +295,10 @@ void main() {
           .resolve('org/name', preferredBackend: PreferredBackend.gpu);
       expect(r.file, 'model.litertlm');
       expect(r.runtime.preferredBackend, PreferredBackend.cpu);
+      expect(r.notes, [
+        'No variant of "org/name" is verified on the requested gpu backend; '
+            'resolved without that hint (cpu).',
+      ]);
     });
 
     test(
@@ -310,37 +334,76 @@ void main() {
         expect(r.runtime.maxTokens, isNull);
         expect(r.runtime.minOutputTokens, isNull);
         expect(r.modelType, isNull);
+        // No `capabilities` block at all: the manifest never looked, which
+        // is "silent" (null) — not "declared unsupported" (false).
+        expect(r.runtime.supportImage, isNull);
+        expect(r.runtime.supportAudio, isNull);
+        expect(r.runtime.isThinking, isNull);
       },
     );
 
-    test('session_defaults is an open object: a notes-only object gives no '
-        'minOutputTokens, a non-int value is ignored', () async {
+    test('a present capabilities block is a declaration: keys it omits are '
+        'false, not null', () async {
       final f = _Fetches();
-      final notesOnly = await f
+      final r = await f
           .resolver(
             manifest(
               model: {
-                'display_name': 'N',
-                'session_defaults': {'notes': 'only notes'},
+                'display_name': 'V',
+                'capabilities': {'vision': true},
               },
             ),
           )
           .resolve('org/name');
-      expect(notesOnly.runtime.minOutputTokens, isNull);
-      expect(notesOnly.notes, ['only notes']);
-
-      final junk = await f
-          .resolver(
-            manifest(
-              model: {
-                'display_name': 'N',
-                'session_defaults': {'max_output_tokens_min': '2048'},
-              },
-            ),
-          )
-          .resolve('org/name');
-      expect(junk.runtime.minOutputTokens, isNull);
+      expect(r.runtime.supportImage, true);
+      expect(r.runtime.supportAudio, false);
+      expect(r.runtime.isThinking, false);
     });
+
+    test(
+      'session_defaults is an open object: a notes-only object gives no '
+      'minOutputTokens; a value outside `integer, minimum: 1` is ignored',
+      () async {
+        final f = _Fetches();
+        final notesOnly = await f
+            .resolver(
+              manifest(
+                model: {
+                  'display_name': 'N',
+                  'session_defaults': {'notes': 'only notes'},
+                },
+              ),
+            )
+            .resolve('org/name');
+        expect(notesOnly.runtime.minOutputTokens, isNull);
+        expect(notesOnly.notes, ['only notes']);
+
+        for (final bad in ['2048', 2048.0, 0, -1, true]) {
+          final junk = await f
+              .resolver(
+                manifest(
+                  model: {
+                    'display_name': 'N',
+                    'session_defaults': {'max_output_tokens_min': bad},
+                  },
+                ),
+              )
+              .resolve('org/name');
+          expect(junk.runtime.minOutputTokens, isNull, reason: '$bad');
+        }
+        final one = await f
+            .resolver(
+              manifest(
+                model: {
+                  'display_name': 'N',
+                  'session_defaults': {'max_output_tokens_min': 1},
+                },
+              ),
+            )
+            .resolve('org/name');
+        expect(one.runtime.minOutputTokens, 1);
+      },
+    );
 
     test('a backend name outside the PreferredBackend enum maps to null '
         '(SDK default), not an error', () async {
@@ -598,6 +661,74 @@ void main() {
           ),
         ),
       );
+    });
+
+    /// A manifest with one element of a string list replaced by a number.
+    Map<String, dynamic> withBadElement(String list) {
+      final variant = <String, dynamic>{
+        'file': 'model.litertlm',
+        'quantization': 'int8',
+        'backends': ['cpu'],
+        'requirements': {
+          'platform_notes': ['ok'],
+        },
+        'known_issues': ['ok'],
+      };
+      switch (list) {
+        case 'platform_notes':
+          variant['requirements'] = {
+            'platform_notes': ['ok', 42],
+          };
+        case 'known_issues':
+          variant['known_issues'] = ['ok', 42];
+        case 'backends':
+          variant['backends'] = ['cpu', 42];
+      }
+      return manifest(variants: [variant]);
+    }
+
+    test('a wrong-typed element in platform_notes / known_issues / backends '
+        'is a FormatException at resolve, not a TypeError from a lazy cast '
+        'later', () async {
+      final f = _Fetches();
+      for (final list in ['platform_notes', 'known_issues', 'backends']) {
+        await expectLater(
+          f.resolver(withBadElement(list)).resolve('org/name'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('org/name'),
+            ),
+          ),
+          reason: list,
+        );
+        // The vendored reader itself checks the elements at parse.
+        expect(
+          () => LitertlmManifest.fromJson(withBadElement(list)),
+          throwsA(isA<TypeError>()),
+          reason: list,
+        );
+      }
+    });
+
+    test('a wrong-typed base_model / architecture is a FormatException, '
+        'not a TypeError from the modelType mapping', () async {
+      final f = _Fetches();
+      for (final field in ['base_model', 'architecture']) {
+        final m = manifest(model: {'display_name': 'N', field: 3});
+        await expectLater(
+          f.resolver(m).resolve('org/name'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('org/name'),
+            ),
+          ),
+          reason: field,
+        );
+      }
     });
   });
 

--- a/packages/flutter_gemma_litertlm/test/manifest/litertlm_manifest_resolver_test.dart
+++ b/packages/flutter_gemma_litertlm/test/manifest/litertlm_manifest_resolver_test.dart
@@ -1,0 +1,817 @@
+// LitertlmManifestResolver against the HuggingFaceResolver seam (#454/#461):
+// selection is by declared ModelFileType only, the manifest's shapes map onto
+// ResolvedHfModel/ModelRuntimeDefaults per the shipped-data field shapes
+// (recommended is an optional ARRAY, capabilities.thinking is an OBJECT,
+// context_length sits on model, session_defaults is an open object), and the
+// URL the resolver hands back is authoritative: revision-pinned and encoded
+// per path segment.
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/model.dart' show ModelFileType, ModelType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_gemma_litertlm/src/manifest/litertlm_manifest.dart';
+import 'package:flutter_gemma_litertlm/src/manifest/litertlm_manifest_resolver.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The LFM2.5 fixture — the shipped manifest whose shape (a cpu-only int4, a
+/// cpu+gpu re-export, a cpu-only int8, with conflicting per-platform
+/// recommendations) discriminates every branch of the spec's resolution rule.
+String lfmFixture() => File(
+  'test/manifest/fixtures/litert-community__LFM2.5-1.2B-Instruct.json',
+).readAsStringSync();
+
+/// A resolver whose fetch returns [body] and records what was requested.
+class _Fetches {
+  Uri? url;
+  Map<String, String>? headers;
+
+  LitertlmManifestResolver resolver(Object body, {String revision = 'main'}) =>
+      LitertlmManifestResolver(
+        revision: revision,
+        fetch: (u, h) async {
+          url = u;
+          headers = h;
+          if (body is ManifestFetchException) throw body;
+          return body is String ? body : jsonEncode(body);
+        },
+      );
+}
+
+/// Minimal valid manifest; override pieces per test.
+Map<String, dynamic> manifest({
+  Map<String, dynamic>? model,
+  List<Map<String, dynamic>>? variants,
+}) => {
+  'manifest_schema': '0.1.0',
+  'repo': 'org/name',
+  'generated': '2026-08-27',
+  'model': model ?? {'display_name': 'Name'},
+  'variants':
+      variants ??
+      [
+        {
+          'file': 'model.litertlm',
+          'sha256': 'a' * 64,
+          'size_bytes': 123456,
+          'quantization': 'int8',
+          'backends': ['cpu'],
+          'default_backend': 'cpu',
+        },
+      ],
+};
+
+void main() {
+  group('canResolve claims exactly ModelFileType.litertlm', () {
+    const r = LitertlmManifestResolver();
+    test('accepts a declared litertlm hint', () {
+      expect(r.canResolve('org/name', fileType: ModelFileType.litertlm), true);
+    });
+    test('declines a null hint (no routing by registration order)', () {
+      expect(r.canResolve('org/name'), false);
+    });
+    test('declines every other file type', () {
+      for (final t in ModelFileType.values) {
+        if (t == ModelFileType.litertlm) continue;
+        expect(r.canResolve('org/name', fileType: t), false, reason: '$t');
+      }
+    });
+  });
+
+  group('registry selection', () {
+    setUp(() => HuggingFaceResolverRegistry.instance.reset());
+    tearDown(() => HuggingFaceResolverRegistry.instance.reset());
+
+    test('found for litertlm, not for a bare or foreign hint', () {
+      const r = LitertlmManifestResolver();
+      HuggingFaceResolverRegistry.instance.registerAll([r]);
+      expect(
+        HuggingFaceResolverRegistry.instance.findFor(
+          'org/name',
+          fileType: ModelFileType.litertlm,
+        ),
+        same(r),
+      );
+      expect(HuggingFaceResolverRegistry.instance.findFor('org/name'), isNull);
+      expect(
+        HuggingFaceResolverRegistry.instance.findFor(
+          'org/name',
+          fileType: ModelFileType.onnx,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('manifest → ResolvedHfModel mapping', () {
+    final full = manifest(
+      model: {
+        'display_name': 'Qwen3-4B-Thinking-2507',
+        'base_model': 'Qwen/Qwen3-4B-Thinking-2507',
+        'architecture': 'qwen3-dense (36 layers)',
+        'context_length': 4096,
+        'session_defaults': {
+          'max_output_tokens_min': 2048,
+          'notes': 'Reasoning model: needs the output floor.',
+        },
+        'capabilities': {
+          'vision': false,
+          'audio': false,
+          'thinking': {
+            'declared': true,
+            'channel': {'start': '<think>\n', 'end': '\n</think>'},
+          },
+        },
+      },
+      variants: [
+        {
+          'file': 'model.litertlm',
+          'sha256': 'b' * 64,
+          'size_bytes': 999,
+          'quantization': 'int4',
+          'backends': ['cpu', 'gpu'],
+          'default_backend': 'gpu',
+          'recommended': [
+            {'platform': 'ios', 'backend': 'gpu', 'reason': 'fastest verified'},
+          ],
+          'requirements': {
+            'platform_notes': ['budget RAM accordingly'],
+          },
+          'known_issues': ['a known issue'],
+        },
+      ],
+    );
+
+    test('runtime defaults come from the documented field homes', () async {
+      final f = _Fetches();
+      final r = await f.resolver(full).resolve('org/name', platform: 'ios');
+      // context_length lives on model, not the variant.
+      expect(r.runtime.maxTokens, 4096);
+      // capabilities.thinking is an object; `declared` is what maps here.
+      expect(r.runtime.isThinking, true);
+      // session_defaults.max_output_tokens_min → the minOutputTokens FLOOR.
+      expect(r.runtime.minOutputTokens, 2048);
+      expect(r.runtime.supportImage, false);
+      expect(r.runtime.supportAudio, false);
+      expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+      expect(r.fileType, ModelFileType.litertlm);
+      expect(r.modelType, ModelType.qwen3);
+      expect(r.file, 'model.litertlm');
+      expect(
+        r.url,
+        'https://huggingface.co/org/name/resolve/main/model.litertlm',
+      );
+      expect(r.sha256, 'b' * 64);
+      expect(r.sizeBytes, 999);
+    });
+
+    test('notes carry platform notes, known issues, and the session-defaults '
+        'notes string, and are unmodifiable', () async {
+      final f = _Fetches();
+      final r = await f.resolver(full).resolve('org/name', platform: 'ios');
+      expect(r.notes, [
+        'budget RAM accordingly',
+        'a known issue',
+        'Reasoning model: needs the output floor.',
+      ]);
+      expect(() => r.notes.add('x'), throwsUnsupportedError);
+    });
+
+    test('no recommended rows → default_backend (the shape 21 of the 35 '
+        'published variants have)', () async {
+      final f = _Fetches();
+      final r = await f
+          .resolver(manifest())
+          .resolve('org/name', platform: 'android');
+      expect(r.file, 'model.litertlm');
+      expect(r.runtime.preferredBackend, PreferredBackend.cpu);
+    });
+
+    test(
+      'a caller backend hint is honoured when the variant lists it',
+      () async {
+        final m = manifest(
+          variants: [
+            {
+              'file': 'model.litertlm',
+              'sha256': 'a' * 64,
+              'size_bytes': 1,
+              'quantization': 'int8',
+              'backends': ['cpu', 'gpu'],
+              'default_backend': 'cpu',
+            },
+          ],
+        );
+        final f = _Fetches();
+        final r = await f
+            .resolver(m)
+            .resolve('org/name', preferredBackend: PreferredBackend.gpu);
+        expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+      },
+    );
+
+    test(
+      'an explicit backend hint is a filter: android+gpu picks the gpu '
+      're-export over the cpu recommendation (spec resolution rule)',
+      () async {
+        final f = _Fetches();
+        final r = await f
+            .resolver(lfmFixture())
+            .resolve(
+              'litert-community/LFM2.5-1.2B-Instruct',
+              platform: 'android',
+              preferredBackend: PreferredBackend.gpu,
+            );
+        expect(r.file, 'LFM2.5-1.2B-Instruct_int4_gpu.litertlm');
+        expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+      },
+    );
+
+    test('with a backend hint, only recommendations naming it count: '
+        'macos+cpu picks the int8 cpu recommendation, not the gpu '
+        're-export forced onto cpu', () async {
+      final f = _Fetches();
+      final r = await f
+          .resolver(lfmFixture())
+          .resolve(
+            'litert-community/LFM2.5-1.2B-Instruct',
+            platform: 'macos',
+            preferredBackend: PreferredBackend.cpu,
+          );
+      expect(r.file, 'LFM2.5-1.2B-Instruct_int8.litertlm');
+      expect(r.runtime.preferredBackend, PreferredBackend.cpu);
+    });
+
+    test(
+      'a hint no variant is verified on is dropped, never silently '
+      'claimed: npu resolves to the platform pick with its own backend',
+      () async {
+        final f = _Fetches();
+        // macos discriminates: the platform pick (int4_gpu via the macos
+        // recommendation) differs from the no-platform fallback (int4/cpu),
+        // so this also pins that the drop lane keeps the platform.
+        final r = await f
+            .resolver(lfmFixture())
+            .resolve(
+              'litert-community/LFM2.5-1.2B-Instruct',
+              platform: 'macos',
+              preferredBackend: PreferredBackend.npu,
+            );
+        expect(r.file, 'LFM2.5-1.2B-Instruct_int4_gpu.litertlm');
+        expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+      },
+    );
+
+    test('gpu hint on a cpu-only repo falls back to the manifest choice '
+        '(the hint is dropped, not substituted into the result)', () async {
+      final f = _Fetches();
+      final r = await f
+          .resolver(manifest())
+          .resolve('org/name', preferredBackend: PreferredBackend.gpu);
+      expect(r.file, 'model.litertlm');
+      expect(r.runtime.preferredBackend, PreferredBackend.cpu);
+    });
+
+    test(
+      'the "unknown" platform key from core means "no per-platform hint"',
+      () async {
+        final m = manifest(
+          variants: [
+            {
+              'file': 'model.litertlm',
+              'sha256': 'a' * 64,
+              'size_bytes': 1,
+              'quantization': 'int8',
+              'backends': ['cpu', 'gpu'],
+              'default_backend': 'gpu',
+              'recommended': [
+                {'platform': 'android', 'backend': 'cpu'},
+              ],
+            },
+          ],
+        );
+        final f = _Fetches();
+        final r = await f.resolver(m).resolve('org/name', platform: 'unknown');
+        // Falls through to default_backend, exactly like passing no platform.
+        expect(r.runtime.preferredBackend, PreferredBackend.gpu);
+      },
+    );
+
+    test(
+      'silent manifest → null runtime fields (SDK defaults apply)',
+      () async {
+        final f = _Fetches();
+        final r = await f.resolver(manifest()).resolve('org/name');
+        expect(r.runtime.maxTokens, isNull);
+        expect(r.runtime.minOutputTokens, isNull);
+        expect(r.modelType, isNull);
+      },
+    );
+
+    test('session_defaults is an open object: a notes-only object gives no '
+        'minOutputTokens, a non-int value is ignored', () async {
+      final f = _Fetches();
+      final notesOnly = await f
+          .resolver(
+            manifest(
+              model: {
+                'display_name': 'N',
+                'session_defaults': {'notes': 'only notes'},
+              },
+            ),
+          )
+          .resolve('org/name');
+      expect(notesOnly.runtime.minOutputTokens, isNull);
+      expect(notesOnly.notes, ['only notes']);
+
+      final junk = await f
+          .resolver(
+            manifest(
+              model: {
+                'display_name': 'N',
+                'session_defaults': {'max_output_tokens_min': '2048'},
+              },
+            ),
+          )
+          .resolve('org/name');
+      expect(junk.runtime.minOutputTokens, isNull);
+    });
+
+    test('a backend name outside the PreferredBackend enum maps to null '
+        '(SDK default), not an error', () async {
+      final m = manifest(
+        variants: [
+          {
+            'file': 'model.litertlm',
+            'sha256': 'a' * 64,
+            'size_bytes': 1,
+            'quantization': 'int8',
+            'backends': ['webgpu'],
+            'default_backend': 'webgpu',
+          },
+        ],
+      );
+      final f = _Fetches();
+      final r = await f.resolver(m).resolve('org/name');
+      expect(r.runtime.preferredBackend, isNull);
+      expect(r.file, 'model.litertlm');
+    });
+  });
+
+  group('fetch: URL, revision, auth', () {
+    test('fetches the manifest at /resolve/main/ with no auth header by '
+        'default', () async {
+      final f = _Fetches();
+      await f.resolver(manifest()).resolve('org/name');
+      expect(
+        f.url.toString(),
+        'https://huggingface.co/org/name/resolve/main/litertlm_manifest.json',
+      );
+      expect(f.headers, isEmpty);
+    });
+
+    test('a token becomes a Bearer header', () async {
+      final f = _Fetches();
+      await f.resolver(manifest()).resolve('org/name', token: 'hf_secret');
+      expect(f.headers, {'Authorization': 'Bearer hf_secret'});
+    });
+
+    test('a pinned revision reaches both the manifest GET and the returned '
+        'url', () async {
+      final f = _Fetches();
+      final r = await f
+          .resolver(manifest(), revision: 'abc123')
+          .resolve('org/name');
+      expect(f.url!.path, '/org/name/resolve/abc123/litertlm_manifest.json');
+      expect(
+        r.url,
+        'https://huggingface.co/org/name/resolve/abc123/model.litertlm',
+      );
+    });
+
+    test('a slash-bearing revision is one encoded path segment in both '
+        'URLs', () async {
+      final f = _Fetches();
+      final r = await f
+          .resolver(manifest(), revision: 'refs/pr/1')
+          .resolve('org/name');
+      expect(
+        f.url.toString(),
+        'https://huggingface.co/org/name/resolve/refs%2Fpr%2F1/'
+        'litertlm_manifest.json',
+      );
+      expect(
+        r.url,
+        'https://huggingface.co/org/name/resolve/refs%2Fpr%2F1/'
+        'model.litertlm',
+      );
+    });
+
+    test('a nested variant path keeps its structure (per-segment encoding, '
+        'same rule as fromHuggingFace)', () async {
+      final m = manifest(
+        variants: [
+          {
+            'file': 'int4/model v2.litertlm',
+            'sha256': 'a' * 64,
+            'size_bytes': 1,
+            'quantization': 'int4',
+            'backends': ['cpu'],
+            'default_backend': 'cpu',
+          },
+        ],
+      );
+      final f = _Fetches();
+      final r = await f.resolver(m).resolve('org/name');
+      expect(
+        r.url,
+        'https://huggingface.co/org/name/resolve/main/int4/model%20v2.litertlm',
+      );
+    });
+
+    test('an empty repo fails loud at the seam', () {
+      final f = _Fetches();
+      expect(() => f.resolver(manifest()).resolve('  '), throwsArgumentError);
+    });
+  });
+
+  group('failure modes', () {
+    test(
+      '404 names the missing manifest and the fromHuggingFace fallback',
+      () async {
+        final f = _Fetches();
+        final r = f.resolver(
+          ManifestFetchException(
+            Uri.parse('https://huggingface.co/x'),
+            'GET failed with HTTP 404',
+            statusCode: 404,
+          ),
+        );
+        await expectLater(
+          r.resolve('org/name'),
+          throwsA(
+            isA<ManifestFetchException>()
+                .having((e) => e.statusCode, 'statusCode', 404)
+                .having(
+                  (e) => e.message,
+                  'message',
+                  allOf(
+                    contains('does not ship a litertlm_manifest.json'),
+                    contains('fromHuggingFace'),
+                  ),
+                ),
+          ),
+        );
+      },
+    );
+
+    test('401 explains gated/private/nonexistent (measured HF behaviour: '
+        'repo existence is not revealed unauthenticated)', () async {
+      final f = _Fetches();
+      final r = f.resolver(
+        ManifestFetchException(
+          Uri.parse('https://huggingface.co/x'),
+          'GET failed with HTTP 401',
+          statusCode: 401,
+        ),
+      );
+      await expectLater(
+        r.resolve('org/name'),
+        throwsA(
+          isA<ManifestFetchException>()
+              .having((e) => e.statusCode, 'statusCode', 401)
+              .having(
+                (e) => e.message,
+                'message',
+                allOf(contains('gated'), contains('token')),
+              ),
+        ),
+      );
+    });
+
+    test('403 points at token acceptance for gated repos', () async {
+      final f = _Fetches();
+      final r = f.resolver(
+        ManifestFetchException(
+          Uri.parse('https://huggingface.co/x'),
+          'GET failed with HTTP 403',
+          statusCode: 403,
+        ),
+      );
+      await expectLater(
+        r.resolve('org/name'),
+        throwsA(
+          isA<ManifestFetchException>()
+              .having((e) => e.statusCode, 'statusCode', 403)
+              .having((e) => e.message, 'message', contains('license')),
+        ),
+      );
+    });
+
+    test('other HTTP failures pass through unrewritten', () async {
+      final f = _Fetches();
+      final r = f.resolver(
+        ManifestFetchException(
+          Uri.parse('https://huggingface.co/x'),
+          'GET failed with HTTP 503',
+          statusCode: 503,
+        ),
+      );
+      await expectLater(
+        r.resolve('org/name'),
+        throwsA(
+          isA<ManifestFetchException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            503,
+          ),
+        ),
+      );
+    });
+
+    test('a body that is not JSON is a FormatException', () async {
+      final f = _Fetches();
+      await expectLater(
+        f.resolver('<!doctype html>').resolve('org/name'),
+        throwsFormatException,
+      );
+    });
+
+    test('a 0.2 manifest is refused, not half-parsed', () async {
+      final f = _Fetches();
+      final m = manifest()..['manifest_schema'] = '0.2.0';
+      await expectLater(
+        f.resolver(m).resolve('org/name'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('0.1.x'),
+          ),
+        ),
+      );
+    });
+
+    test('a variant with no backends is refused at parse '
+        '(schema requires minItems: 1)', () async {
+      final f = _Fetches();
+      for (final variant in [
+        {'file': 'a.litertlm', 'quantization': 'q', 'backends': <String>[]},
+        {'file': 'a.litertlm', 'quantization': 'q'},
+      ]) {
+        await expectLater(
+          f.resolver(manifest(variants: [variant])).resolve('org/name'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('minItems'),
+            ),
+          ),
+        );
+      }
+    });
+
+    test('a malformed field is surfaced as a FormatException naming the '
+        'repo, not an opaque cast error', () async {
+      final f = _Fetches();
+      final m = manifest(
+        variants: [
+          {
+            'file': 42, // wrong type
+            'quantization': 'int8',
+          },
+        ],
+      );
+      await expectLater(
+        f.resolver(m).resolve('org/name'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('org/name'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('modelType mapping (conservative: null over a wrong guess)', () {
+    ModelType? map(String base, {String display = '', String arch = ''}) =>
+        LitertlmManifestResolver.mapModelType(
+          baseModel: base,
+          displayName: display,
+          architecture: arch,
+        );
+
+    test('deepseek wins over the qwen in a distill id', () {
+      expect(
+        map(
+          'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B',
+          arch: 'Qwen2 dense decoder (Qwen2ForCausalLM, 28 layers)',
+        ),
+        ModelType.deepSeek,
+      );
+    });
+
+    test('qwen3.5 is qwen (ChatML without the qwen3 /no_think injection)', () {
+      expect(map('Qwen/Qwen3.5-4B'), ModelType.qwen);
+      expect(map('Qwen/Qwen3.5-0.8B'), ModelType.qwen);
+    });
+
+    test('qwen3 by id, and by the Qwen3ForCausalLM class token when the id '
+        'hides the family (a finetune)', () {
+      expect(map('Qwen/Qwen3-4B-Thinking-2507'), ModelType.qwen3);
+      expect(
+        map(
+          'superwhisper/s1-mini',
+          arch:
+              'Dense 0.6B ASR-transcript normalizer, Qwen3ForCausalLM '
+              'finetune',
+        ),
+        ModelType.qwen3,
+      );
+    });
+
+    test('qwen2-family by id or class token', () {
+      expect(map('Qwen/Qwen2-VL-2B-Instruct'), ModelType.qwen);
+      expect(map('llava-hf/llava-onevision-qwen2-0.5b-ov-hf'), ModelType.qwen);
+      expect(
+        map(
+          'WeiboAI/VibeThinker-3B',
+          arch: 'Dense 3B math/reasoning model, Qwen2ForCausalLM, 36 layers',
+        ),
+        ModelType.qwen,
+      );
+    });
+
+    test('architecture prose naming a compute lineage must NOT map — only '
+        'ids and exact class tokens do', () {
+      // "Llama-architecture granite decoder" describes compute, not the chat
+      // contract; ModelType.llama here would break iOS conversations.
+      expect(
+        map(
+          'ibm-granite/granite-docling-258M',
+          arch:
+              'VLM: SigLIP encoder feeding a Llama-architecture granite '
+              'decoder',
+        ),
+        isNull,
+      );
+      expect(
+        map(
+          'HuggingFaceTB/SmolVLM2-500M-Video-Instruct',
+          arch: 'SigLIP + SmolLM2-360M (Llama) decoder',
+        ),
+        isNull,
+      );
+    });
+
+    test('llama and phi by id, with word boundaries', () {
+      expect(map('meta-llama/Llama-3.2-1B-Instruct'), ModelType.llama);
+      expect(map('microsoft/Phi-4-mini-instruct'), ModelType.phi);
+      expect(map('someorg/ollama-export'), isNull); // 'llama' inside a word
+      expect(map('someorg/delphi-model'), isNull); // 'phi' without a digit
+    });
+
+    test('gemma generations: gemma4 is the E2B/E4B generation, not a 4B '
+        'gemma 3', () {
+      expect(map('google/gemma-4-e2b-it'), ModelType.gemma4);
+      expect(map('google/gemma-3-4b-it'), ModelType.gemmaIt);
+      expect(map('google/gemma-4b-it'), ModelType.gemmaIt);
+      expect(map('google/functiongemma-270m'), ModelType.functionGemma);
+    });
+
+    test('families outside the enum stay null — the app supplies one', () {
+      expect(map('LiquidAI/LFM2.5-1.2B-Instruct'), isNull);
+      expect(map('mistralai/Ministral-3-3B-Instruct-2512'), isNull);
+      expect(map('HuggingFaceTB/SmolLM3-3B'), isNull);
+      expect(
+        map(
+          'nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16',
+          arch: 'NemotronHForCausalLM hybrid',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('vendored reader stays logic-identical to the reference '
+      '(readers/dart 0.2.0)', () {
+    final lfm = LitertlmManifest.fromJson(lfmFixture());
+
+    test('explicit gpu request survives the variant pick', () {
+      final r = lfm.resolve(platform: 'android', backend: 'gpu')!;
+      expect(r.file, 'LFM2.5-1.2B-Instruct_int4_gpu.litertlm');
+      expect(r.backend, 'gpu');
+    });
+
+    test('explicit backend wins over the platform recommendation; caveats '
+        'surface in notes', () {
+      final r = lfm.resolve(platform: 'ios', backend: 'gpu')!;
+      expect(r.file, 'LFM2.5-1.2B-Instruct_int4_gpu.litertlm');
+      expect(r.backend, 'gpu');
+      expect(r.variant.backends, contains(r.backend));
+      expect(r.notes.any((n) => n.contains('Metal')), isTrue);
+    });
+
+    test('explicit backend counts only recommendations naming it', () {
+      final r = lfm.resolve(platform: 'macos', backend: 'cpu')!;
+      expect(r.file, 'LFM2.5-1.2B-Instruct_int8.litertlm');
+      expect(r.backend, 'cpu');
+    });
+
+    test('a backend no variant lists resolves to null, never a substitute', () {
+      expect(lfm.resolve(backend: 'npu'), isNull);
+      expect(lfm.resolve(platform: 'android', backend: 'npu'), isNull);
+    });
+
+    test('deviceClass with no matching entry falls back with a note in '
+        'reason', () {
+      final r = lfm.resolve(platform: 'android', deviceClass: 'budget-2019')!;
+      expect(
+        r.reason,
+        contains('no budget-2019 entry; using the midrange recommendation'),
+      );
+    });
+
+    test('recommended row naming an unverified backend is ignored', () {
+      final m = LitertlmManifest.fromJson({
+        'manifest_schema': '0.1.0',
+        'repo': 'test/malformed',
+        'generated': '2026-08-26',
+        'model': {'display_name': 'Malformed'},
+        'variants': [
+          {
+            'file': 'm.litertlm',
+            'quantization': 'int8',
+            'backends': ['cpu'],
+            'default_backend': 'cpu',
+            'recommended': [
+              {'platform': 'android', 'backend': 'gpu'},
+            ],
+          },
+        ],
+      });
+      final r = m.resolve(platform: 'android')!;
+      expect(r.backend, 'cpu');
+    });
+
+    test('resolution URLs follow the fetched revision', () {
+      final pinned = LitertlmManifest.fromJson(manifest(), revision: 'abc123');
+      expect(pinned.resolve()!.url, contains('/resolve/abc123/'));
+      expect(
+        pinned.resolve(revision: 'deadbeef')!.url,
+        contains('/resolve/deadbeef/'),
+      );
+      expect(lfm.resolve()!.url, contains('/resolve/main/'));
+    });
+
+    test('0.1.1 declared channel set flows through, tool-call included; '
+        'absent → empty', () {
+      final m = LitertlmManifest.fromJson({
+        'manifest_schema': '0.1.1',
+        'repo': 'test/channels',
+        'generated': '2026-08-27',
+        'model': {
+          'display_name': 'Channels',
+          'capabilities': {
+            'thinking': {
+              'declared': true,
+              'channel': {'start': '<think>', 'end': '</think>'},
+            },
+            'channels': [
+              {
+                'name': 'thought',
+                'start': '<think>',
+                'end': '</think>',
+                'is_reasoning': true,
+              },
+              {
+                'name': 'tool_call',
+                'start': '<tool_call>',
+                'end': '</tool_call>',
+              },
+            ],
+          },
+        },
+        'variants': [
+          {
+            'file': 'a.litertlm',
+            'quantization': 'q',
+            'backends': ['cpu'],
+          },
+        ],
+      });
+      expect(m.declaredChannels.length, 2);
+      expect(m.declaredChannels[1].name, 'tool_call');
+      expect(m.declaredChannels[0].isReasoning, isTrue);
+      expect(lfm.declaredChannels, isEmpty);
+    });
+  });
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/manifest_fetch_io_test.dart
+++ b/packages/flutter_gemma_litertlm/test/manifest/manifest_fetch_io_test.dart
@@ -1,0 +1,154 @@
+// The dart:io default fetch against a loopback HttpServer: the status is read
+// before the body (so a 404 whose body is not UTF-8 still reports 404), any
+// 2xx is success (as on web), redirects are followed, headers go out verbatim,
+// and a transport failure is a status-less ManifestFetchException.
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_gemma_litertlm/src/manifest/manifest_fetch_io.dart';
+import 'package:flutter_gemma_litertlm/src/manifest/manifest_fetch_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Bytes no UTF-8 decoder accepts strictly: a lone continuation byte and an
+/// unpaired lead byte around plain ASCII.
+const _notUtf8 = [0x80, 0x7B, 0xC3, 0x7D];
+
+void main() {
+  late HttpServer server;
+  late Uri base;
+  HttpHeaders? lastRequestHeaders;
+
+  setUp(() async {
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    base = Uri.parse('http://${server.address.host}:${server.port}');
+    lastRequestHeaders = null;
+    server.listen((req) async {
+      lastRequestHeaders = req.headers;
+      final res = req.response;
+      switch (req.uri.path) {
+        case '/404-bad-bytes':
+          res.statusCode = 404;
+          res.add(_notUtf8);
+        case '/500-bad-bytes':
+          res.statusCode = 500;
+          res.add(_notUtf8);
+        case '/201':
+          res.statusCode = 201;
+          res.write('{"created":true}');
+        case '/204':
+          res.statusCode = 204;
+        case '/307':
+          res.statusCode = 307;
+          res.headers.set('location', base.resolve('/ok').toString());
+        case '/307-to-404':
+          res.statusCode = 307;
+          res.headers.set(
+            'location',
+            base.resolve('/404-bad-bytes').toString(),
+          );
+        case '/200-bad-bytes':
+          res.statusCode = 200;
+          res.add(_notUtf8);
+        default:
+          res.statusCode = 200;
+          res.write('{"ok":true}');
+      }
+      await res.close();
+    });
+  });
+
+  tearDown(() => server.close(force: true));
+
+  test('a non-2xx whose body is not UTF-8 still carries its status', () async {
+    for (final (path, status) in [
+      ('/404-bad-bytes', 404),
+      ('/500-bad-bytes', 500),
+    ]) {
+      await expectLater(
+        defaultManifestFetch(base.resolve(path), const {}),
+        throwsA(
+          isA<ManifestFetchException>()
+              .having((e) => e.statusCode, 'statusCode', status)
+              .having((e) => e.url.path, 'url', path),
+        ),
+        reason: path,
+      );
+    }
+  });
+
+  test('any 2xx is success, as on web', () async {
+    expect(
+      await defaultManifestFetch(base.resolve('/ok'), const {}),
+      '{"ok":true}',
+    );
+    expect(
+      await defaultManifestFetch(base.resolve('/201'), const {}),
+      '{"created":true}',
+    );
+    expect(await defaultManifestFetch(base.resolve('/204'), const {}), '');
+  });
+
+  test(
+    'a redirect is followed (Hugging Face 307s /resolve/ to its CDN)',
+    () async {
+      expect(
+        await defaultManifestFetch(base.resolve('/307'), const {}),
+        '{"ok":true}',
+      );
+    },
+  );
+
+  test('a redirect that lands on an error reports the final status', () async {
+    await expectLater(
+      defaultManifestFetch(base.resolve('/307-to-404'), const {}),
+      throwsA(
+        isA<ManifestFetchException>().having(
+          (e) => e.statusCode,
+          'statusCode',
+          404,
+        ),
+      ),
+    );
+  });
+
+  test('headers go out verbatim', () async {
+    await defaultManifestFetch(base.resolve('/ok'), {
+      'Authorization': 'Bearer hf_secret',
+    });
+    expect(lastRequestHeaders?.value('authorization'), 'Bearer hf_secret');
+  });
+
+  test('a 2xx body that is not UTF-8 decodes with replacement, like the '
+      "browser's Response.text()", () async {
+    final body = await defaultManifestFetch(
+      base.resolve('/200-bad-bytes'),
+      const {},
+    );
+    expect(body, contains('\u{FFFD}'));
+    expect(body, contains('{'));
+    // Not silently swallowed downstream either: it is not JSON.
+    expect(() => jsonDecode(body), throwsFormatException);
+  });
+
+  test(
+    'a transport failure is a ManifestFetchException without a status',
+    () async {
+      final closed = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final url = Uri.parse('http://${closed.address.host}:${closed.port}/x');
+      await closed.close(force: true);
+      await expectLater(
+        defaultManifestFetch(url, const {}),
+        throwsA(
+          isA<ManifestFetchException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            isNull,
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/shipped_manifests_regression_test.dart
+++ b/packages/flutter_gemma_litertlm/test/manifest/shipped_manifests_regression_test.dart
@@ -1,0 +1,321 @@
+// Runs the resolver over a snapshot of EVERY live manifest the
+// hf-to-litertlm converter had shipped as of 2026-08-27 (21 repos, 35
+// variants — fixtures/README.md regenerates it), across every platform key
+// core can send and every backend hint. Guards the resolver against the real
+// published data: the invariants hold for all ~670 combinations, the golden
+// rows pin the v0.1 selection algorithm to the reference readers' output, and
+// the dataset-shape counts fail loudly if regenerated fixtures change the
+// distributions the mapping decisions were made against.
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/model.dart' show ModelType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show ResolvedHfModel;
+import 'package:flutter_gemma_litertlm/src/manifest/litertlm_manifest_resolver.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _platforms = [
+  null,
+  'android',
+  'ios',
+  'macos',
+  'windows',
+  'linux',
+  'web',
+  'unknown',
+];
+// npu: no shipped variant is verified on it, so it exercises the hint-drop
+// lane (the resolver resolves without the hint) on every repo.
+const _hints = [
+  null,
+  PreferredBackend.cpu,
+  PreferredBackend.gpu,
+  PreferredBackend.npu,
+];
+
+String _wire(PreferredBackend b) => switch (b) {
+  PreferredBackend.cpu => 'cpu',
+  PreferredBackend.gpu => 'gpu',
+  PreferredBackend.npu => 'npu',
+};
+
+void main() {
+  final dir = Directory('test/manifest/fixtures');
+  final fixtures =
+      dir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.json'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  final byRepo = <String, Map<String, dynamic>>{};
+  for (final f in fixtures) {
+    final json = jsonDecode(f.readAsStringSync()) as Map<String, dynamic>;
+    byRepo[json['repo'] as String] = json;
+  }
+
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? platform,
+    PreferredBackend? hint,
+  }) => LitertlmManifestResolver(
+    fetch: (url, headers) async => jsonEncode(byRepo[repo]),
+  ).resolve(repo, platform: platform, preferredBackend: hint);
+
+  test('the snapshot has the documented shape (21 repos, 35 variants)', () {
+    expect(byRepo.length, 21);
+    final variants = byRepo.values
+        .expand((m) => m['variants'] as List)
+        .cast<Map<String, dynamic>>()
+        .toList();
+    expect(variants.length, 35);
+    // The common case is NO recommended rows — 21 of 35 variants — so the
+    // default_backend fallback is the resolver's main path, not an edge.
+    expect(variants.where((v) => v['recommended'] == null).length, 21);
+    // Every published variant carries the integrity pair.
+    for (final v in variants) {
+      expect(v['sha256'], matches(RegExp(r'^[0-9a-f]{64}$')));
+      expect(v['size_bytes'], greaterThan(0));
+    }
+  });
+
+  test('invariants hold for every repo × platform × backend hint', () async {
+    var combinations = 0;
+    for (final entry in byRepo.entries) {
+      final repo = entry.key;
+      final manifest = entry.value;
+      final model = manifest['model'] as Map<String, dynamic>;
+      final capabilities =
+          model['capabilities'] as Map<String, dynamic>? ?? const {};
+      final thinking =
+          capabilities['thinking'] as Map<String, dynamic>? ?? const {};
+      final variantsByFile = {
+        for (final v
+            in (manifest['variants'] as List).cast<Map<String, dynamic>>())
+          v['file'] as String: v,
+      };
+
+      for (final platform in _platforms) {
+        for (final hint in _hints) {
+          combinations++;
+          final r = await resolve(repo, platform: platform, hint: hint);
+          final where = '$repo p=$platform hint=$hint';
+
+          // The chosen file is one of the repo's variants, addressed at the
+          // repo's own /resolve/ path.
+          final variant = variantsByFile[r.file];
+          expect(variant, isNotNull, reason: where);
+          expect(
+            r.url,
+            'https://huggingface.co/$repo/resolve/main/'
+            '${Uri.encodeComponent(r.file)}',
+            reason: where,
+          );
+
+          // Identity comes from that same variant.
+          expect(r.sha256, variant!['sha256'], reason: where);
+          expect(r.sizeBytes, variant['size_bytes'], reason: where);
+
+          // The resolved backend is always in the variant's VERIFIED list
+          // (all shipped backends are cpu/gpu, so the enum mapping is never
+          // silently null).
+          expect(r.runtime.preferredBackend, isNotNull, reason: where);
+          expect(
+            (variant['backends'] as List).cast<String>(),
+            contains(_wire(r.runtime.preferredBackend!)),
+            reason: where,
+          );
+
+          // Spec resolution rule: a hint some variant is verified on is a
+          // FILTER — the result keeps exactly that backend. A hint nothing
+          // lists is dropped: the result must equal the same resolve with no
+          // hint (platform preserved), never a substitute for the request.
+          if (hint != null) {
+            final anyListsHint = variantsByFile.values.any(
+              (v) => (v['backends'] as List).contains(_wire(hint)),
+            );
+            if (anyListsHint) {
+              expect(r.runtime.preferredBackend, hint, reason: where);
+            } else {
+              final noHint = await resolve(repo, platform: platform);
+              expect(r.file, noHint.file, reason: where);
+              expect(
+                r.runtime.preferredBackend,
+                noHint.runtime.preferredBackend,
+                reason: where,
+              );
+            }
+          }
+
+          // Model-level fields land regardless of variant choice.
+          expect(r.runtime.maxTokens, model['context_length'], reason: where);
+          expect(
+            r.runtime.isThinking,
+            thinking['declared'] == true,
+            reason: where,
+          );
+          expect(
+            r.runtime.supportImage,
+            capabilities['vision'] == true,
+            reason: where,
+          );
+          expect(
+            r.runtime.supportAudio,
+            capabilities['audio'] == true,
+            reason: where,
+          );
+        }
+      }
+    }
+    expect(combinations, 21 * _platforms.length * _hints.length);
+  });
+
+  test(
+    'golden selections match the reference readers (v0.1 algorithm)',
+    () async {
+      // Derived by running the hf-to-litertlm readers/dart reference reader
+      // over the same fixtures. Notable: Qwen3-4B on android has NO android
+      // recommendation, so it falls through to smallest-file + default_backend
+      // — while ios/macos rows pick the recommended block-128 file.
+      const goldens = {
+        ('litert-community/LFM2.5-1.2B-Instruct', 'android'): (
+          'LFM2.5-1.2B-Instruct_int4.litertlm',
+          PreferredBackend.cpu,
+        ),
+        ('litert-community/LFM2.5-1.2B-Instruct', 'ios'): (
+          'LFM2.5-1.2B-Instruct_int4.litertlm',
+          PreferredBackend.cpu,
+        ),
+        ('litert-community/LFM2.5-1.2B-Instruct', 'macos'): (
+          'LFM2.5-1.2B-Instruct_int4_gpu.litertlm',
+          PreferredBackend.gpu,
+        ),
+        ('litert-community/Qwen3-4B-Thinking-2507', 'android'): (
+          'Qwen3_4b_thinking_dynamic_wi4b32_afp32.litertlm',
+          PreferredBackend.gpu,
+        ),
+        ('litert-community/Qwen3-4B-Thinking-2507', 'ios'): (
+          'model.litertlm',
+          PreferredBackend.gpu,
+        ),
+        ('litert-community/Qwen3-4B-Thinking-2507', 'macos'): (
+          'model.litertlm',
+          PreferredBackend.gpu,
+        ),
+        ('litert-community/SmolLM3-3B', 'android'): (
+          'SmolLM3-3B_q4_block32_ekv4096.litertlm',
+          PreferredBackend.gpu,
+        ),
+        ('mlboydaisuke/S1-mini-LiteRT', 'macos'): (
+          'S1-mini_int8.litertlm',
+          PreferredBackend.cpu,
+        ),
+      };
+      for (final entry in goldens.entries) {
+        final (repo, platform) = entry.key;
+        final (file, backend) = entry.value;
+        final r = await resolve(repo, platform: platform);
+        expect(r.file, file, reason: '$repo on $platform');
+        expect(
+          r.runtime.preferredBackend,
+          backend,
+          reason: '$repo on $platform',
+        );
+      }
+    },
+  );
+
+  test('session_defaults distribution: the floor is set exactly where the '
+      'published data sets it', () async {
+    const withFloor = {
+      'litert-community/DeepSeek-R1-Distill-Qwen-7B',
+      'litert-community/LFM2.5-1.2B-Thinking',
+      'litert-community/LFM2.5-2.6B',
+      'litert-community/Nanbeige4.2-3B',
+      'litert-community/Qwen3-4B-Thinking-2507',
+      'litert-community/VibeThinker-3B',
+    };
+    for (final repo in byRepo.keys) {
+      final r = await resolve(repo);
+      expect(
+        r.runtime.minOutputTokens,
+        withFloor.contains(repo) ? 2048 : isNull,
+        reason: repo,
+      );
+    }
+  });
+
+  test('modelType over the shipped catalog: mapped only where the family is '
+      'certain, null everywhere else', () async {
+    const expected = <String, ModelType?>{
+      // deepseek outranks the qwen in the distill's id.
+      'litert-community/DeepSeek-R1-Distill-Qwen-7B': ModelType.deepSeek,
+      'litert-community/Qwen3-4B-Thinking-2507': ModelType.qwen3,
+      // Qwen3ForCausalLM class token — the id alone hides the family.
+      'mlboydaisuke/S1-mini-LiteRT': ModelType.qwen3,
+      // Qwen3.5 is ChatML without qwen3's /no_think injection.
+      'litert-community/Qwen3.5-0.8B': ModelType.qwen,
+      'litert-community/Qwen3.5-2B': ModelType.qwen,
+      'litert-community/Qwen3.5-4B': ModelType.qwen,
+      'litert-community/Qwen2-VL-2B': ModelType.qwen,
+      'litert-community/LLaVA-OneVision-0.5B': ModelType.qwen,
+      // Qwen2ForCausalLM class token.
+      'litert-community/VibeThinker-3B': ModelType.qwen,
+      // Everything else — LFM2.5, granite, SmolLM/SmolVLM, Ministral,
+      // Nanbeige, Nemotron — has no ModelType, and prose like
+      // "Llama-architecture granite decoder" must not create one.
+      'litert-community/LFM2.5-1.2B-Instruct': null,
+      'litert-community/LFM2.5-1.2B-JP': null,
+      'litert-community/LFM2.5-1.2B-Thinking': null,
+      'litert-community/LFM2.5-2.6B': null,
+      'litert-community/Ministral-3-3B-Instruct-2512': null,
+      'litert-community/Nanbeige4.2-3B': null,
+      'litert-community/Nemotron-3-Nano-4B': null,
+      'litert-community/SmolLM3-3B': null,
+      'litert-community/SmolVLM2-500M': null,
+      'litert-community/granite-docling-258M': null,
+      'mlboydaisuke/Mordant-3B-Think-LiteRT': null,
+      'mlboydaisuke/Tashkeel-350M-v2-LiteRT': null,
+    };
+    expect(expected.length, byRepo.length);
+    for (final entry in expected.entries) {
+      final r = await resolve(entry.key);
+      expect(r.modelType, entry.value, reason: entry.key);
+    }
+  });
+
+  test('thinking is declared by exactly the 8 repos that declare it, with '
+      'their markers intact in the manifest', () async {
+    const thinkingRepos = {
+      'litert-community/LFM2.5-1.2B-Instruct',
+      'litert-community/LFM2.5-1.2B-JP',
+      'litert-community/LFM2.5-1.2B-Thinking',
+      'litert-community/LFM2.5-2.6B',
+      'litert-community/Qwen3-4B-Thinking-2507',
+      'litert-community/VibeThinker-3B',
+      'mlboydaisuke/Mordant-3B-Think-LiteRT',
+      'mlboydaisuke/S1-mini-LiteRT',
+    };
+    for (final repo in byRepo.keys) {
+      final r = await resolve(repo);
+      expect(r.runtime.isThinking, thinkingRepos.contains(repo), reason: repo);
+    }
+    // The channel markers stay exact in the data (whitespace included) even
+    // though v1 consumes only the declared bool — worth pinning so a future
+    // createSession(defaults:) can rely on them.
+    final qwen = byRepo['litert-community/Qwen3-4B-Thinking-2507']!;
+    final channel =
+        (((qwen['model'] as Map)['capabilities'] as Map)['thinking']
+                as Map)['channel']
+            as Map;
+    expect(channel['start'], '<think>\n');
+    expect(channel['end'], '\n</think>');
+  });
+}

--- a/packages/flutter_gemma_litertlm/test/manifest/shipped_manifests_regression_test.dart
+++ b/packages/flutter_gemma_litertlm/test/manifest/shipped_manifests_regression_test.dart
@@ -143,6 +143,11 @@ void main() {
             );
             if (anyListsHint) {
               expect(r.runtime.preferredBackend, hint, reason: where);
+              expect(
+                r.notes.where((n) => n.contains('resolved without that hint')),
+                isEmpty,
+                reason: where,
+              );
             } else {
               final noHint = await resolve(repo, platform: platform);
               expect(r.file, noHint.file, reason: where);
@@ -151,6 +156,14 @@ void main() {
                 noHint.runtime.preferredBackend,
                 reason: where,
               );
+              // The drop is on the record: the no-hint notes plus one line
+              // naming the dropped hint.
+              expect(r.notes, [
+                ...noHint.notes,
+                'No variant of "$repo" is verified on the requested '
+                    '${_wire(hint)} backend; resolved without that hint '
+                    '(${_wire(r.runtime.preferredBackend!)}).',
+              ], reason: where);
             }
           }
 


### PR DESCRIPTION
The resolver half of #454, built on the seam from #461: `flutter_gemma_litertlm` gains **`LitertlmManifestResolver`**, a `HuggingFaceResolver` for repos that ship a [`litertlm_manifest.json`](https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md) deployment manifest. Register it via `initialize(huggingFaceResolvers:)`, and `resolveHuggingFace(repo, fileType: ModelFileType.litertlm)` returns the right `.litertlm` file for the platform plus overridable runtime defaults — no hardcoded filenames. The README gains the end-to-end snippet.

## What this adds (`lib/src/manifest/`)

- **`LitertlmManifestResolver`** — claims exactly `ModelFileType.litertlm`, never a null hint (the #461 contract). Fetches `…/resolve/<revision>/litertlm_manifest.json` (Bearer token when given; a constructor `revision:` pins both the manifest and the returned file URL, so installing via `fromNetwork(r.url)` keeps the pin). Selection is the manifest spec's v0.1 algorithm, vendored from the reference Dart reader and kept logic-identical, so every integration resolves a repo to the same file.
- **IO** — an injectable `ManifestFetch`; the defaults are `dart:io`'s `HttpClient` natively and the browser's `fetch` on web. No new dependencies. Both follow Hugging Face's 307 redirect on `/resolve/` paths.
- **Errors with guidance** — 404: the repo ships no manifest, install with `fromHuggingFace(repo, file:)`. 401/403: token guidance — measured Hugging Face behaviour is 401 (not 404) for unauthenticated gated, private, *and nonexistent* repos, since repo existence isn't revealed. A non-0.1.x manifest is refused with a `FormatException` rather than half-parsed.

## Mapping (the decisions to veto)

- `maxTokens` ← `model.context_length` (the engine still clamps downstream, #318); `supportImage`/`supportAudio` ← `capabilities`; `isThinking` ← `capabilities.thinking.declared` — an object in the spec; the exact channel markers stay available in the manifest for a future `createSession(defaults:)`.
- `minOutputTokens` ← `session_defaults.max_output_tokens_min`. `session_defaults` is schema-open, so the key is read by name as an optional int and junk types are ignored. I've also declared the in-the-wild keys additively in the spec's 0.1 line ([schema commit](https://github.com/john-rocky/hf-to-litertlm/commit/c27de1e)), so a wrong type now fails validation at manifest-generation time.
- `preferredBackend` ← the resolved backend. An explicit caller hint follows the spec's resolution rule — a *filter*, not a preference: only variants verified on it compete and the result keeps exactly that backend; when no variant lists it, the hint is dropped with a log line and the manifest's own choice comes back, never a silent claim of the requested backend. A name outside `{cpu, gpu, npu}` maps to null (SDK default) with a log line.
- `modelType` — conservative, **null over a wrong guess**: on iOS `.litertlm` chats are formatted manually by `ModelType`, so a wrong family breaks conversations. Family words match only the curated `base_model`/`display_name` ids — the free-prose `architecture` never maps by itself (granite-docling's "Llama-architecture granite decoder" must not become `ModelType.llama`) — plus exactly two machine-precise class tokens, `Qwen3ForCausalLM`/`Qwen2ForCausalLM`, which catch finetunes whose ids hide the family. Qwen3.5 deliberately maps to `qwen`, not `qwen3`: same ChatML handling, but `qwen3` also injects ` /no_think` into user turns, which Qwen3.5 would read as literal text. Over today's catalog: `deepSeek` 1 (the R1 distill — `deepseek` outranks the `qwen` in its id), `qwen3` 2, `qwen` 6, null 12.
- `notes` ← `platform_notes` + `known_issues` + the curated `session_defaults.notes` string. Sampler hints (`temperature`/`top_k`/`top_p`, present in one shipped manifest) have no `ModelRuntimeDefaults` home yet — they wait for `createSession(defaults:)`.
- v1 resolves on **platform only**; `device_class` stays advisory (free strings, no defined vocabulary, no detection in core) — per the #454 agreement.

## Testing

- 52 contract/unit tests: fake-fetch mapping, registry probe, URL/revision/per-segment encoding, failure modes, the full `modelType` table, and a vendored-reader parity group mirroring the reference reader's own suite (explicit-backend filter, null over substitution, unverified recommendations ignored, deviceClass fallback notes, 0.1.1 `declaredChannels`).
- A regression sweep over a snapshot of **every shipped manifest** (21 repos / 35 variants as of 2026-08-27; `fixtures/README.md` has the regeneration one-liner): 672 platform × backend-hint combinations hold the invariants — the resolved backend is always in the variant's *verified* `backends` list, a hint some variant is verified on is honoured exactly, identity fields come from the chosen variant, model-level fields land regardless of variant choice. Golden selections are pinned to the reference readers' output, and dataset-shape counts keep the mapping honest: 21 of the 35 variants carry no `recommended`, so the `default_backend` fallback is the resolver's main path, not an edge.
- Live-verified against Hugging Face: platform selections, the revision pin, 307 following, and the 401/404 semantics above.
- Full package suite: 94 tests green; `flutter analyze` reports nothing for the new code.

## Not in this PR

- Acting on the sampler hints (waits for `createSession(defaults:)`).
- `device_class` resolution, and post-download sha256/size verification (carried as advisory, per #461).
- Exporting the raw manifest-reader types — `LitertlmManifestResolver` plus the fetch seam are the public surface; happy to widen it if apps want the `measured[]` rows.

Version is bumped 1.5.2 → 1.6.0 on the branch with a one-line CHANGELOG entry — renumber as you prefer. The `flutter_gemma` constraint is untouched: it needs whatever release carries #461, and that number is yours.
