### PR TITLE
fix(builtin-ai): iOS/macOS build failed on Xcode below 26.4 (#460)

### DIFF
--- a/packages/flutter_gemma_builtin_ai/CHANGELOG.md
+++ b/packages/flutter_gemma_builtin_ai/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.1
 - Add `BuiltInAiHuggingFaceResolver` (auto-registered from `BuiltInAiEngine`) so `resolveHuggingFace` reports that built-in OS models have no Hugging Face file (#454).
+- fix: iOS/macOS builds failed on Xcode below 26.4 — `SystemLanguageModel.tokenCount` is absent from those SDKs and `#available` cannot gate a missing declaration (#460).
 
 ## 0.2.0
 - Web support: Gemini Nano via the Chrome Prompt API (desktop Chrome/Edge).

--- a/packages/flutter_gemma_builtin_ai/README.md
+++ b/packages/flutter_gemma_builtin_ai/README.md
@@ -113,8 +113,15 @@ final response = await session.getResponse();
 | Audio input | ❌ | ❌ | ❌ |
 | Function calling | ✅ (prompt-based) | ✅ (prompt-based) | ✅ (prompt-based) |
 | Thinking mode | ❌ | ❌ | ❌ |
-| `sizeInTokens` | ✅ native token count | ✅ native token count | ✅ `measureContextUsage` |
+| `sizeInTokens` | ✅ native token count | ✅ on OS 26.4+, built with Xcode 26.4+ (estimate otherwise) | ✅ `measureContextUsage` |
 | LoRA weights | ❌ | ❌ | ❌ |
+
+`sizeInTokens` on Apple needs BOTH conditions. `SystemLanguageModel.tokenCount` is
+`@available(iOS 26.4, macOS 26.4)`, so the declaration is absent from earlier SDKs —
+a package built with Xcode 26.1 cannot call it at all, and one built with 26.4+ still
+falls back when RUNNING on an older OS. The fallback is core's `text.length / 4`
+estimate, reported through a `TOKENIZER_UNAVAILABLE` error that names which of the two
+conditions was missing.
 
 The Chrome Prompt API also supports a web-only JSON-schema `responseConstraint` for structured
 output; it is intentionally **not** part of the cross-platform contract above (native has no

--- a/packages/flutter_gemma_builtin_ai/darwin/flutter_gemma_builtin_ai/Sources/flutter_gemma_builtin_ai/BuiltInAiServiceImpl.swift
+++ b/packages/flutter_gemma_builtin_ai/darwin/flutter_gemma_builtin_ai/Sources/flutter_gemma_builtin_ai/BuiltInAiServiceImpl.swift
@@ -387,34 +387,65 @@ public class BuiltInAiServiceImpl: NSObject, BuiltInAiService, FlutterStreamHand
     completion(.success(()))
   }
 
+  /// Reported when the native tokenizer cannot be reached, so Dart falls back
+  /// to its `text.length / 4` heuristic. Two distinct causes, one signal: the
+  /// SDK we were BUILT against has no `tokenCount`, or the OS we are RUNNING on
+  /// is older than 26.4.
+  private static func tokenizerUnavailable(_ why: String) -> PigeonError {
+    PigeonError(
+      code: "TOKENIZER_UNAVAILABLE",
+      message: "Token counting is unavailable: \(why)",
+      details: nil)
+  }
+
   func countTokens(text: String, completion: @escaping (Result<Int64, Error>) -> Void) {
-    // `SystemLanguageModel.tokenCount(for:)` is gated to iOS 26.4 / macOS 26.4
-    // (stricter than the 26.0 floor of the rest of the framework). On any OS
-    // below that — including 26.0–26.3, where the model exists but the tokenizer
-    // API does not — we return a pigeon error so Dart falls back to its
-    // (text.length / 4) char heuristic.
-    guard #available(iOS 26.4, macOS 26.4, *) else {
+    // `SystemLanguageModel.tokenCount(for:)` is `@available(iOS 26.4, macOS
+    // 26.4, visionOS 26.4, *)`, stricter than the 26.0 floor of the rest of the
+    // framework.
+    //
+    // `#available` alone is NOT enough, and that is what broke #460. It is a
+    // RUNTIME check: it permits CALLING a newer API, but the declaration still
+    // has to exist in the SDK being compiled against. It does not exist in the
+    // 26.0–26.3 SDKs, so Xcode 26.1 fails the build outright with "Value of
+    // type 'SystemLanguageModel' has no member 'tokenCount'" — for every
+    // consumer of this package, whether or not they ever call countTokens.
+    //
+    // Swift has no SDK-version conditional to gate on. `canImport(_version:)`
+    // reads the module's user-module-version and FoundationModels declares
+    // none: measured against the 26.5 SDK it answers YES to `_version: 1` and
+    // NO to `_version: 26.4`, so it cannot express "this SDK has tokenCount".
+    //
+    // The toolchain ships WITH the SDK, so the compiler version is the usable
+    // proxy — Xcode 26.5 carries Swift 6.3.2 (verified locally, and the SDK's
+    // own .swiftinterface records `-interface-compiler-version 6.3.2`), while
+    // the Xcode 26.1 in the report carries 6.2.1. The gate is deliberately
+    // biased toward the fallback: an SDK that HAS the API but ships an older
+    // compiler loses exact counts, which is a worse NUMBER, not a broken build.
+    #if compiler(>=6.3)
+      guard #available(iOS 26.4, macOS 26.4, *) else {
+        completion(.failure(Self.tokenizerUnavailable("requires iOS/macOS 26.4 or newer")))
+        return
+      }
+      Task {
+        do {
+          let count = try await SystemLanguageModel.default.tokenCount(for: text)
+          completion(.success(Int64(count)))
+        } catch {
+          completion(
+            .failure(
+              PigeonError(
+                code: "TOKENIZER_ERROR",
+                message: error.localizedDescription,
+                details: nil)))
+        }
+      }
+    #else
       completion(
         .failure(
-          PigeonError(
-            code: "TOKENIZER_UNAVAILABLE",
-            message: "Token counting requires iOS 26.4 / macOS 26.4 or newer.",
-            details: nil)))
-      return
-    }
-    Task {
-      do {
-        let count = try await SystemLanguageModel.default.tokenCount(for: text)
-        completion(.success(Int64(count)))
-      } catch {
-        completion(
-          .failure(
-            PigeonError(
-              code: "TOKENIZER_ERROR",
-              message: error.localizedDescription,
-              details: nil)))
-      }
-    }
+          Self.tokenizerUnavailable(
+            "this package was built against an SDK without "
+              + "SystemLanguageModel.tokenCount (Xcode 26.4+ provides it)")))
+    #endif
   }
 
   // MARK: - Error mapping

