### PR TITLE
feat(hf): one-call fromHuggingFace + engine-carried HF resolvers

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 1.7.0
-- Add the `HuggingFaceResolver` seam — `resolveHuggingFace` / `fromHuggingFace` / `getActiveModel(defaults:)` — for manifest-driven Hugging Face installs (#454).
-- One-call `installModel(…).fromHuggingFace(repo)` resolves the manifest and installs; engines carry their resolver, so no `huggingFaceResolvers:` list needed (#454).
+- Manifest-driven Hugging Face install (#454): `resolveHuggingFace` / one-call `installModel(…).fromHuggingFace(repo)`, with engines auto-registering their resolver.
 
 ## 1.6.5
 - Tool-declaration injection is a declarative `InferenceChat` flag, not a hardcoded gemma4 check (no behavior change).

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.7.0
 - Add the `HuggingFaceResolver` seam — `resolveHuggingFace` / `fromHuggingFace` / `getActiveModel(defaults:)` — for manifest-driven Hugging Face installs (#454).
+- One-call `installModel(…).fromHuggingFace(repo)` resolves the manifest and installs; engines carry their resolver, so no `huggingFaceResolvers:` list needed (#454).
 
 ## 1.6.5
 - Tool-declaration injection is a declarative `InferenceChat` flag, not a hardcoded gemma4 check (no behavior change).

--- a/packages/flutter_gemma/example/lib/gemma_bootstrap.dart
+++ b/packages/flutter_gemma/example/lib/gemma_bootstrap.dart
@@ -39,19 +39,16 @@ const kExampleSttBackends = [LiteRtSttBackend()];
 /// The opt-in TTS backends the example registers. Single source of truth.
 const kExampleTtsBackends = [LiteRtTtsBackend()];
 
-/// The opt-in Hugging Face resolvers the example registers — one per engine
-/// that ships one. So `FlutterGemma.resolveHuggingFace(repo, fileType:)` gives
-/// a clear result for `.litertlm` / `.onnx` / `.builtIn`, not core's generic
-/// "no resolver registered". (MediaPipe `.task`/`.bin` has no HF resolver, so
-/// `resolveHuggingFace(fileType: task)` still throws that generic error.)
-/// `LitertlmManifestResolver` reads a repo's `litertlm_manifest.json`; ONNX
-/// throws "not implemented yet" (directory install is a follow-up); built-in
-/// throws "not possible" (OS owns the weights, no HF file).
-const kExampleHuggingFaceResolvers = [
-  LitertlmManifestResolver(),
-  OnnxHuggingFaceResolver(),
-  BuiltInAiHuggingFaceResolver(),
-];
+// The Hugging Face resolvers are NOT listed here on purpose: each engine that
+// ships one (LiteRtLmEngine → litertlm_manifest.json, OnnxEngine,
+// BuiltInAiEngine) implements `HuggingFaceResolverSource`, so
+// `FlutterGemma.initialize(inferenceEngines: …)` auto-registers them — no
+// parallel `huggingFaceResolvers:` list to keep in sync. So
+// `FlutterGemma.resolveHuggingFace(repo, fileType:)` gives a clear result for
+// `.litertlm` / `.onnx` / `.builtIn` (MediaPipe `.task`/`.bin` has no resolver,
+// so `fileType: task` still throws the generic "no resolver registered").
+// Pass `huggingFaceResolvers:` to `initialize` only to OVERRIDE an engine's
+// default — e.g. `LitertlmManifestResolver(revision: 'abc123')` to pin a commit.
 
 /// The agentic skill executors the example registers (text / JS / native
 /// intent). Registered through `FlutterGemma.initialize(skillExecutors: …)` —
@@ -114,7 +111,8 @@ Future<void> bootstrapGemma({required RagBackend ragBackend}) {
     embeddingBackends: kExampleEmbeddingBackends,
     sttBackends: kExampleSttBackends,
     ttsBackends: kExampleTtsBackends,
-    huggingFaceResolvers: kExampleHuggingFaceResolvers,
+    // huggingFaceResolvers: omitted — resolvers auto-register from the engines
+    // above (each implements HuggingFaceResolverSource). See the note there.
     skillExecutors: kExampleSkillExecutors,
     vectorStore: vectorStoreFor(ragBackend),
   );

--- a/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
+++ b/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
@@ -489,7 +489,7 @@ class FlutterGemma {
   /// [HuggingFaceResolverSource] (e.g. `LiteRtLmEngine` → `LitertlmManifestResolver`).
   /// [initialize] registers these AFTER the explicit `huggingFaceResolvers:`
   /// list, so an app's explicit resolver wins the equal-priority tie. An engine
-  /// that returns `null` (has no resolver right now) contributes nothing.
+  /// that does not implement [HuggingFaceResolverSource] contributes nothing.
   /// Extracted so the derivation is unit-testable without a full [initialize].
   @visibleForTesting
   static List<HuggingFaceResolver> engineHuggingFaceResolvers(
@@ -500,8 +500,7 @@ class FlutterGemma {
       // Bind via pattern: HuggingFaceResolverSource is not a subtype of
       // InferenceEngineProvider, so a plain `is` check would not promote `e`.
       if (e case final HuggingFaceResolverSource source) {
-        final r = source.huggingFaceResolver;
-        if (r != null) resolvers.add(r);
+        resolvers.add(source.huggingFaceResolver);
       }
     }
     return resolvers;
@@ -550,9 +549,11 @@ class FlutterGemma {
   ///     .fromNetwork(r.url)
   ///     .install();
   /// final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
+  /// // minOutputTokens is a FLOOR, not a cap — leave maxOutputTokens unset (or
+  /// // keep it >= r.runtime.minOutputTokens); passing the floor AS the cap
+  /// // would truncate a reasoning model mid-thought.
   /// final session = await model.createSession(
   ///   enableThinking: r.runtime.isThinking ?? false,
-  ///   maxOutputTokens: r.runtime.minOutputTokens,
   /// );
   /// ```
   ///
@@ -571,9 +572,11 @@ class FlutterGemma {
     );
     if (resolver == null) {
       throw StateError(
-        'No Hugging Face resolver registered for "$repo". Pass one to '
-        'FlutterGemma.initialize(huggingFaceResolvers: [...]) — e.g. the '
-        'litertlm manifest resolver from flutter_gemma_litertlm.',
+        'No Hugging Face resolver registered for "$repo" (fileType: $fileType). '
+        'Register the engine that provides one — its resolver auto-registers via '
+        'HuggingFaceResolverSource (e.g. LiteRtLmEngine ships the litertlm '
+        'manifest resolver) — or pass one explicitly to '
+        'FlutterGemma.initialize(huggingFaceResolvers: [...]).',
       );
     }
     return resolver.resolve(

--- a/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
+++ b/packages/flutter_gemma/lib/core/api/flutter_gemma.dart
@@ -18,6 +18,7 @@ import 'package:flutter_gemma/core/registry/tts_registry.dart';
 import 'package:flutter_gemma/core/registry/skill_executor_registry.dart';
 import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
 import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart';
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/embedding_backend_provider.dart';
 import 'package:flutter_gemma/core/registry/stt_backend_provider.dart';
@@ -228,6 +229,16 @@ class FlutterGemma {
     }
     if (huggingFaceResolvers.isNotEmpty) {
       HuggingFaceResolverRegistry.instance.registerAll(huggingFaceResolvers);
+    }
+    // Auto-register resolvers that ride on the engines themselves (an engine
+    // that `implements HuggingFaceResolverSource` — LiteRtLmEngine, OnnxEngine,
+    // BuiltInAiEngine). Registered AFTER the explicit list so an app-supplied
+    // resolver wins the equal-priority tie (findFor: first-registered). Dedup
+    // is handled by registerAll (a `const` resolver passed both explicitly and
+    // via its engine is the same instance → registered once).
+    final engineResolvers = engineHuggingFaceResolvers(inferenceEngines);
+    if (engineResolvers.isNotEmpty) {
+      HuggingFaceResolverRegistry.instance.registerAll(engineResolvers);
     }
 
     // Single-flight model-manager init: restore the previously-active model
@@ -474,6 +485,28 @@ class FlutterGemma {
     );
   }
 
+  /// The Hugging Face resolvers contributed by [engines] that implement
+  /// [HuggingFaceResolverSource] (e.g. `LiteRtLmEngine` → `LitertlmManifestResolver`).
+  /// [initialize] registers these AFTER the explicit `huggingFaceResolvers:`
+  /// list, so an app's explicit resolver wins the equal-priority tie. An engine
+  /// that returns `null` (has no resolver right now) contributes nothing.
+  /// Extracted so the derivation is unit-testable without a full [initialize].
+  @visibleForTesting
+  static List<HuggingFaceResolver> engineHuggingFaceResolvers(
+    List<InferenceEngineProvider> engines,
+  ) {
+    final resolvers = <HuggingFaceResolver>[];
+    for (final e in engines) {
+      // Bind via pattern: HuggingFaceResolverSource is not a subtype of
+      // InferenceEngineProvider, so a plain `is` check would not promote `e`.
+      if (e case final HuggingFaceResolverSource source) {
+        final r = source.huggingFaceResolver;
+        if (r != null) resolvers.add(r);
+      }
+    }
+    return resolvers;
+  }
+
   /// Three-tier runtime-default merge used by [getActiveModel]: an explicit
   /// argument wins over a manifest [ModelRuntimeDefaults] value, which wins over
   /// the SDK default. Extracted so the precedence rule is stated — and tested —
@@ -483,8 +516,16 @@ class FlutterGemma {
       explicit ?? manifest ?? sdkDefault;
 
   /// Resolves a Hugging Face repo id into a [ResolvedHfModel] by reading that
-  /// repo's deployment metadata (e.g. `litertlm_manifest.json`), using the
-  /// resolver registered via `initialize(huggingFaceResolvers: [...])`.
+  /// repo's deployment metadata (e.g. `litertlm_manifest.json`), using a
+  /// resolver registered via `initialize` — either passed in
+  /// `huggingFaceResolvers:` or auto-derived from a registered engine that ships
+  /// one (LiteRtLmEngine, OnnxEngine, BuiltInAiEngine).
+  ///
+  /// This is the INSPECT-ONLY path (resolve, then install yourself). To resolve
+  /// AND install in one call, use `installModel(...).fromHuggingFace(repo)` with
+  /// no `file:` — it resolves the manifest internally, installs the
+  /// revision-pinned variant, and returns the runtime defaults on
+  /// `InferenceInstallation.runtime`.
   ///
   /// [fileType] tells the registry which resolver to pick (the litertlm
   /// resolver claims `ModelFileType.litertlm`); it is the only deterministic

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -28,6 +28,16 @@ class InferenceInstallationBuilder {
   void Function(int progress)? _onProgress;
   CancelToken? _cancelToken;
 
+  // Deferred Hugging Face resolution — set by `fromHuggingFace(repo)` with no
+  // `file`. The manifest is resolved in `install()`, not here, because
+  // resolution is async and builder setters are synchronous. Mutually exclusive
+  // with [_modelSource]: every other `fromX()` setter clears [_hfRepo], and the
+  // deferred `fromHuggingFace` clears [_modelSource], so the last-called source
+  // always wins.
+  String? _hfRepo;
+  String? _hfToken;
+  bool? _hfForeground;
+
   /// Create builder with model identity
   InferenceInstallationBuilder({
     required ModelType modelType,
@@ -55,6 +65,7 @@ class InferenceInstallationBuilder {
       authToken: token,
       foreground: foreground,
     );
+    _hfRepo = null; // an explicit source cancels a pending deferred-HF resolve
     return this;
   }
 
@@ -64,6 +75,7 @@ class InferenceInstallationBuilder {
   /// Handles 'assets/' prefix automatically.
   InferenceInstallationBuilder fromAsset(String path) {
     _modelSource = ModelSource.asset(path);
+    _hfRepo = null;
     return this;
   }
 
@@ -75,6 +87,7 @@ class InferenceInstallationBuilder {
   /// - Web: /assets/{resourceName}
   InferenceInstallationBuilder fromBundled(String resourceName) {
     _modelSource = ModelSource.bundled(resourceName);
+    _hfRepo = null;
     return this;
   }
 
@@ -84,39 +97,84 @@ class InferenceInstallationBuilder {
   /// Use case: User-provided models via file picker
   InferenceInstallationBuilder fromFile(String path) {
     _modelSource = ModelSource.file(path);
+    _hfRepo = null;
     return this;
   }
 
-  /// Set model source from a file in a Hugging Face repo.
+  /// Set model source from a Hugging Face repo. Two modes:
   ///
-  /// Builds `https://huggingface.co/<repo>/resolve/<revision>/<file>` and
-  /// installs it via the network path — the plugin already applies the
-  /// configured HuggingFace token to `huggingface.co` URLs for gated repos, so
-  /// [token] is only needed to override it.
+  /// **Explicit file** (pass [file]): builds
+  /// `https://huggingface.co/<repo>/resolve/<revision>/<file>` and installs it
+  /// via the network path. [file] may contain `/` for a repo that nests
+  /// variants in subfolders (e.g. `int4/model.litertlm`); each segment is
+  /// URL-encoded independently so the path structure survives. Use this when
+  /// you know the exact path (and optionally a pinned [revision]).
   ///
-  /// Pass [file] explicitly, or take it from
-  /// [FlutterGemma.resolveHuggingFace] when the repo ships a deployment
-  /// manifest (`ResolvedHfModel.file`). [file] may contain `/` for a repo that
-  /// nests variants in subfolders (e.g. `int4/model.litertlm`); each segment is
-  /// URL-encoded independently so the path structure survives.
+  /// **Manifest (one-call)** (OMIT [file]): resolves the repo's deployment
+  /// manifest internally at [install] time — via the resolver registered for
+  /// this builder's `fileType` (see [FlutterGemma.resolveHuggingFace]) — then
+  /// installs the resolved, revision-pinned variant and returns the manifest's
+  /// overridable runtime defaults on [InferenceInstallation.runtime]:
+  /// ```dart
+  /// final install = await FlutterGemma
+  ///     .installModel(modelType: ModelType.general, fileType: ModelFileType.litertlm)
+  ///     .fromHuggingFace('org/repo')            // no file — resolve the manifest
+  ///     .install();
+  /// final model = await FlutterGemma.getActiveModel(defaults: install.runtime);
+  /// ```
+  /// Notes on the manifest mode:
+  /// - [revision] must be left `'main'`: the registered resolver owns the pin
+  ///   (it builds a revision-pinned URL). Passing a non-`'main'` [revision]
+  ///   without a [file] throws [ArgumentError].
+  /// - The resolver's own error surfaces from [install]: e.g. `.onnx` throws
+  ///   `UnimplementedError`, `.builtIn` throws `UnsupportedError` (the OS owns
+  ///   the weights) — both naming the repo.
+  /// - Unlike other sources, this requires NETWORK access at [install] even if
+  ///   the model is already installed (the variant filename is only known after
+  ///   the manifest fetch). For offline-safe idempotent installs, cache the
+  ///   `ResolvedHfModel` yourself and install from `fromNetwork(r.url)`.
+  ///
+  /// The plugin already applies the configured HuggingFace token to
+  /// `huggingface.co` URLs for gated repos, so [token] is only needed to
+  /// override it (it is also threaded into the manifest fetch).
   InferenceInstallationBuilder fromHuggingFace(
     String repo, {
-    required String file,
+    String? file,
     String revision = 'main',
     String? token,
     bool? foreground,
   }) {
-    // Fail loud at the seam — a resolver that returns an empty file, or an
-    // empty repo, would otherwise build a directory URL that only 404s (or,
-    // worse, saves a CDN error page as the model) far downstream.
+    // Fail loud at the seam — an empty repo would otherwise build a URL that
+    // only 404s (or, worse, saves a CDN error page as the model) far downstream.
     if (repo.trim().isEmpty) {
       throw ArgumentError.value(repo, 'repo', 'must be a non-empty "org/name"');
+    }
+    if (file == null) {
+      // Manifest mode: defer resolution to install(). The resolver builds the
+      // revision-pinned URL, so a caller-supplied non-'main' revision here has
+      // nowhere to go — reject it loudly rather than silently dropping the pin.
+      if (revision != 'main') {
+        throw ArgumentError.value(
+          revision,
+          'revision',
+          'cannot be set without an explicit `file`: the registered resolver '
+              'owns the revision pin. Pass `file:` to install a specific path '
+              'at a specific revision, or register the resolver with the '
+              'revision you want.',
+        );
+      }
+      _modelSource = null; // cancel any earlier explicit source
+      _hfRepo = repo;
+      _hfToken = token;
+      _hfForeground = foreground;
+      return this;
     }
     if (file.trim().isEmpty) {
       throw ArgumentError.value(
         file,
         'file',
-        'must be a non-empty repo-relative path',
+        'must be a non-empty repo-relative path (or omit `file` to resolve the '
+            'repo manifest)',
       );
     }
     final encodedPath = file.split('/').map(Uri.encodeComponent).join('/');
@@ -203,9 +261,53 @@ class InferenceInstallationBuilder {
     // Check cancellation before starting
     _cancelToken?.throwIfCancelled();
 
+    // Runtime defaults / notes / model family resolved from a Hugging Face
+    // manifest (deferred `fromHuggingFace(repo)`). Null/empty for every non-HF
+    // source; ride on the RESULT ([InferenceInstallation]), never on the spec —
+    // preserving install-vs-runtime separation.
+    ModelRuntimeDefaults? resolvedRuntime;
+    List<String> resolvedNotes = const [];
+    ModelType? resolvedModelType;
+
+    // Deferred Hugging Face resolution runs FIRST — before the builtIn /
+    // onnx-web branches below, which assume a concrete _modelSource. For a
+    // `.builtIn` / `.onnx` repo the resolver throws its own clear error here
+    // (UnsupportedError / UnimplementedError, naming the repo) instead of those
+    // branches tripping over a null _modelSource.
+    if (_hfRepo != null) {
+      final r = await FlutterGemma.resolveHuggingFace(
+        _hfRepo!,
+        fileType: _fileType,
+        token: _hfToken,
+      );
+      // The manifest fetch itself is not cancellable (the resolver contract
+      // takes no CancelToken) — fail fast here, before the download starts.
+      _cancelToken?.throwIfCancelled();
+      if (r.modelType != null && r.modelType != _modelType) {
+        gemmaLog(
+          '⚠️  Hugging Face manifest declares modelType ${r.modelType} for '
+          '"$_hfRepo" — using it instead of the passed $_modelType (the '
+          'manifest is authoritative about the model family). Pass that '
+          'modelType explicitly to silence this warning.',
+        );
+      }
+      for (final note in r.notes) {
+        gemmaLog('ℹ️  Hugging Face ($_hfRepo): $note');
+      }
+      _modelSource = ModelSource.network(
+        r.url,
+        authToken: _hfToken,
+        foreground: _hfForeground,
+      );
+      resolvedModelType = r.modelType;
+      resolvedRuntime = r.runtime;
+      resolvedNotes = r.notes;
+    }
+
     if (_modelSource == null) {
       throw StateError(
-        'Model source not configured. Use fromNetwork(), fromAsset(), fromBundled(), or fromFile().',
+        'Model source not configured. Use fromNetwork(), fromAsset(), '
+        'fromBundled(), fromFile(), or fromHuggingFace().',
       );
     }
 
@@ -223,7 +325,7 @@ class InferenceInstallationBuilder {
         name: FileNameUtils.getBaseName(modelFile.filename),
         modelSource: _modelSource!,
         replacePolicy: ModelReplacePolicy.keep,
-        modelType: _modelType,
+        modelType: resolvedModelType ?? _modelType,
         fileType: _fileType,
       );
       final manager = FlutterGemmaPlugin.instance.modelManager;
@@ -251,7 +353,7 @@ class InferenceInstallationBuilder {
         name: FileNameUtils.getBaseName(modelFile.filename),
         modelSource: _modelSource!,
         replacePolicy: ModelReplacePolicy.keep,
-        modelType: _modelType,
+        modelType: resolvedModelType ?? _modelType,
         fileType: _fileType,
       );
       final manager = FlutterGemmaPlugin.instance.modelManager;
@@ -270,7 +372,7 @@ class InferenceInstallationBuilder {
       modelSource: _modelSource!,
       loraSource: _loraSource,
       replacePolicy: ModelReplacePolicy.keep,
-      modelType: _modelType,
+      modelType: resolvedModelType ?? _modelType,
       fileType: _fileType,
     );
 
@@ -329,7 +431,11 @@ class InferenceInstallationBuilder {
 
     gemmaLog('✅ Inference model installed and set as active: ${spec.name}');
 
-    return InferenceInstallation(spec: spec);
+    return InferenceInstallation(
+      spec: spec,
+      runtime: resolvedRuntime,
+      notes: resolvedNotes,
+    );
   }
 }
 
@@ -337,7 +443,28 @@ class InferenceInstallationBuilder {
 class InferenceInstallation {
   final InferenceModelSpec spec;
 
-  InferenceInstallation({required this.spec});
+  /// Overridable runtime defaults resolved from a Hugging Face manifest when
+  /// installed via `fromHuggingFace(repo)` (no `file`); `null` for every other
+  /// source. Apply the model-level fields with
+  /// `getActiveModel(defaults: installation.runtime)`, and forward the two
+  /// session-level fields (`isThinking`, `minOutputTokens`) to `createSession`
+  /// yourself.
+  ///
+  /// EPHEMERAL — not persisted. After an app restart the restored active model
+  /// carries no manifest defaults, so re-resolve the manifest (or cache the
+  /// `ResolvedHfModel` yourself) to recover these on a later launch.
+  final ModelRuntimeDefaults? runtime;
+
+  /// Advisory notes surfaced by the Hugging Face resolver (platform caveats,
+  /// known issues); empty for non-HF sources. Also written to the log at
+  /// install time.
+  final List<String> notes;
+
+  InferenceInstallation({
+    required this.spec,
+    this.runtime,
+    this.notes = const [],
+  });
 
   /// Model ID (filename without extension)
   String get modelId => spec.name;

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -133,6 +133,12 @@ class InferenceInstallationBuilder {
   ///   the model is already installed (the variant filename is only known after
   ///   the manifest fetch). For offline-safe idempotent installs, cache the
   ///   `ResolvedHfModel` yourself and install from `fromNetwork(r.url)`.
+  /// - `modelType`: pass `ModelType.general` to let the manifest decide the
+  ///   family; pass a SPECIFIC type to keep your choice (it wins over the
+  ///   manifest, and any disagreement is surfaced in [InferenceInstallation.notes]).
+  /// - A [CancelToken] set via `withCancelToken` cannot interrupt the manifest
+  ///   fetch itself (the resolver takes no token); cancellation is honoured
+  ///   immediately after the fetch returns, before the download starts.
   ///
   /// The plugin already applies the configured HuggingFace token to
   /// `huggingface.co` URLs for gated repos, so [token] is only needed to
@@ -263,17 +269,23 @@ class InferenceInstallationBuilder {
 
     // Runtime defaults / notes / model family resolved from a Hugging Face
     // manifest (deferred `fromHuggingFace(repo)`). Null/empty for every non-HF
-    // source; ride on the RESULT ([InferenceInstallation]), never on the spec —
-    // preserving install-vs-runtime separation.
+    // source; they ride on the RESULT ([InferenceInstallation]), never on the
+    // spec — preserving install-vs-runtime separation.
     ModelRuntimeDefaults? resolvedRuntime;
     List<String> resolvedNotes = const [];
     ModelType? resolvedModelType;
 
+    // The effective model source. install() is a pure READER of builder state:
+    // the deferred-HF resolve below assigns the resolved network source to this
+    // LOCAL, never back to `_modelSource`, so reusing a builder instance never
+    // sees install() mutate its source mid-flight.
+    ModelSource? source = _modelSource;
+
     // Deferred Hugging Face resolution runs FIRST — before the builtIn /
-    // onnx-web branches below, which assume a concrete _modelSource. For a
-    // `.builtIn` / `.onnx` repo the resolver throws its own clear error here
+    // onnx-web branches below, which assume a concrete source. For a `.builtIn`
+    // / `.onnx` repo the resolver throws its own clear error here
     // (UnsupportedError / UnimplementedError, naming the repo) instead of those
-    // branches tripping over a null _modelSource.
+    // branches tripping over a null source.
     if (_hfRepo != null) {
       final r = await FlutterGemma.resolveHuggingFace(
         _hfRepo!,
@@ -283,28 +295,41 @@ class InferenceInstallationBuilder {
       // The manifest fetch itself is not cancellable (the resolver contract
       // takes no CancelToken) — fail fast here, before the download starts.
       _cancelToken?.throwIfCancelled();
-      if (r.modelType != null && r.modelType != _modelType) {
-        gemmaLog(
-          '⚠️  Hugging Face manifest declares modelType ${r.modelType} for '
-          '"$_hfRepo" — using it instead of the passed $_modelType (the '
-          'manifest is authoritative about the model family). Pass that '
-          'modelType explicitly to silence this warning.',
-        );
+
+      // Model-family precedence: `ModelType.general` is the conventional "no
+      // claim — resolve it for me" value, so the manifest's family wins over it;
+      // any SPECIFIC modelType the caller passed wins over the manifest
+      // (explicit > manifest, matching `mergeRuntimeDefault`). A real
+      // disagreement is surfaced in a RELEASE-visible note — `gemmaLog` is
+      // debug-only, so it can't be the only channel.
+      final manifestType = r.modelType;
+      if (_modelType == ModelType.general) {
+        resolvedModelType = manifestType; // may be null → stays general
+        resolvedNotes = r.notes;
+      } else if (manifestType != null && manifestType != _modelType) {
+        resolvedModelType = _modelType; // explicit wins
+        final note =
+            'Installed as ${_modelType.name} (your explicit choice); the '
+            'Hugging Face manifest for "$_hfRepo" declares ${manifestType.name}.';
+        resolvedNotes = [...r.notes, note];
+        gemmaLog('ℹ️  $note');
+      } else {
+        resolvedModelType = _modelType; // agrees, or manifest silent
+        resolvedNotes = r.notes;
       }
       for (final note in r.notes) {
         gemmaLog('ℹ️  Hugging Face ($_hfRepo): $note');
       }
-      _modelSource = ModelSource.network(
+
+      source = ModelSource.network(
         r.url,
         authToken: _hfToken,
         foreground: _hfForeground,
       );
-      resolvedModelType = r.modelType;
       resolvedRuntime = r.runtime;
-      resolvedNotes = r.notes;
     }
 
-    if (_modelSource == null) {
+    if (source == null) {
       throw StateError(
         'Model source not configured. Use fromNetwork(), fromAsset(), '
         'fromBundled(), fromFile(), or fromHuggingFace().',
@@ -320,10 +345,10 @@ class InferenceInstallationBuilder {
           'LoRA is not supported for built-in OS models (ModelFileType.builtIn).',
         );
       }
-      final modelFile = InferenceModelFile.fromSource(_modelSource!);
+      final modelFile = InferenceModelFile.fromSource(source);
       final spec = InferenceModelSpec(
         name: FileNameUtils.getBaseName(modelFile.filename),
-        modelSource: _modelSource!,
+        modelSource: source,
         replacePolicy: ModelReplacePolicy.keep,
         modelType: resolvedModelType ?? _modelType,
         fileType: _fileType,
@@ -331,7 +356,11 @@ class InferenceInstallationBuilder {
       final manager = FlutterGemmaPlugin.instance.modelManager;
       manager.setActiveModel(spec);
       gemmaLog('✅ Built-in model set as active: ${spec.name}');
-      return InferenceInstallation(spec: spec);
+      return InferenceInstallation(
+        spec: spec,
+        runtime: resolvedRuntime,
+        notes: resolvedNotes,
+      );
     }
 
     // ONNX on WEB: Transformers.js (@huggingface/transformers) resolves +
@@ -348,10 +377,10 @@ class InferenceInstallationBuilder {
           'LoRA is not supported for ONNX web models (ModelFileType.onnx).',
         );
       }
-      final modelFile = InferenceModelFile.fromSource(_modelSource!);
+      final modelFile = InferenceModelFile.fromSource(source);
       final spec = InferenceModelSpec(
         name: FileNameUtils.getBaseName(modelFile.filename),
-        modelSource: _modelSource!,
+        modelSource: source,
         replacePolicy: ModelReplacePolicy.keep,
         modelType: resolvedModelType ?? _modelType,
         fileType: _fileType,
@@ -362,14 +391,18 @@ class InferenceInstallationBuilder {
         '✅ ONNX web model set as active (Transformers.js owns the weights): '
         '${spec.name}',
       );
-      return InferenceInstallation(spec: spec);
+      return InferenceInstallation(
+        spec: spec,
+        runtime: resolvedRuntime,
+        notes: resolvedNotes,
+      );
     }
 
     // Create spec
-    final modelFile = InferenceModelFile.fromSource(_modelSource!);
+    final modelFile = InferenceModelFile.fromSource(source);
     final spec = InferenceModelSpec(
       name: FileNameUtils.getBaseName(modelFile.filename),
-      modelSource: _modelSource!,
+      modelSource: source,
       loraSource: _loraSource,
       replacePolicy: ModelReplacePolicy.keep,
       modelType: resolvedModelType ?? _modelType,
@@ -396,10 +429,10 @@ class InferenceInstallationBuilder {
     } else {
       // Install model file
       final handlerRegistry = registry.sourceHandlerRegistry;
-      final handler = handlerRegistry.getHandler(_modelSource!);
+      final handler = handlerRegistry.getHandler(source);
       if (_onProgress != null) {
         await for (final progress in handler!.installWithProgress(
-          _modelSource!,
+          source,
           cancelToken: _cancelToken,
           targetFilename: namespacedModelFilename,
         )) {
@@ -407,7 +440,7 @@ class InferenceInstallationBuilder {
         }
       } else {
         await handler!.install(
-          _modelSource!,
+          source,
           cancelToken: _cancelToken,
           targetFilename: namespacedModelFilename,
         );
@@ -457,14 +490,15 @@ class InferenceInstallation {
 
   /// Advisory notes surfaced by the Hugging Face resolver (platform caveats,
   /// known issues); empty for non-HF sources. Also written to the log at
-  /// install time.
+  /// install time. Unmodifiable — the constructor wraps whatever the resolver
+  /// handed over, so this never aliases a list a resolver still holds.
   final List<String> notes;
 
   InferenceInstallation({
     required this.spec,
     this.runtime,
-    this.notes = const [],
-  });
+    List<String> notes = const [],
+  }) : notes = List.unmodifiable(notes);
 
   /// Model ID (filename without extension)
   String get modelId => spec.name;

--- a/packages/flutter_gemma/lib/core/registry/hugging_face_resolver_source.dart
+++ b/packages/flutter_gemma/lib/core/registry/hugging_face_resolver_source.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+
+/// Opt-in capability interface: an `InferenceEngineProvider` that also ships a
+/// Hugging Face manifest [HuggingFaceResolver] for its own model family.
+///
+/// An engine that implements this exposes its resolver via
+/// [huggingFaceResolver], and `FlutterGemma.initialize(inferenceEngines: …)`
+/// auto-registers it — so an app that adds the engine gets that engine's
+/// `.litertlm` / `.onnx` / `.builtIn` resolver WITHOUT maintaining a parallel
+/// `huggingFaceResolvers:` list. The engine and its resolver ship in the same
+/// package, so the capability travels with the engine.
+///
+/// Kept SEPARATE from `InferenceEngineProvider` on purpose (Interface
+/// Segregation): putting this getter on the base provider would force every
+/// engine — including MediaPipe, which has no HF resolver — to implement it,
+/// and (because engines `implements` the provider, so default bodies are not
+/// inherited) would be a breaking change to every existing engine, first- and
+/// third-party. Instead an engine WITH a resolver opts in
+/// (`implements InferenceEngineProvider, HuggingFaceResolverSource`); one
+/// without simply does not implement this.
+///
+/// The engine only POINTS to its resolver here; it does not perform resolution.
+/// The manifest IO stays in the standalone [HuggingFaceResolver] (e.g.
+/// `LitertlmManifestResolver`), so the engine keeps its single responsibility —
+/// this is a reference, not a merge of the two roles.
+///
+/// Explicit `huggingFaceResolvers:` still wins: `initialize` registers the
+/// explicit list FIRST, so an app-supplied resolver overrides an engine's
+/// built-in one at equal priority (the registry breaks ties by
+/// first-registered). Pass the explicit list only to override an engine's
+/// default (e.g. pin a manifest revision or inject a custom fetch).
+abstract interface class HuggingFaceResolverSource {
+  /// The Hugging Face resolver this engine provides, or `null` if it currently
+  /// has none (e.g. a multi-format engine with no manifest for the active
+  /// configuration).
+  HuggingFaceResolver? get huggingFaceResolver;
+}

--- a/packages/flutter_gemma/lib/core/registry/hugging_face_resolver_source.dart
+++ b/packages/flutter_gemma/lib/core/registry/hugging_face_resolver_source.dart
@@ -30,9 +30,16 @@ import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
 /// built-in one at equal priority (the registry breaks ties by
 /// first-registered). Pass the explicit list only to override an engine's
 /// default (e.g. pin a manifest revision or inject a custom fetch).
+///
+/// An engine that has nothing to resolve does NOT implement this interface — or,
+/// if it wants to reserve its `ModelFileType` slot so the caller gets a specific
+/// error instead of core's generic "no resolver registered", returns a resolver
+/// whose `resolve` throws (the pattern `OnnxHuggingFaceResolver` /
+/// `BuiltInAiHuggingFaceResolver` use). Either way is more informative than a
+/// `null`, which is why [huggingFaceResolver] is non-nullable.
 abstract interface class HuggingFaceResolverSource {
-  /// The Hugging Face resolver this engine provides, or `null` if it currently
-  /// has none (e.g. a multi-format engine with no manifest for the active
-  /// configuration).
-  HuggingFaceResolver? get huggingFaceResolver;
+  /// The Hugging Face resolver this engine provides. Non-null: an engine that
+  /// implements this interface always contributes a resolver (see the class doc
+  /// for how to express "no resolver").
+  HuggingFaceResolver get huggingFaceResolver;
 }

--- a/packages/flutter_gemma/test/core/api/from_hugging_face_test.dart
+++ b/packages/flutter_gemma/test/core/api/from_hugging_face_test.dart
@@ -161,6 +161,62 @@ void main() {
       },
     );
 
+    test('a SPECIFIC caller modelType wins over a differing manifest, and the '
+        'conflict is surfaced in a release-visible note', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          forFileType: ModelFileType.litertlm,
+          result: const ResolvedHfModel(
+            file: 'model.litertlm',
+            url: 'https://huggingface.co/org/repo/resolve/main/model.litertlm',
+            fileType: ModelFileType.litertlm,
+            modelType: ModelType.qwen3, // manifest disagrees with the caller
+            notes: ['base note'],
+          ),
+        ),
+      ]);
+
+      // Caller deliberately passed a specific family, not ModelType.general.
+      final install = await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromHuggingFace('org/repo').install();
+
+      // Explicit specific choice is KEPT, not overridden by the manifest.
+      expect(install.spec.modelType, ModelType.gemmaIt);
+      // The base note survives AND a conflict note naming both families is
+      // appended (release-visible, not just gemmaLog).
+      expect(install.notes, contains('base note'));
+      expect(
+        install.notes.any((n) => n.contains('gemmaIt') && n.contains('qwen3')),
+        isTrue,
+        reason: 'a release-visible conflict note naming both families',
+      );
+    });
+
+    test('install.notes is unmodifiable', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          forFileType: ModelFileType.litertlm,
+          result: const ResolvedHfModel(
+            file: 'model.litertlm',
+            url: 'https://huggingface.co/org/repo/resolve/main/model.litertlm',
+            fileType: ModelFileType.litertlm,
+            notes: ['a note'],
+          ),
+        ),
+      ]);
+
+      final install = await FlutterGemma.installModel(
+        modelType: ModelType.general,
+        fileType: ModelFileType.litertlm,
+      ).fromHuggingFace('org/repo').install();
+
+      expect(() => install.notes.add('x'), throwsUnsupportedError);
+    });
+
     test('the resolver error surfaces from install BEFORE any download '
         '(.onnx → UnimplementedError)', () async {
       await ServiceRegistry.initialize(downloadService: download);

--- a/packages/flutter_gemma/test/core/api/from_hugging_face_test.dart
+++ b/packages/flutter_gemma/test/core/api/from_hugging_face_test.dart
@@ -1,0 +1,291 @@
+// One-call `installModel(...).fromHuggingFace(repo)` (no `file`): the builder
+// resolves the repo's manifest at install() time via the registered resolver,
+// installs the revision-pinned variant, and carries the manifest's overridable
+// runtime defaults + notes on the InferenceInstallation result.
+//
+// Uses the same PathProvider-fixture + fake-DownloadService harness as
+// test/core/api/install_identity_namespacing_test.dart, plus a scripted fake
+// HuggingFaceResolver, so nothing hits the network.
+//
+// Run: flutter test test/core/api/from_hugging_face_test.dart
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_gemma/core/di/service_registry.dart';
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_gemma/core/services/download_service.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+
+final _fakeModelBytes = Uint8List(1024 * 1024 + 16);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory fakeDocuments;
+  late Directory fakeAppSupport;
+  late Directory sourceDir;
+  late _FixtureDownloadService download;
+
+  setUp(() async {
+    fakeDocuments = await Directory.systemTemp.createTemp('fg_hf_docs_');
+    fakeAppSupport = await Directory.systemTemp.createTemp('fg_hf_support_');
+    sourceDir = await Directory.systemTemp.createTemp('fg_hf_src_');
+    PathProviderPlatform.instance = _FixedPathProviderPlatform(
+      documentsPath: fakeDocuments.path,
+      appSupportPath: fakeAppSupport.path,
+    );
+    SharedPreferences.setMockInitialValues({});
+    ServiceRegistry.reset();
+    HuggingFaceResolverRegistry.instance.reset();
+    download = _FixtureDownloadService(_fakeModelBytes);
+  });
+
+  tearDown(() async {
+    ServiceRegistry.reset();
+    HuggingFaceResolverRegistry.instance.reset();
+    for (final dir in [fakeDocuments, fakeAppSupport, sourceDir]) {
+      if (await dir.exists()) await dir.delete(recursive: true);
+    }
+  });
+
+  group('fromHuggingFace argument validation (synchronous, no install)', () {
+    test('a non-"main" revision without an explicit file throws', () {
+      expect(
+        () => FlutterGemma.installModel(
+          modelType: ModelType.general,
+          fileType: ModelFileType.litertlm,
+        ).fromHuggingFace('org/repo', revision: 'abc123'),
+        throwsArgumentError,
+      );
+    });
+
+    test('an empty repo throws', () {
+      expect(
+        () => FlutterGemma.installModel(
+          modelType: ModelType.general,
+        ).fromHuggingFace('   '),
+        throwsArgumentError,
+      );
+    });
+
+    test('an explicit but empty file throws', () {
+      expect(
+        () => FlutterGemma.installModel(
+          modelType: ModelType.general,
+        ).fromHuggingFace('org/repo', file: '  '),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('one-call manifest install (deferred resolution)', () {
+    test('resolves the manifest, installs from the resolver URL '
+        '(revision pinned), and returns the runtime defaults + notes', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      const pinnedUrl =
+          'https://huggingface.co/org/repo/resolve/pinnedsha123/model.litertlm';
+      final resolver = _ScriptedResolver(
+        forFileType: ModelFileType.litertlm,
+        result: const ResolvedHfModel(
+          file: 'model.litertlm',
+          url: pinnedUrl,
+          fileType: ModelFileType.litertlm,
+          modelType: ModelType.qwen3,
+          runtime: ModelRuntimeDefaults(
+            maxTokens: 4096,
+            isThinking: true,
+            minOutputTokens: 2048,
+          ),
+          notes: ['heads up: verified on cpu only'],
+        ),
+      );
+      HuggingFaceResolverRegistry.instance.registerAll([resolver]);
+
+      final install = await FlutterGemma.installModel(
+        modelType: ModelType.general, // fallback — manifest overrides
+        fileType: ModelFileType.litertlm,
+      ).fromHuggingFace('org/repo', token: 'hf_test').install();
+
+      // Resolver selected for the builder's fileType, once, with the token.
+      expect(resolver.resolveCalls, 1);
+      expect(resolver.lastToken, 'hf_test');
+      // Installed from the resolver's authoritative (revision-pinned) URL —
+      // NOT a rebuilt main URL.
+      expect(download.requestedUrls, contains(pinnedUrl));
+      // Runtime defaults ride on the RESULT, not the spec.
+      expect(install.runtime, isNotNull);
+      expect(install.runtime!.maxTokens, 4096);
+      expect(install.runtime!.isThinking, true);
+      expect(install.runtime!.minOutputTokens, 2048);
+      expect(install.notes, ['heads up: verified on cpu only']);
+      // Manifest modelType wins over the passed fallback.
+      expect(install.spec.modelType, ModelType.qwen3);
+    });
+
+    test(
+      'a manifest silent on modelType falls back to the passed modelType',
+      () async {
+        await ServiceRegistry.initialize(downloadService: download);
+        HuggingFaceResolverRegistry.instance.registerAll([
+          _ScriptedResolver(
+            forFileType: ModelFileType.litertlm,
+            result: const ResolvedHfModel(
+              file: 'model.litertlm',
+              url:
+                  'https://huggingface.co/org/repo/resolve/main/model.litertlm',
+              fileType: ModelFileType.litertlm,
+              // modelType omitted → resolver could not determine it
+            ),
+          ),
+        ]);
+
+        final install = await FlutterGemma.installModel(
+          modelType: ModelType.gemmaIt,
+          fileType: ModelFileType.litertlm,
+        ).fromHuggingFace('org/repo').install();
+
+        expect(install.spec.modelType, ModelType.gemmaIt);
+        // No manifest runtime hints → all-null defaults, empty notes.
+        expect(install.runtime, isNotNull);
+        expect(install.runtime!.maxTokens, isNull);
+        expect(install.notes, isEmpty);
+      },
+    );
+
+    test('the resolver error surfaces from install BEFORE any download '
+        '(.onnx → UnimplementedError)', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          forFileType: ModelFileType.onnx,
+          throwError: UnimplementedError('not implemented yet ("org/repo")'),
+        ),
+      ]);
+
+      await expectLater(
+        FlutterGemma.installModel(
+          modelType: ModelType.general,
+          fileType: ModelFileType.onnx,
+        ).fromHuggingFace('org/repo').install(),
+        throwsA(isA<UnimplementedError>()),
+      );
+      // Resolve-first ordering: nothing was downloaded.
+      expect(download.requestedUrls, isEmpty);
+    });
+
+    test('an explicit source after fromHuggingFace cancels the deferred '
+        'resolve (last source wins, resolver never called)', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      final resolver = _ScriptedResolver(
+        forFileType: ModelFileType.litertlm,
+        result: const ResolvedHfModel(
+          file: 'm.litertlm',
+          url: 'https://huggingface.co/o/r/resolve/main/m.litertlm',
+          fileType: ModelFileType.litertlm,
+        ),
+      );
+      HuggingFaceResolverRegistry.instance.registerAll([resolver]);
+
+      final localModel = File(p.join(sourceDir.path, 'local.litertlm'));
+      await localModel.writeAsBytes(_fakeModelBytes);
+
+      final install = await FlutterGemma.installModel(
+        modelType: ModelType.gemmaIt,
+        fileType: ModelFileType.litertlm,
+      ).fromHuggingFace('o/r').fromFile(localModel.path).install();
+
+      expect(resolver.resolveCalls, 0);
+      expect(install.runtime, isNull);
+      expect(install.spec.modelType, ModelType.gemmaIt);
+    });
+  });
+}
+
+/// Scripted resolver: claims exactly [forFileType]; [resolve] returns [result]
+/// or throws [throwError]. Records call count + the token it was handed.
+class _ScriptedResolver implements HuggingFaceResolver {
+  _ScriptedResolver({required this.forFileType, this.result, this.throwError});
+  final ModelFileType forFileType;
+  final ResolvedHfModel? result;
+  final Object? throwError;
+  int resolveCalls = 0;
+  String? lastToken;
+
+  @override
+  String get name => 'scripted';
+  @override
+  int get priority => 0;
+  @override
+  bool canResolve(String repo, {ModelFileType? fileType}) =>
+      fileType == forFileType;
+  @override
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? token,
+    String? platform,
+    PreferredBackend? preferredBackend,
+  }) async {
+    resolveCalls++;
+    lastToken = token;
+    if (throwError != null) throw throwError!;
+    return result!;
+  }
+}
+
+class _FixedPathProviderPlatform extends PathProviderPlatform {
+  _FixedPathProviderPlatform({
+    required this.documentsPath,
+    required this.appSupportPath,
+  });
+  final String documentsPath;
+  final String appSupportPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+  @override
+  Future<String?> getApplicationSupportPath() async => appSupportPath;
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+/// Writes [bytes] to whatever target it is asked to download to, recording each
+/// requested URL so tests can assert which URL install() actually fetched.
+class _FixtureDownloadService implements DownloadService {
+  _FixtureDownloadService(this.bytes);
+  final Uint8List bytes;
+  final List<String> requestedUrls = [];
+
+  @override
+  Future<void> download(
+    String url,
+    String targetPath, {
+    String? token,
+    CancelToken? cancelToken,
+  }) async {
+    requestedUrls.add(url);
+    await File(targetPath).writeAsBytes(bytes);
+  }
+
+  @override
+  Stream<int> downloadWithProgress(
+    String url,
+    String targetPath, {
+    String? token,
+    int maxRetries = 10,
+    CancelToken? cancelToken,
+    bool? foreground,
+  }) async* {
+    requestedUrls.add(url);
+    await File(targetPath).writeAsBytes(bytes);
+    yield 100;
+  }
+}

--- a/packages/flutter_gemma/test/core/registry/hugging_face_resolver_registry_test.dart
+++ b/packages/flutter_gemma/test/core/registry/hugging_face_resolver_registry_test.dart
@@ -51,7 +51,7 @@ class _EngineWithResolver
     RuntimeConfig config,
   ) => throw UnimplementedError();
   @override
-  HuggingFaceResolver? get huggingFaceResolver => _resolver;
+  HuggingFaceResolver get huggingFaceResolver => _resolver;
 }
 
 /// Plain engine — no [HuggingFaceResolverSource]. Contributes nothing.
@@ -67,24 +67,6 @@ class _PlainEngine implements InferenceEngineProvider {
     InferenceModelSpec spec,
     RuntimeConfig config,
   ) => throw UnimplementedError();
-}
-
-/// Opts in but has no resolver right now (returns null). Contributes nothing.
-class _EngineNullResolver
-    implements InferenceEngineProvider, HuggingFaceResolverSource {
-  @override
-  String get name => 'null-resolver';
-  @override
-  int get priority => 0;
-  @override
-  bool canHandle(InferenceModelSpec spec) => false;
-  @override
-  Future<InferenceModel> createModel(
-    InferenceModelSpec spec,
-    RuntimeConfig config,
-  ) => throw UnimplementedError();
-  @override
-  HuggingFaceResolver? get huggingFaceResolver => null;
 }
 
 void main() {
@@ -211,18 +193,14 @@ void main() {
       final derived = FlutterGemma.engineHuggingFaceResolvers([
         _EngineWithResolver(r),
         _PlainEngine(), // no HuggingFaceResolverSource → skipped
-        _EngineNullResolver(), // opts in but returns null → skipped
       ]);
       expect(derived, hasLength(1));
       expect(derived.single, same(r));
     });
 
-    test('empty when no engine provides a resolver', () {
+    test('empty when no engine implements HuggingFaceResolverSource', () {
       expect(
-        FlutterGemma.engineHuggingFaceResolvers([
-          _PlainEngine(),
-          _EngineNullResolver(),
-        ]),
+        FlutterGemma.engineHuggingFaceResolvers([_PlainEngine()]),
         isEmpty,
       );
     });

--- a/packages/flutter_gemma/test/core/registry/hugging_face_resolver_registry_test.dart
+++ b/packages/flutter_gemma/test/core/registry/hugging_face_resolver_registry_test.dart
@@ -1,9 +1,15 @@
 import 'package:flutter_gemma/core/api/flutter_gemma.dart';
 import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart';
 import 'package:flutter_gemma/core/domain/platform_types.dart'
     show PreferredBackend;
 import 'package:flutter_gemma/core/model.dart' show ModelFileType, ModelType;
+import 'package:flutter_gemma/core/model_management/model_specs.dart'
+    show InferenceModelSpec;
 import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
+import 'package:flutter_gemma/core/registry/runtime_config.dart';
+import 'package:flutter_gemma/flutter_gemma_interface.dart' show InferenceModel;
 import 'package:flutter_test/flutter_test.dart';
 
 /// Minimal fake resolver — probe-chain selection is what these tests exercise,
@@ -26,6 +32,59 @@ class _R implements HuggingFaceResolver {
     String? platform,
     PreferredBackend? preferredBackend,
   }) async => throw UnimplementedError();
+}
+
+/// Engine that opts into [HuggingFaceResolverSource] and returns [_resolver].
+class _EngineWithResolver
+    implements InferenceEngineProvider, HuggingFaceResolverSource {
+  _EngineWithResolver(this._resolver);
+  final HuggingFaceResolver _resolver;
+  @override
+  String get name => 'with-resolver';
+  @override
+  int get priority => 0;
+  @override
+  bool canHandle(InferenceModelSpec spec) => false;
+  @override
+  Future<InferenceModel> createModel(
+    InferenceModelSpec spec,
+    RuntimeConfig config,
+  ) => throw UnimplementedError();
+  @override
+  HuggingFaceResolver? get huggingFaceResolver => _resolver;
+}
+
+/// Plain engine — no [HuggingFaceResolverSource]. Contributes nothing.
+class _PlainEngine implements InferenceEngineProvider {
+  @override
+  String get name => 'plain';
+  @override
+  int get priority => 0;
+  @override
+  bool canHandle(InferenceModelSpec spec) => false;
+  @override
+  Future<InferenceModel> createModel(
+    InferenceModelSpec spec,
+    RuntimeConfig config,
+  ) => throw UnimplementedError();
+}
+
+/// Opts in but has no resolver right now (returns null). Contributes nothing.
+class _EngineNullResolver
+    implements InferenceEngineProvider, HuggingFaceResolverSource {
+  @override
+  String get name => 'null-resolver';
+  @override
+  int get priority => 0;
+  @override
+  bool canHandle(InferenceModelSpec spec) => false;
+  @override
+  Future<InferenceModel> createModel(
+    InferenceModelSpec spec,
+    RuntimeConfig config,
+  ) => throw UnimplementedError();
+  @override
+  HuggingFaceResolver? get huggingFaceResolver => null;
 }
 
 void main() {
@@ -145,4 +204,43 @@ void main() {
       );
     },
   );
+
+  group('engineHuggingFaceResolvers (auto-derivation from engines)', () {
+    test('collects a resolver only from engines that provide one', () {
+      final r = _R('litertlm', 0);
+      final derived = FlutterGemma.engineHuggingFaceResolvers([
+        _EngineWithResolver(r),
+        _PlainEngine(), // no HuggingFaceResolverSource → skipped
+        _EngineNullResolver(), // opts in but returns null → skipped
+      ]);
+      expect(derived, hasLength(1));
+      expect(derived.single, same(r));
+    });
+
+    test('empty when no engine provides a resolver', () {
+      expect(
+        FlutterGemma.engineHuggingFaceResolvers([
+          _PlainEngine(),
+          _EngineNullResolver(),
+        ]),
+        isEmpty,
+      );
+    });
+
+    test('explicit resolver wins the tie over an engine-derived one '
+        '(initialize registers the explicit list first)', () {
+      final explicit = _R('explicit', 0);
+      final engine = _EngineWithResolver(_R('engine', 0));
+      // Mirror initialize(): explicit list FIRST, engine-derived SECOND, so the
+      // explicit resolver wins on equal priority (findFor: first-registered).
+      HuggingFaceResolverRegistry.instance.registerAll([explicit]);
+      HuggingFaceResolverRegistry.instance.registerAll(
+        FlutterGemma.engineHuggingFaceResolvers([engine]),
+      );
+      expect(
+        HuggingFaceResolverRegistry.instance.findFor('o/r')!.name,
+        'explicit',
+      );
+    });
+  });
 }

--- a/packages/flutter_gemma_builtin_ai/CHANGELOG.md
+++ b/packages/flutter_gemma_builtin_ai/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.2.1
-- Add `BuiltInAiHuggingFaceResolver` so `resolveHuggingFace` reports that built-in OS models have no Hugging Face file (#454).
+- Add `BuiltInAiHuggingFaceResolver` (auto-registered from `BuiltInAiEngine`) so `resolveHuggingFace` reports that built-in OS models have no Hugging Face file (#454).
 
 ## 0.2.0
 - Web support: Gemini Nano via the Chrome Prompt API (desktop Chrome/Edge).

--- a/packages/flutter_gemma_builtin_ai/lib/src/builtin_ai_engine.dart
+++ b/packages/flutter_gemma_builtin_ai/lib/src/builtin_ai_engine.dart
@@ -1,4 +1,8 @@
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart'
+    show HuggingFaceResolverSource;
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/runtime_config.dart';
 import 'package:flutter_gemma/core/model_management/model_specs.dart'
@@ -6,13 +10,16 @@ import 'package:flutter_gemma/core/model_management/model_specs.dart'
 import 'package:flutter_gemma/flutter_gemma_interface.dart' show InferenceModel;
 
 import 'availability.dart';
+import 'builtin_ai_hugging_face_resolver.dart'
+    show BuiltInAiHuggingFaceResolver;
 import 'builtin_ai_model.dart';
 
 /// Built-in OS AI engine (Gemini Nano via ML Kit GenAI on Android; Apple
 /// Foundation Models on iOS/macOS). Pure factory: probes availability, tells
 /// the native host to create the model, then returns a bare [BuiltInAiModel];
 /// core owns the singleton lifecycle via [InferenceModel.addCloseListener].
-class BuiltInAiEngine implements InferenceEngineProvider {
+class BuiltInAiEngine
+    implements InferenceEngineProvider, HuggingFaceResolverSource {
   const BuiltInAiEngine();
 
   @override
@@ -20,6 +27,15 @@ class BuiltInAiEngine implements InferenceEngineProvider {
 
   @override
   int get priority => 0;
+
+  /// The engine's own Hugging Face resolver. Auto-registered by
+  /// `FlutterGemma.initialize(inferenceEngines: …)` so it reserves the
+  /// `.builtIn` slot: `resolveHuggingFace(fileType: builtIn)` (and the one-call
+  /// `fromHuggingFace`) throws a clear `UnsupportedError` — the OS owns the
+  /// weights, there is no Hugging Face file to resolve.
+  @override
+  HuggingFaceResolver? get huggingFaceResolver =>
+      const BuiltInAiHuggingFaceResolver();
 
   @override
   bool canHandle(InferenceModelSpec spec) =>

--- a/packages/flutter_gemma_builtin_ai/lib/src/builtin_ai_engine.dart
+++ b/packages/flutter_gemma_builtin_ai/lib/src/builtin_ai_engine.dart
@@ -34,7 +34,7 @@ class BuiltInAiEngine
   /// `fromHuggingFace`) throws a clear `UnsupportedError` — the OS owns the
   /// weights, there is no Hugging Face file to resolve.
   @override
-  HuggingFaceResolver? get huggingFaceResolver =>
+  HuggingFaceResolver get huggingFaceResolver =>
       const BuiltInAiHuggingFaceResolver();
 
   @override

--- a/packages/flutter_gemma_builtin_ai/lib/src/builtin_ai_hugging_face_resolver.dart
+++ b/packages/flutter_gemma_builtin_ai/lib/src/builtin_ai_hugging_face_resolver.dart
@@ -17,8 +17,9 @@ import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
 /// Face to resolve. Install a built-in model with `ModelFileType.builtIn`
 /// directly (see `BuiltInAiModels`).
 ///
-/// Register it via `FlutterGemma.initialize(huggingFaceResolvers: [...])`,
-/// alongside `BuiltInAiEngine`.
+/// Auto-registered from `BuiltInAiEngine` (which implements
+/// `HuggingFaceResolverSource`), so registering the engine is enough; pass it in
+/// `FlutterGemma.initialize(huggingFaceResolvers: [...])` only to override.
 class BuiltInAiHuggingFaceResolver implements HuggingFaceResolver {
   const BuiltInAiHuggingFaceResolver();
 

--- a/packages/flutter_gemma_builtin_ai/lib/src/web/builtin_ai_engine_web.dart
+++ b/packages/flutter_gemma_builtin_ai/lib/src/web/builtin_ai_engine_web.dart
@@ -38,7 +38,7 @@ class BuiltInAiEngine
   /// reserves the `.builtIn` slot so `resolveHuggingFace(fileType: builtIn)`
   /// throws a clear `UnsupportedError` — the OS owns the weights.
   @override
-  HuggingFaceResolver? get huggingFaceResolver =>
+  HuggingFaceResolver get huggingFaceResolver =>
       const BuiltInAiHuggingFaceResolver();
 
   @override

--- a/packages/flutter_gemma_builtin_ai/lib/src/web/builtin_ai_engine_web.dart
+++ b/packages/flutter_gemma_builtin_ai/lib/src/web/builtin_ai_engine_web.dart
@@ -1,4 +1,8 @@
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart'
+    show HuggingFaceResolverSource;
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/runtime_config.dart';
 import 'package:flutter_gemma/core/model_management/model_specs.dart'
@@ -7,6 +11,8 @@ import 'package:flutter_gemma/flutter_gemma_interface.dart' show InferenceModel;
 
 import '../availability_types.dart'
     show BuiltInAiAvailability, BuiltInAiUnavailableException;
+import '../builtin_ai_hugging_face_resolver.dart'
+    show BuiltInAiHuggingFaceResolver;
 import 'availability_web.dart';
 import 'builtin_ai_model_web.dart';
 
@@ -18,7 +24,8 @@ import 'builtin_ai_model_web.dart';
 /// `priority`, and `canHandle` (routes on `fileType == ModelFileType.builtIn`
 /// regardless of platform; [BuiltInAiModels.geminiNano] just works on both
 /// Android and Web because it carries that fileType).
-class BuiltInAiEngine implements InferenceEngineProvider {
+class BuiltInAiEngine
+    implements InferenceEngineProvider, HuggingFaceResolverSource {
   const BuiltInAiEngine();
 
   @override
@@ -26,6 +33,13 @@ class BuiltInAiEngine implements InferenceEngineProvider {
 
   @override
   int get priority => 0;
+
+  /// The engine's own Hugging Face resolver (same stub as the native arm):
+  /// reserves the `.builtIn` slot so `resolveHuggingFace(fileType: builtIn)`
+  /// throws a clear `UnsupportedError` — the OS owns the weights.
+  @override
+  HuggingFaceResolver? get huggingFaceResolver =>
+      const BuiltInAiHuggingFaceResolver();
 
   @override
   bool canHandle(InferenceModelSpec spec) =>

--- a/packages/flutter_gemma_litertlm/CHANGELOG.md
+++ b/packages/flutter_gemma_litertlm/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.6.0
-- Add `LitertlmManifestResolver`: manifest-driven Hugging Face install for repos shipping `litertlm_manifest.json` (#454).
+- Add `LitertlmManifestResolver`: manifest-driven Hugging Face install for repos shipping `litertlm_manifest.json`, auto-registered from `LiteRtLmEngine` (#454).
 
 ## 1.5.3
 - Fix a rebuilt native library not reaching the build.

--- a/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine.dart
@@ -1,6 +1,10 @@
 import 'package:flutter_gemma/core/domain/platform_types.dart'
     show PreferredBackend;
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart'
+    show HuggingFaceResolverSource;
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/runtime_config.dart';
 import 'package:flutter_gemma/core/utils/gemma_log.dart';
@@ -13,6 +17,7 @@ import 'package:path_provider/path_provider.dart';
 import 'ffi/backend_preference.dart';
 import 'ffi/ffi_inference_model.dart';
 import 'ffi/litert_lm_client.dart';
+import 'manifest/litertlm_manifest_resolver.dart' show LitertlmManifestResolver;
 
 /// Minimum context window (`max_num_tokens`) for `.litertlm` models.
 ///
@@ -70,7 +75,8 @@ encoderInitArgs(RuntimeConfig config, PreferredBackend activeBackend) => (
 /// LiteRT-LM (.litertlm) inference engine. Pure factory: builds and returns a
 /// bare [InferenceModel]; core owns the singleton lifecycle and registers its
 /// reset via [InferenceModel.addCloseListener] (added in a later task).
-class LiteRtLmEngine implements InferenceEngineProvider {
+class LiteRtLmEngine
+    implements InferenceEngineProvider, HuggingFaceResolverSource {
   const LiteRtLmEngine();
 
   @override
@@ -82,6 +88,16 @@ class LiteRtLmEngine implements InferenceEngineProvider {
   @override
   bool canHandle(InferenceModelSpec spec) =>
       spec.fileType == ModelFileType.litertlm;
+
+  /// The engine's own Hugging Face resolver: reads a repo's
+  /// `litertlm_manifest.json`. Auto-registered by
+  /// `FlutterGemma.initialize(inferenceEngines: …)`, so `.litertlm` HF manifests
+  /// resolve without a separate `huggingFaceResolvers:` list. Pass an explicit
+  /// `LitertlmManifestResolver(revision: …)` to `initialize` only to override
+  /// (e.g. pin a revision).
+  @override
+  HuggingFaceResolver? get huggingFaceResolver =>
+      const LitertlmManifestResolver();
 
   @override
   Future<InferenceModel> createModel(

--- a/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine.dart
@@ -96,7 +96,7 @@ class LiteRtLmEngine
   /// `LitertlmManifestResolver(revision: …)` to `initialize` only to override
   /// (e.g. pin a revision).
   @override
-  HuggingFaceResolver? get huggingFaceResolver =>
+  HuggingFaceResolver get huggingFaceResolver =>
       const LitertlmManifestResolver();
 
   @override

--- a/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine_web.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine_web.dart
@@ -1,4 +1,8 @@
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart'
+    show HuggingFaceResolverSource;
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/runtime_config.dart';
 import 'package:flutter_gemma/flutter_gemma_interface.dart' show InferenceModel;
@@ -6,13 +10,15 @@ import 'package:flutter_gemma/core/model_management/model_specs.dart'
     show InferenceModelSpec;
 import 'package:flutter_gemma/web/web_model_source.dart';
 
+import 'manifest/litertlm_manifest_resolver.dart' show LitertlmManifestResolver;
 import 'web/litert_lm_web_inference.dart';
 
 /// Web LiteRT-LM (`@litert-lm/core`) inference engine. A REAL engine (not a
 /// stub): builds [LiteRtLmWebInferenceModel] from a [WebModelSourceResolver]
 /// it constructs itself via `forActiveModel()`. `createModel` is a pure factory
 /// — core owns the singleton lifecycle via [InferenceModel.addCloseListener].
-class LiteRtLmEngine implements InferenceEngineProvider {
+class LiteRtLmEngine
+    implements InferenceEngineProvider, HuggingFaceResolverSource {
   const LiteRtLmEngine();
 
   @override
@@ -24,6 +30,14 @@ class LiteRtLmEngine implements InferenceEngineProvider {
   @override
   bool canHandle(InferenceModelSpec spec) =>
       spec.fileType == ModelFileType.litertlm;
+
+  /// The engine's own Hugging Face resolver (reads `litertlm_manifest.json`).
+  /// Auto-registered by `FlutterGemma.initialize(inferenceEngines: …)` — same
+  /// on web as native, so a repo's manifest resolves without a separate
+  /// `huggingFaceResolvers:` list.
+  @override
+  HuggingFaceResolver? get huggingFaceResolver =>
+      const LitertlmManifestResolver();
 
   @override
   Future<InferenceModel> createModel(

--- a/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine_web.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/litert_lm_engine_web.dart
@@ -36,7 +36,7 @@ class LiteRtLmEngine
   /// on web as native, so a repo's manifest resolves without a separate
   /// `huggingFaceResolvers:` list.
   @override
-  HuggingFaceResolver? get huggingFaceResolver =>
+  HuggingFaceResolver get huggingFaceResolver =>
       const LitertlmManifestResolver();
 
   @override

--- a/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest_resolver.dart
+++ b/packages/flutter_gemma_litertlm/lib/src/manifest/litertlm_manifest_resolver.dart
@@ -25,10 +25,10 @@ export 'manifest_fetch_types.dart' show ManifestFetch, ManifestFetchException;
 /// wins (core's `explicit arg > manifest > SDK default` merge).
 ///
 /// ```dart
-/// await FlutterGemma.initialize(
-///   inferenceEngines: [LiteRtLmEngine()],
-///   huggingFaceResolvers: [const LitertlmManifestResolver()],
-/// );
+/// // LiteRtLmEngine carries this resolver (HuggingFaceResolverSource), so
+/// // registering the engine auto-registers it — no huggingFaceResolvers: list.
+/// // Pass one explicitly only to override, e.g. LitertlmManifestResolver(revision: …).
+/// await FlutterGemma.initialize(inferenceEngines: [LiteRtLmEngine()]);
 ///
 /// final r = await FlutterGemma.resolveHuggingFace(
 ///     'litert-community/Qwen3-4B-Thinking-2507',

--- a/packages/flutter_gemma_onnx/CHANGELOG.md
+++ b/packages/flutter_gemma_onnx/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.3.2
-- Add `OnnxHuggingFaceResolver` so `resolveHuggingFace` gives an ONNX-specific answer; directory-based genai_config install is a follow-up (#454).
+- Add `OnnxHuggingFaceResolver` (auto-registered from `OnnxEngine`) so `resolveHuggingFace` gives an ONNX-specific answer; directory-based genai_config install is a follow-up (#454).
 
 ## 0.3.1
 - Fix a rebuilt native library not reaching the build.

--- a/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
@@ -64,7 +64,7 @@ class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
   /// yet") instead of core's generic "no resolver registered". Directory-based
   /// `genai_config.json` resolution is a follow-up.
   @override
-  HuggingFaceResolver? get huggingFaceResolver =>
+  HuggingFaceResolver get huggingFaceResolver =>
       const OnnxHuggingFaceResolver();
 
   /// In lockstep with `hook/build.dart`'s `_archivesFor`: every host whose

--- a/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
@@ -7,12 +7,17 @@ import 'package:flutter_gemma/core/domain/platform_types.dart'
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
 import 'package:flutter_gemma/core/model_management/model_specs.dart'
     show InferenceModelSpec;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart'
+    show HuggingFaceResolverSource;
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/runtime_config.dart';
 import 'package:flutter_gemma/core/utils/gemma_log.dart' show gemmaLog;
 import 'package:flutter_gemma/flutter_gemma_interface.dart' show InferenceModel;
 
 import 'ffi/gen_ai_client.dart';
+import 'onnx_hugging_face_resolver.dart' show OnnxHuggingFaceResolver;
 import 'onnx_inference_model.dart';
 
 /// ONNX Runtime GenAI on-device inference engine.
@@ -34,7 +39,7 @@ import 'onnx_inference_model.dart';
 /// Mirrors [LiteRtLmEngine] from `flutter_gemma_litertlm`: a pure factory
 /// that core probes via [canHandle] and calls to build a bare
 /// [InferenceModel]; core owns the singleton lifecycle.
-class OnnxEngine implements InferenceEngineProvider {
+class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
   /// [clientFactory] is the injection seam for tests — defaults to the real
   /// `dart:ffi` worker-isolate client. Never override it in production code;
   /// it exists so `test/onnx_engine_test.dart` can inject a fake with zero
@@ -51,6 +56,16 @@ class OnnxEngine implements InferenceEngineProvider {
 
   @override
   int get priority => 0;
+
+  /// The engine's own Hugging Face resolver. Auto-registered by
+  /// `FlutterGemma.initialize(inferenceEngines: …)` so it reserves the `.onnx`
+  /// slot: `resolveHuggingFace(fileType: onnx)` (and the one-call
+  /// `fromHuggingFace`) throws a clear `UnimplementedError` ("not implemented
+  /// yet") instead of core's generic "no resolver registered". Directory-based
+  /// `genai_config.json` resolution is a follow-up.
+  @override
+  HuggingFaceResolver? get huggingFaceResolver =>
+      const OnnxHuggingFaceResolver();
 
   /// In lockstep with `hook/build.dart`'s `_archivesFor`: every host whose
   /// archive the hook bundles AND whose engine path is verified on a real

--- a/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
@@ -18,8 +18,9 @@ import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
 /// `genai_config.json`-driven directory resolver is the follow-up; until then
 /// install an ONNX model from a local directory.
 ///
-/// Register it via `FlutterGemma.initialize(huggingFaceResolvers: [...])`,
-/// exactly like the engine (`OnnxEngine`) and backend (`OnnxEmbeddingBackend`).
+/// Auto-registered from `OnnxEngine` (which implements
+/// `HuggingFaceResolverSource`), so registering the engine is enough; pass it in
+/// `FlutterGemma.initialize(huggingFaceResolvers: [...])` only to override.
 class OnnxHuggingFaceResolver implements HuggingFaceResolver {
   const OnnxHuggingFaceResolver();
 

--- a/packages/flutter_gemma_onnx/lib/src/web/onnx_engine_web.dart
+++ b/packages/flutter_gemma_onnx/lib/src/web/onnx_engine_web.dart
@@ -11,10 +11,15 @@
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
 import 'package:flutter_gemma/core/model_management/model_specs.dart'
     show InferenceModelSpec;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
+    show HuggingFaceResolver;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_source.dart'
+    show HuggingFaceResolverSource;
 import 'package:flutter_gemma/core/registry/inference_engine_provider.dart';
 import 'package:flutter_gemma/core/registry/runtime_config.dart';
 import 'package:flutter_gemma/flutter_gemma_interface.dart' show InferenceModel;
 
+import '../onnx_hugging_face_resolver.dart' show OnnxHuggingFaceResolver;
 import 'onnx_web_inference_model.dart';
 import 'transformers_web_resolver.dart';
 
@@ -28,7 +33,7 @@ import 'transformers_web_resolver.dart';
 /// [OnnxWebInferenceModel]'s module doc for how that changes model identity
 /// and the generation loop. Use `OnnxEmbeddingBackend` for the web
 /// embeddings arm (onnxruntime-web).
-class OnnxEngine implements InferenceEngineProvider {
+class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
   const OnnxEngine();
 
   @override
@@ -36,6 +41,13 @@ class OnnxEngine implements InferenceEngineProvider {
 
   @override
   int get priority => 0;
+
+  /// The engine's own Hugging Face resolver (same stub as the native arm):
+  /// reserves the `.onnx` slot so `resolveHuggingFace(fileType: onnx)` throws a
+  /// clear `UnimplementedError` rather than core's generic "no resolver".
+  @override
+  HuggingFaceResolver? get huggingFaceResolver =>
+      const OnnxHuggingFaceResolver();
 
   @override
   bool canHandle(InferenceModelSpec spec) =>

--- a/packages/flutter_gemma_onnx/lib/src/web/onnx_engine_web.dart
+++ b/packages/flutter_gemma_onnx/lib/src/web/onnx_engine_web.dart
@@ -46,7 +46,7 @@ class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
   /// reserves the `.onnx` slot so `resolveHuggingFace(fileType: onnx)` throws a
   /// clear `UnimplementedError` rather than core's generic "no resolver".
   @override
-  HuggingFaceResolver? get huggingFaceResolver =>
+  HuggingFaceResolver get huggingFaceResolver =>
       const OnnxHuggingFaceResolver();
 
   @override

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -231,9 +231,11 @@ final install = await FlutterGemma.installModel(
   .install();
 
 final model = await FlutterGemma.getActiveModel(defaults: install.runtime);
+// `minOutputTokens` is a FLOOR, not a cap — leave `maxOutputTokens` unset (or
+// keep it >= `install.runtime?.minOutputTokens`). Passing the floor as the cap
+// would truncate a reasoning model mid-thought.
 final session = await model.createSession(
   enableThinking: install.runtime?.isThinking ?? false,
-  maxOutputTokens: install.runtime?.minOutputTokens,
 );
 ```
 

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -215,9 +215,31 @@ await FlutterGemma.installModel(
 
 ### Hugging Face
 
-Two extra paths install a model straight from a Hugging Face repo.
+Install a model straight from a Hugging Face repo. The resolver that reads a repo's deployment manifest ships with the engine, so registering the engine is enough — there is no separate resolver list to maintain.
 
-**Explicit file** — `fromHuggingFace(repo, file:)` resolves `…/resolve/main/<file>` and installs it (the HF token is applied to `huggingface.co` automatically), for any `fileType`:
+**One call (manifest-driven)** — omit `file`, and `fromHuggingFace(repo)` resolves the repo's manifest (e.g. `litertlm_manifest.json`) at install time, installs the right revision-pinned variant for the device, and returns the manifest's overridable runtime defaults on the result:
+
+```dart
+// The engine carries its resolver — nothing else to register.
+await FlutterGemma.initialize(inferenceEngines: [LiteRtLmEngine()]);
+
+final install = await FlutterGemma.installModel(
+  modelType: ModelType.general,     // fallback — the manifest overrides it
+  fileType: ModelFileType.litertlm, // selects the litertlm resolver
+)
+  .fromHuggingFace('litert-community/Qwen3-4B-Thinking-2507')
+  .install();
+
+final model = await FlutterGemma.getActiveModel(defaults: install.runtime);
+final session = await model.createSession(
+  enableThinking: install.runtime?.isThinking ?? false,
+  maxOutputTokens: install.runtime?.minOutputTokens,
+);
+```
+
+`.onnx` and `.builtIn` repos surface their resolver's status here — ONNX reports that directory-based install is a follow-up, and built-in reports that OS models have no Hugging Face file.
+
+**Explicit file** — pass `file`, and `fromHuggingFace(repo, file:)` resolves `…/resolve/<revision>/<file>` and installs it directly, for any `fileType` (no manifest needed; the HF token is applied to `huggingface.co` automatically):
 
 ```dart
 await FlutterGemma.installModel(
@@ -228,29 +250,23 @@ await FlutterGemma.installModel(
   .install();
 ```
 
-**Manifest-driven** — `resolveHuggingFace(repo, fileType:)` reads the repo's deployment manifest (e.g. `litertlm_manifest.json`), picks the right variant for the device, and returns install identity plus overridable runtime defaults. Register a resolver first via `initialize(huggingFaceResolvers: [...])`:
+**Inspect first** — `resolveHuggingFace(repo, fileType:)` returns the resolved identity plus overridable runtime defaults WITHOUT installing, so you can inspect the variant, its notes, and defaults before committing:
 
 ```dart
-// Register the resolver once at startup (alongside the engine).
-await FlutterGemma.initialize(
-  inferenceEngines: [LiteRtLmEngine()],
-  huggingFaceResolvers: [const LitertlmManifestResolver()],
-);
-
 final r = await FlutterGemma.resolveHuggingFace(
   'litert-community/Qwen3-4B-Thinking-2507',
   fileType: ModelFileType.litertlm,
 );
+// … inspect r.file / r.notes / r.runtime …
 await FlutterGemma.installModel(
   modelType: r.modelType ?? ModelType.general,
   fileType: r.fileType,
 )
   .fromNetwork(r.url) // r.url pins the resolver's revision
   .install();
-final model = await FlutterGemma.getActiveModel(defaults: r.runtime);
 ```
 
-The resolver lives in the engine package — `LitertlmManifestResolver` in `flutter_gemma_litertlm` reads `litertlm_manifest.json`. ONNX and built-in engines register resolvers too: ONNX reports that directory-based install is a follow-up, and built-in reports that OS models have no Hugging Face file.
+The resolver lives in the engine package — `LitertlmManifestResolver` in `flutter_gemma_litertlm` reads `litertlm_manifest.json` — and rides on the engine via `HuggingFaceResolverSource`, so `initialize(inferenceEngines: […])` auto-registers it. Pass `initialize(huggingFaceResolvers: [...])` only to override an engine's default (e.g. `LitertlmManifestResolver(revision: 'abc123')` to pin a commit).
 
 ### Source capabilities
 


### PR DESCRIPTION
## What

Two ergonomic additions to the Hugging Face resolver arc (#454), folding into the still-unpublished 1.7.0:

- **Engine-carried resolvers (auto-register).** Engines that ship an HF resolver expose it via a new opt-in `HuggingFaceResolverSource` capability interface, and `FlutterGemma.initialize(inferenceEngines: …)` auto-registers them — an app no longer maintains a parallel `huggingFaceResolvers:` list. The explicit list still wins on an equal-priority tie (for overrides such as a pinned revision). Kept OFF `InferenceEngineProvider` (Interface Segregation) so MediaPipe and third-party engines are not forced to implement it, and so no existing engine breaks.
- **One-call install.** `installModel(…).fromHuggingFace(repo)` with no `file` resolves the repo's deployment manifest at install time, installs the revision-pinned variant, and returns the manifest's overridable runtime defaults + notes on `InferenceInstallation`. `.onnx`/`.builtIn` surface their resolver's own error before any download.

## modelType precedence

`ModelType.general` is treated as "no claim — resolve it for me", so the manifest's family wins over it; any SPECIFIC caller type wins over the manifest, and a real disagreement is surfaced in `InferenceInstallation.notes` (release-visible, not just a debug log).

## Review

Two multi-agent review rounds (7 agents on the feature, 4 on the fix commit) plus a fable-model architect adjudication of the design calls. Applied: non-nullable resolver getter, the `general`-sentinel modelType precedence with a release-visible conflict note, side-effect-free `install()` (resolved source held in a local, never written back to the builder), unmodifiable `InferenceInstallation.notes`, floor-vs-cap doc fix (`minOutputTokens`), and auto-registration docs. Second round: all clean, 0 CRITICAL/IMPORTANT.

## Notes

Docs (website + CHANGELOG for core / litertlm / onnx / builtin) updated in this PR. No version bumps — everything folds into the unpublished 1.7.0 arc already on `main`.