--- a/website/content/docs/builtin-ai.md
+++ b/website/content/docs/builtin-ai.md
@@ -141,7 +141,7 @@ final response = await session.getResponse();
 | Function calling | ✅ prompt-based | ✅ prompt-based | ✅ prompt-based |
 | Vision (image input) | ✅ | ✅ on OS 27+ (text-only on OS 26) | ❌ (v1, tracked) |
 | Audio · Thinking · LoRA | ❌ | ❌ | ❌ |
-| `sizeInTokens` | ✅ native count | ✅ native count | ✅ `measureContextUsage` |
+| `sizeInTokens` | ✅ native count | ✅ on OS 26.4+, built with Xcode 26.4+ (estimate otherwise) | ✅ `measureContextUsage` |
 
 - **Function calling is prompt-based** — tool definitions are woven into the
   prompt by core `InferenceChat`; the OS models don't expose a usable native
@@ -149,6 +149,12 @@ final response = await session.getResponse();
   and not production-usable (Chrome 151), so it too goes through the prompt-based
   path. Gemini Nano handles single-turn calls; multi-turn agent chaining is not
   supported on Web (see [Agent Skills](/docs/agent)).
+- **`sizeInTokens` on Apple needs two things at once.**
+  `SystemLanguageModel.tokenCount` is `@available(iOS 26.4, macOS 26.4)`, so the
+  declaration is missing from earlier SDKs entirely — a build on Xcode 26.1
+  cannot reference it, and a build on 26.4+ still falls back when running on an
+  older OS. Either way the count comes from core's `text.length / 4` estimate.
+
 - **Web is text-only in this release** (image/audio dropped with a one-time log).
 
 ## Web setup


### PR DESCRIPTION
Closes #460.

`flutter_gemma_builtin_ai` 0.2.0 does not compile on Xcode below 26.4 — for
every consumer, whether or not they ever count a token. @abdulmominsakib hit it
on Xcode 26.1 with `flutter build ipa`.

## Why `#available` was not enough

`SystemLanguageModel.tokenCount(for:)` is `@available(iOS 26.4, macOS 26.4,
visionOS 26.4, *)` — read out of the SDK's own `.swiftinterface`, while
`SystemLanguageModel` itself is 26.0. `#available` is a **runtime** check: it
permits *calling* a newer API, but the declaration still has to exist in the SDK
being compiled against. It does not in 26.0–26.3, so the compiler stops at

```
Value of type 'SystemLanguageModel' has no member 'tokenCount'
```

## What to gate on instead

Swift has no SDK-version conditional. `canImport(_version:)` reads the module's
`user-module-version` and FoundationModels declares none — measured against the
26.5 SDK it answers YES to `_version: 1` and NO to `_version: 26.4`, so it
cannot express "this SDK has tokenCount".

The toolchain ships **with** the SDK, so the compiler version is the usable
proxy:

| | Swift | SDK | `tokenCount` |
|---|---|---|---|
| Xcode 26.1 (the report) | 6.2.1 | 26.1 | absent |
| Xcode 26.5 (verified here) | 6.3.2 | 26.5 | present |

`#if compiler(>=6.3)`. The gate is deliberately biased toward the fallback: an
SDK that HAS the API but ships an older compiler loses exact counts, which is a
worse *number*, not a broken build. The error now names which of the two
conditions was missing, instead of a bare `TOKENIZER_UNAVAILABLE`.

## Verified

Built the example both ways:

| | result |
|---|---|
| gate as written (Swift 6.3.2 → `tokenCount` branch) | `✓ Built` |
| gate forced to `compiler(>=99)`, standing in for an old SDK → fallback branch | `✓ Built` |

The second is the one that matters: it is the branch an Xcode 26.1 user takes,
and it never mentions `tokenCount`.

## Docs

README and `website/content/docs/builtin-ai.md` both listed `sizeInTokens` on
Apple as an unqualified "✅ native token count". It needs **both** an OS at 26.4+
and a build on Xcode 26.4+, so both now say that, with a note on what the
fallback is.

Rides the already-prepared, unpublished **0.2.1** rather than burning a version.

---

Two things found while walking the release skill, neither addressed here:

- **`flutter_gemma_builtin_ai` 0.2.1 cannot be published on its own.** It
  declares `flutter_gemma: ^1.7.0` and core 1.7.0 is not on pub.dev (1.6.5 is).
  Core has to go first — this is the Step 1g ordering rule, and `--dry-run` is
  blind to it.
- **`guard-release-docs` blocks three other packages in the pending batch**:
  core, `flutter_gemma_onnx` and `flutter_gemma_agent` each changed `lib/` since
  their current version was set without a README update. For core specifically
  the gap is real — the one-call `fromHuggingFace(repo)` from #471 is the
  headline of 1.7.0 and appears nowhere in the README that becomes its pub.dev
  page.
