### PR TITLE
feat(onnx): install ORT-GenAI models from Hugging Face as a directory (#454)

### DIFF
--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.7.0
-- Manifest-driven Hugging Face install (#454): `resolveHuggingFace` / one-call `installModel(…).fromHuggingFace(repo)`, with engines auto-registering their resolver.
+- Hugging Face install (#454): `resolveHuggingFace` / one-call `installModel(…).fromHuggingFace(repo)`, with engines auto-registering their resolver.
 
 ## 1.6.5
 - Tool-declaration injection is a declarative `InferenceChat` flag, not a hardcoded gemma4 check (no behavior change).

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -833,6 +833,24 @@ Each `DownloadError` exposes `toUserMessage()`, `toTitle()`, `isRetryable`, and
 ## Installation Sources
 
 ```dart
+// Hugging Face repo — the engine's resolver picks the right file/variant.
+// One call: omit `file` and the resolver reads the repo (a litertlm manifest,
+// or the ONNX file tree) at install time and installs the right variant.
+await FlutterGemma.installModel(
+  modelType: ModelType.general, // a resolver may override (e.g. litertlm manifest)
+  fileType: ModelFileType.litertlm,
+)
+  .fromHuggingFace('litert-community/Qwen3-4B-Thinking-2507')
+  .install();
+
+// Or pin an explicit file (any fileType; no manifest needed):
+await FlutterGemma.installModel(
+  modelType: ModelType.gemmaIt,
+  fileType: ModelFileType.litertlm,
+)
+  .fromHuggingFace('litert-community/Gemma3-1B-IT', file: 'model.litertlm')
+  .install();
+
 // Network — .litertlm is the cross-platform default (Android/iOS/Desktop).
 // For mobile-only or web-only apps you can substitute a .task URL of the
 // same model — and drop the fileType, which defaults to ModelFileType.task.
@@ -867,6 +885,14 @@ await FlutterGemma.installModel(
   .fromFile('/path/to/model.litertlm')
   .install();
 ```
+
+`fromHuggingFace` needs the matching engine's resolver, which the engine
+registers itself: `LiteRtLmEngine` reads `litertlm_manifest.json`, `OnnxEngine`
+resolves an ORT-GenAI directory (auto-picking a CPU execution-provider folder).
+`resolveHuggingFace(repo, fileType:)` returns the resolved identity and
+overridable runtime defaults *without* installing, so you can inspect the variant
+and its `notes` first. See each engine package's README for the resolver
+specifics.
 
 ## Modern API vs Legacy API
 

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -568,12 +568,15 @@ class InferenceInstallationBuilder {
     }
 
     // Belt-and-suspenders: a directory with a genai_config.json but no .onnx
-    // weight file installs "successfully" and only fails later inside
-    // OgaCreateModel. The onnx resolver already guards this, but any resolver
-    // could hand us an incomplete set — refuse it here too.
+    // GRAPH file installs "successfully" and only fails later inside
+    // OgaCreateModel. This checks graph PRESENCE only — not that every weight
+    // the graph references (external `.onnx_data`) is included, so a mis-export
+    // can still fail at load. The onnx resolver already guards presence, but any
+    // resolver could hand us an incomplete set — refuse the no-`.onnx` case here
+    // too.
     if (!hfFiles.any((f) => f.name.endsWith('.onnx'))) {
       throw StateError(
-        'Directory model "$_hfRepo" has no .onnx weight file among its '
+        'Directory model "$_hfRepo" has no .onnx graph file among its '
         '${hfFiles.length} files — it cannot load. The resolver returned an '
         'incomplete file set.',
       );

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -527,19 +527,31 @@ class InferenceInstallationBuilder {
         'got none.',
       );
     }
+    // The subdir name is interpolated as a path segment (`<modelId>/<leaf>`) and
+    // fed to deleteModel's recursive Directory.delete — a traversing modelId
+    // (`..`, or one carrying a separator) would escape the storage dir and could
+    // delete its parent. `sanitizeHfDirName` guards its own output, but a
+    // third-party resolver can supply `directoryName` directly, so re-check here.
+    if (modelId == '.' ||
+        modelId == '..' ||
+        modelId.contains('/') ||
+        modelId.contains(r'\')) {
+      throw ArgumentError.value(
+        modelId,
+        'ResolvedHfModel.directoryName',
+        'must be a single safe path segment (no "/", "\\", "." or ".." ) — a '
+            'traversing name would escape the model storage directory; refusing '
+            '"$_hfRepo"',
+      );
+    }
 
     // A directory member must be a BARE leaf name. A resolver name with a path
     // separator or a "."/".." segment (e.g. "../victim.onnx") would escape the
     // model directory at both install and delete time — refuse it.
     for (final f in hfFiles) {
-      final n = f.name;
-      if (n.isEmpty ||
-          n == '.' ||
-          n == '..' ||
-          n.contains('/') ||
-          n.contains(r'\')) {
+      if (!f.isBareLeafName) {
         throw ArgumentError.value(
-          n,
+          f.name,
           'ResolvedHfFile.name',
           'directory model file names must be bare leaf names (no path '
               'separators or "."/".." segments) — refusing "$_hfRepo" file',
@@ -552,6 +564,18 @@ class InferenceInstallationBuilder {
         'Directory model "$_hfRepo" resolved without its primary file '
         '"$primaryName" in the file list — cannot locate the model directory\'s '
         'entry point.',
+      );
+    }
+
+    // Belt-and-suspenders: a directory with a genai_config.json but no .onnx
+    // weight file installs "successfully" and only fails later inside
+    // OgaCreateModel. The onnx resolver already guards this, but any resolver
+    // could hand us an incomplete set — refuse it here too.
+    if (!hfFiles.any((f) => f.name.endsWith('.onnx'))) {
+      throw StateError(
+        'Directory model "$_hfRepo" has no .onnx weight file among its '
+        '${hfFiles.length} files — it cannot load. The resolver returned an '
+        'incomplete file set.',
       );
     }
 
@@ -589,21 +613,40 @@ class InferenceInstallationBuilder {
     final handlerRegistry = registry.sourceHandlerRegistry;
 
     final files = spec.files;
-    var done = 0;
-    for (final file in files) {
+    final total = files.length;
+    for (var i = 0; i < files.length; i++) {
+      final file = files[i];
       _cancelToken?.throwIfCancelled();
       if (await repository.isInstalled(file.filename)) {
         gemmaLog('ℹ️  Already installed: ${file.filename} (skipping download)');
       } else {
         final handler = handlerRegistry.getHandler(file.source);
-        await handler!.install(
-          file.source,
-          cancelToken: _cancelToken,
-          targetFilename: file.filename,
-        );
+        if (handler == null) {
+          throw StateError(
+            'No source handler for ${file.source.runtimeType} (directory '
+            'member "${file.filename}").',
+          );
+        }
+        if (_onProgress != null) {
+          // Each file owns the slice [i/total, (i+1)/total]; stream WITHIN it so
+          // the bar keeps moving during the multi-GB model.onnx download instead
+          // of freezing between file boundaries (weights dominate total size).
+          await for (final pct in handler.installWithProgress(
+            file.source,
+            cancelToken: _cancelToken,
+            targetFilename: file.filename,
+          )) {
+            _onProgress!((((i + pct / 100) / total) * 100).round());
+          }
+        } else {
+          await handler.install(
+            file.source,
+            cancelToken: _cancelToken,
+            targetFilename: file.filename,
+          );
+        }
       }
-      done++;
-      _onProgress?.call(((done / files.length) * 100).round());
+      _onProgress?.call((((i + 1) / total) * 100).round());
     }
 
     final manager = FlutterGemmaPlugin.instance.modelManager;

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -126,9 +126,10 @@ class InferenceInstallationBuilder {
   /// - [revision] must be left `'main'`: the registered resolver owns the pin
   ///   (it builds a revision-pinned URL). Passing a non-`'main'` [revision]
   ///   without a [file] throws [ArgumentError].
-  /// - The resolver's own error surfaces from [install]: e.g. `.onnx` throws
-  ///   `UnimplementedError`, `.builtIn` throws `UnsupportedError` (the OS owns
-  ///   the weights) — both naming the repo.
+  /// - The resolver's own behavior surfaces from [install]: `.onnx` resolves
+  ///   and installs an ORT-GenAI model DIRECTORY (via the HF file tree), while
+  ///   `.builtIn` throws `UnsupportedError` (the OS owns the weights — there is
+  ///   no Hugging Face file) — naming the repo.
   /// - Unlike other sources, this requires NETWORK access at [install] even if
   ///   the model is already installed (the variant filename is only known after
   ///   the manifest fetch). For offline-safe idempotent installs, cache the
@@ -282,10 +283,10 @@ class InferenceInstallationBuilder {
     ModelSource? source = _modelSource;
 
     // Deferred Hugging Face resolution runs FIRST — before the builtIn /
-    // onnx-web branches below, which assume a concrete source. For a `.builtIn`
-    // / `.onnx` repo the resolver throws its own clear error here
-    // (UnsupportedError / UnimplementedError, naming the repo) instead of those
-    // branches tripping over a null source.
+    // onnx-web branches below, which assume a concrete source. A `.onnx` repo
+    // resolves to a directory (or a fileless web model) here; a `.builtIn` repo
+    // throws its own clear `UnsupportedError` (the OS owns the weights, no HF
+    // file) — either way, before those branches trip over a null source.
     if (_hfRepo != null) {
       final r = await FlutterGemma.resolveHuggingFace(
         _hfRepo!,

--- a/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
+++ b/packages/flutter_gemma/lib/core/api/inference_installation_builder.dart
@@ -321,12 +321,26 @@ class InferenceInstallationBuilder {
         gemmaLog('ℹ️  Hugging Face ($_hfRepo): $note');
       }
 
+      resolvedRuntime = r.runtime;
+
+      // DIRECTORY model (ORT-GenAI): a set of files that must install together
+      // into a per-model subdirectory with bare names (the layout
+      // `OgaCreateModel` needs). Self-contained path — download the bundle and
+      // return; the single-file flow below never runs.
+      if (r.files != null) {
+        return _installDirectory(
+          r,
+          modelType: resolvedModelType ?? _modelType,
+          runtime: resolvedRuntime,
+          notes: resolvedNotes,
+        );
+      }
+
       source = ModelSource.network(
         r.url,
         authToken: _hfToken,
         foreground: _hfForeground,
       );
-      resolvedRuntime = r.runtime;
     }
 
     if (source == null) {
@@ -469,6 +483,134 @@ class InferenceInstallationBuilder {
       runtime: resolvedRuntime,
       notes: resolvedNotes,
     );
+  }
+
+  /// Installs a DIRECTORY (ORT-GenAI) model resolved from a Hugging Face repo:
+  /// every file in [r].files is downloaded into a per-model subdirectory
+  /// (`<modelId>/<bareLeaf>`) with its bare leaf name — the layout
+  /// `OgaCreateModel` needs (`genai_config.json` references its siblings by bare
+  /// name; the native loader is handed the directory). Mirrors the TTS bundle
+  /// install loop, but subdir-namespaced rather than flat. The active spec's
+  /// primary file is `genai_config.json`, so `getModelFilePaths.values.first`
+  /// resolves inside the directory and the engine's `File(modelPath).parent` is
+  /// exactly that directory.
+  Future<InferenceInstallation> _installDirectory(
+    ResolvedHfModel r, {
+    required ModelType modelType,
+    required ModelRuntimeDefaults? runtime,
+    required List<String> notes,
+  }) async {
+    // LoRA rides on a single-file inference model; a directory (ORT-GenAI)
+    // model has no place to attach it. Reject loudly instead of silently
+    // dropping it (mirrors the builtIn / onnx-web paths).
+    if (_loraSource != null) {
+      throw ArgumentError(
+        'LoRA is not supported for directory (ORT-GenAI) models installed via '
+        'fromHuggingFace("$_hfRepo").',
+      );
+    }
+
+    final hfFiles = r.files!;
+    final primaryName = r.file; // bare leaf, e.g. genai_config.json
+
+    // The subdirectory name is REQUIRED and must be variant-inclusive — a
+    // repo-only fallback would let two execution-provider variants of the same
+    // repo (cpu vs cuda) collide in one directory, and the second install's
+    // "already installed" skips would activate a spec backed by the other
+    // variant's files. The resolver supplies it via
+    // FileNameUtils.sanitizeHfDirName(repo, variant: …).
+    final modelId = r.directoryName;
+    if (modelId == null || modelId.isEmpty) {
+      throw ArgumentError(
+        'A directory model resolved from "$_hfRepo" must supply '
+        'ResolvedHfModel.directoryName (a variant-inclusive subdirectory name); '
+        'got none.',
+      );
+    }
+
+    // A directory member must be a BARE leaf name. A resolver name with a path
+    // separator or a "."/".." segment (e.g. "../victim.onnx") would escape the
+    // model directory at both install and delete time — refuse it.
+    for (final f in hfFiles) {
+      final n = f.name;
+      if (n.isEmpty ||
+          n == '.' ||
+          n == '..' ||
+          n.contains('/') ||
+          n.contains(r'\')) {
+        throw ArgumentError.value(
+          n,
+          'ResolvedHfFile.name',
+          'directory model file names must be bare leaf names (no path '
+              'separators or "."/".." segments) — refusing "$_hfRepo" file',
+        );
+      }
+    }
+
+    if (!hfFiles.any((f) => f.name == primaryName)) {
+      throw StateError(
+        'Directory model "$_hfRepo" resolved without its primary file '
+        '"$primaryName" in the file list — cannot locate the model directory\'s '
+        'entry point.',
+      );
+    }
+
+    // Primary first so getModelFilePaths.values.first is the file the engine
+    // loads from (its parent dir is what OgaCreateModel is handed).
+    final ordered = [
+      ...hfFiles.where((f) => f.name == primaryName),
+      ...hfFiles.where((f) => f.name != primaryName),
+    ];
+    final bundle = [
+      for (final f in ordered)
+        DirectoryBundleFile.member(
+          modelId: modelId,
+          bareName: f.name,
+          primaryName: primaryName,
+          source: ModelSource.network(
+            f.url,
+            authToken: _hfToken,
+            foreground: _hfForeground,
+          ),
+        ),
+    ];
+
+    final spec = InferenceModelSpec(
+      name: modelId,
+      modelSource: bundle.first.source, // the primary (genai_config.json)
+      replacePolicy: ModelReplacePolicy.keep,
+      modelType: modelType,
+      fileType: _fileType,
+      directoryFiles: bundle,
+    );
+
+    final registry = ServiceRegistry.instance;
+    final repository = registry.modelRepository;
+    final handlerRegistry = registry.sourceHandlerRegistry;
+
+    final files = spec.files;
+    var done = 0;
+    for (final file in files) {
+      _cancelToken?.throwIfCancelled();
+      if (await repository.isInstalled(file.filename)) {
+        gemmaLog('ℹ️  Already installed: ${file.filename} (skipping download)');
+      } else {
+        final handler = handlerRegistry.getHandler(file.source);
+        await handler!.install(
+          file.source,
+          cancelToken: _cancelToken,
+          targetFilename: file.filename,
+        );
+      }
+      done++;
+      _onProgress?.call(((done / files.length) * 100).round());
+    }
+
+    final manager = FlutterGemmaPlugin.instance.modelManager;
+    manager.setActiveModel(spec);
+    gemmaLog('✅ ONNX directory model installed and set as active: $modelId');
+
+    return InferenceInstallation(spec: spec, runtime: runtime, notes: notes);
   }
 }
 

--- a/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/managers/mobile_model_manager.dart
@@ -191,6 +191,18 @@ class MobileModelManager extends ModelFileManager {
       return;
     }
 
+    // DIRECTORY model (ORT-GenAI): the persisted primary filename is the
+    // subpath `<modelId>/genai_config.json`. Rebuild the whole bundle from the
+    // repository records under that subdir — the repository is the single
+    // source of truth `_isModelInstalled` also checks, so restore and
+    // install-check cannot desync. Reconstructing via `FileSource(path)` (the
+    // single-file path below) would re-derive a BARE leaf filename, missing the
+    // subpath repo key, and `isModelInstalled` would be false every launch.
+    if (fileType == ModelFileType.onnx && filename.contains('/')) {
+      await _restoreActiveInferenceDirectory(filename, modelType, fileType);
+      return;
+    }
+
     final filePath = await ServiceRegistry.instance.fileSystemService
         .getTargetPath(filename);
     if (!File(filePath).existsSync()) {
@@ -207,6 +219,70 @@ class MobileModelManager extends ModelFileManager {
       fileType: fileType,
     );
     gemmaLog('[ModelManager] restored active inference model: $filename');
+  }
+
+  /// Restores a DIRECTORY (ORT-GenAI) active model from the repository records
+  /// under `<modelId>/`. [primaryFilename] is the persisted subpath
+  /// `<modelId>/<primaryBareLeaf>` (the file the engine loads from). Every
+  /// member is rebuilt with an EXPLICIT subpath filename (never derived from a
+  /// source), primary first, so `getModelFilePaths.values.first` resolves inside
+  /// the model directory.
+  Future<void> _restoreActiveInferenceDirectory(
+    String primaryFilename,
+    ModelType modelType,
+    ModelFileType fileType,
+  ) async {
+    final slash = primaryFilename.indexOf('/');
+    final modelId = primaryFilename.substring(0, slash);
+    final primaryBare = primaryFilename.substring(slash + 1);
+
+    final repository = ServiceRegistry.instance.modelRepository;
+    final members = (await repository.listInstalled())
+        .where((m) => m.id.startsWith('$modelId/'))
+        .toList();
+    if (!members.any((m) => m.id == primaryFilename)) {
+      gemmaLog(
+        '[ModelManager] active directory model restore: no primary record '
+        '"$primaryFilename" — skipping',
+      );
+      return;
+    }
+
+    // Every member must be physically present, or the model cannot load.
+    for (final m in members) {
+      final p = await ModelFileSystemManager.getModelFilePath(m.id);
+      if (!File(p).existsSync()) {
+        gemmaLog(
+          '[ModelManager] active directory model restore: missing file $p '
+          '— skipping',
+        );
+        return;
+      }
+    }
+
+    DirectoryBundleFile toMember(repo.ModelInfo m) =>
+        DirectoryBundleFile.member(
+          modelId: modelId,
+          bareName: m.id.substring(modelId.length + 1),
+          primaryName: primaryBare,
+          source: m.source,
+        );
+    final bundle = <DirectoryBundleFile>[
+      ...members.where((m) => m.id == primaryFilename).map(toMember),
+      ...members.where((m) => m.id != primaryFilename).map(toMember),
+    ];
+
+    _activeInferenceModel = InferenceModelSpec(
+      name: modelId,
+      modelSource: bundle.first.source,
+      modelType: modelType,
+      fileType: fileType,
+      directoryFiles: bundle,
+    );
+    gemmaLog(
+      '[ModelManager] restored active directory model: $modelId '
+      '(${bundle.length} files)',
+    );
   }
 
   /// One-time migration of a pre-refactor (plain-named) COMPANION file to its
@@ -819,6 +895,18 @@ class MobileModelManager extends ModelFileManager {
         await repository.deleteModel(file.filename);
       }
 
+      // Directory (ORT-GenAI) model: its members lived in a per-model
+      // subdirectory. Remove the now-empty subdir so it doesn't accumulate
+      // (deleteModelFile only removes the individual files inside it).
+      if (spec is InferenceModelSpec && spec.directoryFiles != null) {
+        final dirName = spec.directoryFiles!.first.filename.split('/').first;
+        final dirPath = await ModelFileSystemManager.getModelFilePath(dirName);
+        final dir = Directory(dirPath);
+        if (await dir.exists()) {
+          await dir.delete(recursive: true);
+        }
+      }
+
       gemmaLog('UnifiedModelManager: Model deleted - ${spec.name}');
     } catch (e) {
       gemmaLog(
@@ -966,7 +1054,14 @@ class MobileModelManager extends ModelFileManager {
       for (final file in spec.files) {
         // Get path based on source type
         final String path;
-        if (file.source is FileSource) {
+        if (file is DirectoryBundleFile) {
+          // Directory (ORT-GenAI) member: its identity is the explicit subpath
+          // `<modelId>/<bareLeaf>` under the model storage dir — resolve by
+          // filename regardless of the carrier source type (a restored bundle
+          // may carry a network/file source, but the on-disk location is always
+          // the subdir).
+          path = await ModelFileSystemManager.getModelFilePath(file.filename);
+        } else if (file.source is FileSource) {
           // External file - use path from source
           path = (file.source as FileSource).path;
         } else if (file.source is BundledSource) {

--- a/packages/flutter_gemma/lib/core/model_management/types/inference_model_spec.dart
+++ b/packages/flutter_gemma/lib/core/model_management/types/inference_model_spec.dart
@@ -167,17 +167,7 @@ class InferenceModelSpec extends ModelSpec {
     required ModelType modelType,
     ModelFileType fileType = ModelFileType.task,
     List<DirectoryBundleFile>? directoryFiles,
-  }) : assert(
-         directoryFiles == null || loraSource == null,
-         'directory (ORT-GenAI) models do not support LoRA',
-       ),
-       assert(
-         directoryFiles == null ||
-             directoryFiles.isEmpty ||
-             modelSource == directoryFiles.first.source,
-         'modelSource must be the primary (first) directory file source',
-       ),
-       _name = name,
+  }) : _name = name,
        _modelSource = modelSource,
        _loraSource = loraSource,
        _replacePolicy = replacePolicy,
@@ -187,7 +177,36 @@ class InferenceModelSpec extends ModelSpec {
        // so the bundle must not stay aliased to a list the caller can mutate.
        _directoryFiles = directoryFiles == null
            ? null
-           : List<DirectoryBundleFile>.unmodifiable(directoryFiles);
+           : List<DirectoryBundleFile>.unmodifiable(directoryFiles) {
+    // Enforced in RELEASE too — an `assert` is compiled out, so a mis-built
+    // directory spec would otherwise surface far downstream as
+    // "Bad state: No element" on `files.first`, not here. The install path
+    // rejects these earlier; this guards direct construction of the public ctor.
+    final bundle = _directoryFiles;
+    if (bundle != null) {
+      if (loraSource != null) {
+        throw ArgumentError.value(
+          loraSource,
+          'loraSource',
+          'directory (ORT-GenAI) models do not support LoRA',
+        );
+      }
+      if (bundle.isEmpty) {
+        throw ArgumentError.value(
+          directoryFiles,
+          'directoryFiles',
+          'a directory model needs at least one file (primary first)',
+        );
+      }
+      if (modelSource != bundle.first.source) {
+        throw ArgumentError.value(
+          modelSource,
+          'modelSource',
+          'must be the primary (first) directory file source',
+        );
+      }
+    }
+  }
 
   /// Legacy compatibility constructor for String URLs
   factory InferenceModelSpec.fromLegacyUrl({

--- a/packages/flutter_gemma/lib/core/model_management/types/inference_model_spec.dart
+++ b/packages/flutter_gemma/lib/core/model_management/types/inference_model_spec.dart
@@ -74,6 +74,71 @@ class LoraModelFile extends ModelFile {
   bool get isRequired => false;
 }
 
+/// One file of a DIRECTORY inference model (ORT-GenAI): the model is a set of
+/// files that must live together in a per-model subdirectory with their BARE
+/// leaf names (`genai_config.json` references its siblings by bare name and the
+/// native loader is handed the directory). [filename] is the EXPLICIT install
+/// identity `<modelId>/<bareLeaf>` (a real subpath) — NEVER derived from
+/// [source], so the on-disk id and the repository key always agree (a
+/// `FileSource`-derived basename would drop the subdir and break the repo
+/// lookup on every restore). The PRIMARY file (`genai_config.json`) uses
+/// [PreferencesKeys.installedModelFileName] as its [prefsKey] so the
+/// persist-identity + `modelFilePaths.values.first` both find it; siblings use
+/// their bare leaf name so each maps to a distinct `getModelFilePaths` entry.
+class DirectoryBundleFile extends ModelFile {
+  final ModelSource _source;
+  final String _filename;
+  final String _prefsKey;
+
+  DirectoryBundleFile({
+    required ModelSource source,
+    required String filename,
+    required String prefsKey,
+  }) : _source = source,
+       _filename = filename,
+       _prefsKey = prefsKey;
+
+  /// Builds one bundle member from its [modelId] (the subdirectory), its BARE
+  /// leaf [bareName], and the bundle's [primaryName] (the file the engine loads
+  /// from — for ORT-GenAI, `genai_config.json`). The primary gets
+  /// [PreferencesKeys.installedModelFileName] as its key so persist-identity and
+  /// `getModelFilePaths.values.first` find it; every sibling keys on its bare
+  /// name so each maps to a distinct path entry. Used by both the install path
+  /// and the restore path, so the key rule lives in one place.
+  factory DirectoryBundleFile.member({
+    required String modelId,
+    required String bareName,
+    required String primaryName,
+    required ModelSource source,
+  }) => DirectoryBundleFile(
+    source: source,
+    filename: '$modelId/$bareName',
+    prefsKey: bareName == primaryName
+        ? PreferencesKeys.installedModelFileName
+        : bareName,
+  );
+
+  @override
+  ModelSource get source => _source;
+
+  @override
+  String get filename => _filename;
+
+  @override
+  String get prefsKey => _prefsKey;
+
+  @override
+  bool get isRequired => true;
+
+  /// Directory members (`.onnx_data`, `genai_config.json`, tokenizer json/vocab)
+  /// aren't in `FileNameUtils.supportedExtensions`, so the extension heuristic
+  /// would wrongly impose the 1 MB default on small config files. We only assert
+  /// "a non-empty file landed"; real size/sha verification is a follow-up
+  /// (`ResolvedHfFile.sha256`/`sizeBytes` are carried but not yet checked).
+  @override
+  int? get minimumSizeBytes => 1;
+}
+
 /// Specification for inference models (main model + optional LoRA)
 class InferenceModelSpec extends ModelSpec {
   final String _name;
@@ -83,6 +148,13 @@ class InferenceModelSpec extends ModelSpec {
   final ModelType _modelType;
   final ModelFileType _fileType;
 
+  /// For a DIRECTORY model (ORT-GenAI): the full set of files, primary
+  /// (`genai_config.json`) FIRST. Null for a single-file model — [files] then
+  /// returns the ordinary `[model, lora?]`, byte-for-byte unchanged. When
+  /// non-null [modelSource] is the primary file's source (so single-file
+  /// consumers of [modelSource] still see the entry the engine loads from).
+  final List<DirectoryBundleFile>? _directoryFiles;
+
   InferenceModelSpec({
     required String name,
     required ModelSource modelSource,
@@ -90,12 +162,14 @@ class InferenceModelSpec extends ModelSpec {
     ModelReplacePolicy replacePolicy = ModelReplacePolicy.keep,
     required ModelType modelType,
     ModelFileType fileType = ModelFileType.task,
+    List<DirectoryBundleFile>? directoryFiles,
   }) : _name = name,
        _modelSource = modelSource,
        _loraSource = loraSource,
        _replacePolicy = replacePolicy,
        _modelType = modelType,
-       _fileType = fileType;
+       _fileType = fileType,
+       _directoryFiles = directoryFiles;
 
   /// Legacy compatibility constructor for String URLs
   factory InferenceModelSpec.fromLegacyUrl({
@@ -127,6 +201,11 @@ class InferenceModelSpec extends ModelSpec {
 
   @override
   List<ModelFile> get files {
+    // Directory (ORT-GenAI) model: the explicit bundle IS the file list, in
+    // order (primary first). LoRA is not supported for directory models.
+    final bundle = _directoryFiles;
+    if (bundle != null) return List<ModelFile>.unmodifiable(bundle);
+
     final modelFile = InferenceModelFile.fromSource(_modelSource);
     final result = <ModelFile>[modelFile];
 
@@ -137,6 +216,10 @@ class InferenceModelSpec extends ModelSpec {
 
     return result;
   }
+
+  /// The directory bundle for an ORT-GenAI model, or null for a single-file
+  /// model. Exposed so the restore path can tell a directory model apart.
+  List<DirectoryBundleFile>? get directoryFiles => _directoryFiles;
 
   /// Modern type-safe getters
   ModelSource get modelSource => _modelSource;
@@ -177,6 +260,13 @@ class InferenceModelSpec extends ModelSpec {
     }
   }
 
+  /// Value signature of the directory bundle (ordered member filenames), or
+  /// null for a single-file model. Folded into [==]/[hashCode] so two directory
+  /// specs with the same name/source/type but DIFFERENT members are not treated
+  /// as equal — install-validity depends on every member.
+  String? get _directoryFilesKey =>
+      _directoryFiles?.map((f) => f.filename).join('|');
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -187,7 +277,8 @@ class InferenceModelSpec extends ModelSpec {
         _loraSource == other._loraSource &&
         _replacePolicy == other._replacePolicy &&
         _modelType == other._modelType &&
-        _fileType == other._fileType;
+        _fileType == other._fileType &&
+        _directoryFilesKey == other._directoryFilesKey;
   }
 
   @override
@@ -199,6 +290,7 @@ class InferenceModelSpec extends ModelSpec {
       _replacePolicy,
       _modelType,
       _fileType,
+      _directoryFilesKey,
     );
   }
 }

--- a/packages/flutter_gemma/lib/core/model_management/types/inference_model_spec.dart
+++ b/packages/flutter_gemma/lib/core/model_management/types/inference_model_spec.dart
@@ -90,7 +90,11 @@ class DirectoryBundleFile extends ModelFile {
   final String _filename;
   final String _prefsKey;
 
-  DirectoryBundleFile({
+  // Private: every member MUST come through [DirectoryBundleFile.member] so the
+  // `<modelId>/<bareLeaf>` filename and the primary-vs-sibling prefsKey rule are
+  // never bypassed (a raw ctor could key a sibling on installedModelFileName —
+  // two files fighting for the persist-identity slot).
+  DirectoryBundleFile._({
     required ModelSource source,
     required String filename,
     required String prefsKey,
@@ -110,7 +114,7 @@ class DirectoryBundleFile extends ModelFile {
     required String bareName,
     required String primaryName,
     required ModelSource source,
-  }) => DirectoryBundleFile(
+  }) => DirectoryBundleFile._(
     source: source,
     filename: '$modelId/$bareName',
     prefsKey: bareName == primaryName
@@ -163,13 +167,27 @@ class InferenceModelSpec extends ModelSpec {
     required ModelType modelType,
     ModelFileType fileType = ModelFileType.task,
     List<DirectoryBundleFile>? directoryFiles,
-  }) : _name = name,
+  }) : assert(
+         directoryFiles == null || loraSource == null,
+         'directory (ORT-GenAI) models do not support LoRA',
+       ),
+       assert(
+         directoryFiles == null ||
+             directoryFiles.isEmpty ||
+             modelSource == directoryFiles.first.source,
+         'modelSource must be the primary (first) directory file source',
+       ),
+       _name = name,
        _modelSource = modelSource,
        _loraSource = loraSource,
        _replacePolicy = replacePolicy,
        _modelType = modelType,
        _fileType = fileType,
-       _directoryFiles = directoryFiles;
+       // Defensive copy: every other facet of this immutable spec is protected,
+       // so the bundle must not stay aliased to a list the caller can mutate.
+       _directoryFiles = directoryFiles == null
+           ? null
+           : List<DirectoryBundleFile>.unmodifiable(directoryFiles);
 
   /// Legacy compatibility constructor for String URLs
   factory InferenceModelSpec.fromLegacyUrl({

--- a/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
+++ b/packages/flutter_gemma/lib/core/model_management/utils/file_system_manager.dart
@@ -113,6 +113,14 @@ class ModelFileSystemManager {
 
     final orphaned = <OrphanedFileInfo>[];
 
+    // v1 limitation: non-recursive + extension-filtered. Directory (ORT-GenAI)
+    // models live under `<storage>/<modelId>/…` with `.onnx`/`.onnx_data`/config
+    // files that are NOT in [supportedExtensions], so this scan — and
+    // getStorageInfo / cleanupStorage, which share it — does NOT see them: it
+    // under-reports their (often multi-GB) size and cannot reclaim an orphaned
+    // ORT subdirectory. getStorageStats (repo-id based) IS directory-aware, so
+    // the two reporting APIs can disagree. A recursive scan is a follow-up; the
+    // direction is safe — a directory model is never wrongly deleted, only unseen.
     final files = directory
         .listSync()
         .whereType<File>()

--- a/packages/flutter_gemma/lib/core/registry/hugging_face_resolver.dart
+++ b/packages/flutter_gemma/lib/core/registry/hugging_face_resolver.dart
@@ -54,6 +54,31 @@ class ModelRuntimeDefaults {
   });
 }
 
+/// One file of a multi-file (directory) model resolved from a Hugging Face
+/// repo — e.g. an ORT-GenAI model is a DIRECTORY (`genai_config.json` +
+/// `model.onnx`[+`model.onnx_data`] + tokenizer files), not a single file.
+///
+/// [name] is the BARE leaf filename as it must appear inside the installed
+/// model directory (ORT-GenAI's `genai_config.json` references its siblings by
+/// bare name, and the native loader is handed the directory). It MUST be a
+/// single path segment — no path separators and no `.`/`..` — or the installer
+/// rejects it (a `../…` name would otherwise escape the model directory). [url]
+/// is the pinned download URL. [sha256]/[sizeBytes] are advisory (carried, not
+/// yet verified — see [ResolvedHfModel.sha256]).
+class ResolvedHfFile {
+  final String name;
+  final String url;
+  final String? sha256;
+  final int? sizeBytes;
+
+  const ResolvedHfFile({
+    required this.name,
+    required this.url,
+    this.sha256,
+    this.sizeBytes,
+  });
+}
+
 /// A model resolved from a Hugging Face repo's deployment metadata into
 /// flutter_gemma's install + runtime vocabulary.
 ///
@@ -98,6 +123,22 @@ class ResolvedHfModel {
   final String? sha256;
   final int? sizeBytes;
 
+  /// For a DIRECTORY model (ORT-GenAI): every file that must be installed into
+  /// the model's directory, each by its BARE leaf [ResolvedHfFile.name]. Null
+  /// for a single-file model (`.litertlm`, `.task`) — that path installs [url]
+  /// alone, unchanged. When non-null, [file]/[url] name the PRIMARY entry the
+  /// engine loads from (for ORT-GenAI: `genai_config.json`) and that entry must
+  /// also appear in this list.
+  final List<ResolvedHfFile>? files;
+
+  /// For a DIRECTORY model: the single filesystem-safe subdirectory name the
+  /// files install into. REQUIRED whenever [files] is non-null (the installer
+  /// throws without it) and MUST include the resolved execution-provider variant
+  /// (e.g. `microsoft__Phi-3.5-mini-instruct-onnx__cpu_and_mobile`) so two EP
+  /// variants of the same repo never share a directory — build it with
+  /// `FileNameUtils.sanitizeHfDirName(repo, variant: …)`. Null for single-file.
+  final String? directoryName;
+
   /// The overridable runtime defaults (see [ModelRuntimeDefaults]).
   final ModelRuntimeDefaults runtime;
 
@@ -112,6 +153,8 @@ class ResolvedHfModel {
     this.modelType,
     this.sha256,
     this.sizeBytes,
+    this.files,
+    this.directoryName,
     this.runtime = const ModelRuntimeDefaults(),
     this.notes = const [],
   });

--- a/packages/flutter_gemma/lib/core/registry/hugging_face_resolver.dart
+++ b/packages/flutter_gemma/lib/core/registry/hugging_face_resolver.dart
@@ -77,6 +77,17 @@ class ResolvedHfFile {
     this.sha256,
     this.sizeBytes,
   });
+
+  /// Whether [name] is a safe BARE leaf — a single path segment with no
+  /// separators and no `.`/`..`. The installer refuses a directory member whose
+  /// name is not (a `../…` name would escape the model directory). The rule
+  /// lives here so resolvers and the installer share one definition.
+  bool get isBareLeafName =>
+      name.isNotEmpty &&
+      name != '.' &&
+      name != '..' &&
+      !name.contains('/') &&
+      !name.contains(r'\');
 }
 
 /// A model resolved from a Hugging Face repo's deployment metadata into

--- a/packages/flutter_gemma/lib/core/utils/file_name_utils.dart
+++ b/packages/flutter_gemma/lib/core/utils/file_name_utils.dart
@@ -212,10 +212,25 @@ class FileNameUtils {
   /// single path segment safe on POSIX and Windows and free of the `/` that the
   /// restore path uses to split `modelId` from the bare leaf. Idempotent for an
   /// already-sanitized id.
+  ///
+  /// Throws [ArgumentError] if [repo]/[variant] sanitize to an empty or
+  /// dot-only name (`.`/`..`): `.` survives the charset filter, so a literal
+  /// `".."` repo would otherwise pass through verbatim and — interpolated as a
+  /// path segment — escape the model storage directory (a `deleteModel` on such
+  /// a spec would recursively delete its PARENT).
   static String sanitizeHfDirName(String repo, {String? variant}) {
     final raw = variant == null || variant.isEmpty ? repo : '$repo/$variant';
     final sanitized = raw.replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '__');
     // Trim any leading/trailing separators so the id is never empty-segmented.
-    return sanitized.replaceAll(RegExp(r'^_+|_+$'), '');
+    final result = sanitized.replaceAll(RegExp(r'^_+|_+$'), '');
+    if (result.isEmpty || result == '.' || result == '..') {
+      throw ArgumentError.value(
+        raw,
+        'repo/variant',
+        'sanitizes to "$result" — an empty or dot-only directory name that '
+            'would escape the model storage directory',
+      );
+    }
+    return result;
   }
 }

--- a/packages/flutter_gemma/lib/core/utils/file_name_utils.dart
+++ b/packages/flutter_gemma/lib/core/utils/file_name_utils.dart
@@ -194,4 +194,28 @@ class FileNameUtils {
     if (basename.startsWith(prefix)) return basename;
     return '$prefix$basename';
   }
+
+  /// A filesystem-safe directory name for a DIRECTORY model (ORT-GenAI)
+  /// installed from a Hugging Face repo. Unlike [namespaced] (which produces a
+  /// FLAT `modelId__basename` prefix), a directory model's files must keep their
+  /// BARE leaf names inside a real subdirectory — `genai_config.json` references
+  /// its siblings by bare name and the native loader is handed the directory.
+  ///
+  /// [repo] is the HF `org/name`; [variant] is the resolved execution-provider
+  /// subfolder when the resolver picked one (e.g. `cpu_and_mobile/cpu-int4-…`)
+  /// — it MUST be part of the id, or two EP variants of the same repo would
+  /// share one directory and `OgaCreateModel` could load a `genai_config.json`
+  /// from one against a `model.onnx` from the other.
+  ///
+  /// The `/` separators (repo owner, nested variant) and any other character
+  /// outside `[A-Za-z0-9._-]` collapse to the `__` separator, so the result is a
+  /// single path segment safe on POSIX and Windows and free of the `/` that the
+  /// restore path uses to split `modelId` from the bare leaf. Idempotent for an
+  /// already-sanitized id.
+  static String sanitizeHfDirName(String repo, {String? variant}) {
+    final raw = variant == null || variant.isEmpty ? repo : '$repo/$variant';
+    final sanitized = raw.replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '__');
+    // Trim any leading/trailing separators so the id is never empty-segmented.
+    return sanitized.replaceAll(RegExp(r'^_+|_+$'), '');
+  }
 }

--- a/packages/flutter_gemma/lib/core/utils/file_name_utils.dart
+++ b/packages/flutter_gemma/lib/core/utils/file_name_utils.dart
@@ -213,6 +213,15 @@ class FileNameUtils {
   /// restore path uses to split `modelId` from the bare leaf. Idempotent for an
   /// already-sanitized id.
   ///
+  /// **v1 limitation — not injective.** A literal `_` passes through while `/`
+  /// and other disallowed runs collapse to `__`, so two distinct
+  /// `(repo, variant)` inputs can map to the same id (e.g.
+  /// `sanitizeHfDirName('a/b__c')` and `sanitizeHfDirName('a/b', variant: 'c')`
+  /// both → `a__b__c`). Collision odds for real ORT-GenAI repo/variant names are
+  /// very low; if two colliding installs did occur, the second would silently
+  /// skip download (its members read as "already installed"). Reserving a
+  /// distinct join token is a follow-up if it ever bites.
+  ///
   /// Throws [ArgumentError] if [repo]/[variant] sanitize to an empty or
   /// dot-only name (`.`/`..`): `.` survives the charset filter, so a literal
   /// `".."` repo would otherwise pass through verbatim and — interpolated as a

--- a/packages/flutter_gemma/lib/flutter_gemma.dart
+++ b/packages/flutter_gemma/lib/flutter_gemma.dart
@@ -17,14 +17,15 @@ export 'core/services/vector_store_repository.dart'; // VectorStoreRepository + 
 export 'core/registry/skill_executor_provider.dart'; // SkillExecutorProvider contract
 export 'core/registry/skill_executor_registry.dart'; // SkillExecutorRegistry (fromModel reads it)
 // Hugging Face manifest-resolver seam. Only the app-facing value types are
-// re-exported — [ResolvedHfModel] / [ModelRuntimeDefaults] are the result of
-// FlutterGemma.resolveHuggingFace. The [HuggingFaceResolver] contract itself is
-// implemented by engine packages, which import it directly from
-// core/registry/hugging_face_resolver.dart — as they do the inference / embedding
-// / stt / tts *Provider contracts (those are not barrel-exported either;
-// skill_executor_provider above is the lone exception).
+// re-exported — [ResolvedHfModel] (plus its directory members [ResolvedHfFile])
+// and [ModelRuntimeDefaults] are the result of FlutterGemma.resolveHuggingFace.
+// The [HuggingFaceResolver] contract itself is implemented by engine packages,
+// which import it directly from core/registry/hugging_face_resolver.dart — as
+// they do the inference / embedding / stt / tts *Provider contracts (those are
+// not barrel-exported either; skill_executor_provider above is the lone
+// exception).
 export 'core/registry/hugging_face_resolver.dart'
-    show ResolvedHfModel, ModelRuntimeDefaults;
+    show ResolvedHfModel, ResolvedHfFile, ModelRuntimeDefaults;
 export 'core/domain/platform_types.dart'; // PreferredBackend + RAG value types
 export 'core/message.dart';
 export 'core/model.dart'; // Export ModelType and other model-related classes

--- a/packages/flutter_gemma/test/core/api/onnx_directory_install_test.dart
+++ b/packages/flutter_gemma/test/core/api/onnx_directory_install_test.dart
@@ -22,6 +22,8 @@ import 'package:flutter_gemma/core/model_management/model_specs.dart'
 import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
 import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
 import 'package:flutter_gemma/core/services/download_service.dart';
+import 'package:flutter_gemma/core/utils/file_name_utils.dart'
+    show FileNameUtils;
 import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_gemma/mobile/flutter_gemma_mobile.dart'
     show MobileModelManager;
@@ -215,6 +217,91 @@ void main() {
           fileType: ModelFileType.onnx,
         ).fromHuggingFace('org/repo').install(),
         throwsArgumentError,
+      );
+    });
+
+    test('a traversing directoryName ("..") is rejected before any download '
+        '(would let deleteModel escape the storage dir)', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          ModelFileType.onnx,
+          const ResolvedHfModel(
+            file: 'genai_config.json',
+            url:
+                'https://huggingface.co/org/repo/resolve/main/genai_config.json',
+            fileType: ModelFileType.onnx,
+            directoryName: '..', // traversal — must be refused
+            files: [
+              ResolvedHfFile(
+                name: 'genai_config.json',
+                url:
+                    'https://huggingface.co/org/repo/resolve/main/genai_config.json',
+              ),
+              ResolvedHfFile(
+                name: 'model.onnx',
+                url: 'https://huggingface.co/org/repo/resolve/main/model.onnx',
+              ),
+            ],
+          ),
+        ),
+      ]);
+      await expectLater(
+        FlutterGemma.installModel(
+          modelType: ModelType.general,
+          fileType: ModelFileType.onnx,
+        ).fromHuggingFace('org/repo').install(),
+        throwsArgumentError,
+      );
+      expect(download.requestedUrls, isEmpty);
+    });
+
+    test('a directory bundle with no .onnx weight is refused', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          ModelFileType.onnx,
+          const ResolvedHfModel(
+            file: 'genai_config.json',
+            url:
+                'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+            fileType: ModelFileType.onnx,
+            directoryName: 'org__repo__cpu',
+            files: [
+              ResolvedHfFile(
+                name: 'genai_config.json',
+                url:
+                    'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+              ),
+              ResolvedHfFile(
+                name: 'tokenizer.json',
+                url:
+                    'https://huggingface.co/org/repo/resolve/main/cpu/tokenizer.json',
+              ),
+            ],
+          ),
+        ),
+      ]);
+      await expectLater(
+        FlutterGemma.installModel(
+          modelType: ModelType.general,
+          fileType: ModelFileType.onnx,
+        ).fromHuggingFace('org/repo').install(),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('sanitizeHfDirName rejects a dot-only / empty result', () {
+      expect(() => FileNameUtils.sanitizeHfDirName('..'), throwsArgumentError);
+      expect(() => FileNameUtils.sanitizeHfDirName('.'), throwsArgumentError);
+      expect(() => FileNameUtils.sanitizeHfDirName('@@'), throwsArgumentError);
+      // A normal repo/variant sanitizes to a safe single segment.
+      expect(
+        FileNameUtils.sanitizeHfDirName(
+          'org/repo',
+          variant: 'cpu_and_mobile/x',
+        ),
+        'org__repo__cpu_and_mobile__x',
       );
     });
 

--- a/packages/flutter_gemma/test/core/api/onnx_directory_install_test.dart
+++ b/packages/flutter_gemma/test/core/api/onnx_directory_install_test.dart
@@ -1,0 +1,381 @@
+// Directory (ORT-GenAI) install: `installModel(fileType: onnx).fromHuggingFace(repo)`
+// with a resolver that returns a multi-file `ResolvedHfModel` installs every
+// file into a per-model subdirectory with its BARE leaf name, builds a directory
+// InferenceModelSpec whose primary is genai_config.json, restores that spec on a
+// cold relaunch, and cleans up the subdir on delete.
+//
+// Run: flutter test test/core/api/onnx_directory_install_test.dart
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_gemma/core/di/service_registry.dart';
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/model_management/model_specs.dart'
+    show DirectoryBundleFile, InferenceModelSpec;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_gemma/core/services/download_service.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/mobile/flutter_gemma_mobile.dart'
+    show MobileModelManager;
+
+const _modelId = 'org__repo__cpu';
+const _dirModel = ResolvedHfModel(
+  file: 'genai_config.json', // primary (bare leaf)
+  url: 'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+  fileType: ModelFileType.onnx,
+  modelType: ModelType.qwen3, // manifest declares the family
+  directoryName: _modelId,
+  files: [
+    ResolvedHfFile(
+      name: 'genai_config.json',
+      url: 'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+    ),
+    ResolvedHfFile(
+      name: 'model.onnx',
+      url: 'https://huggingface.co/org/repo/resolve/main/cpu/model.onnx',
+    ),
+    ResolvedHfFile(
+      name: 'tokenizer.json',
+      url: 'https://huggingface.co/org/repo/resolve/main/cpu/tokenizer.json',
+    ),
+  ],
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory fakeDocuments;
+  late Directory fakeAppSupport;
+  late _FixtureDownloadService download;
+
+  setUp(() async {
+    fakeDocuments = await Directory.systemTemp.createTemp('fg_onnx_docs_');
+    fakeAppSupport = await Directory.systemTemp.createTemp('fg_onnx_support_');
+    PathProviderPlatform.instance = _FixedPathProviderPlatform(
+      documentsPath: fakeDocuments.path,
+      appSupportPath: fakeAppSupport.path,
+    );
+    SharedPreferences.setMockInitialValues({});
+    ServiceRegistry.reset();
+    HuggingFaceResolverRegistry.instance.reset();
+    download = _FixtureDownloadService(
+      Uint8List.fromList(List.filled(2048, 7)),
+    );
+  });
+
+  tearDown(() async {
+    ServiceRegistry.reset();
+    HuggingFaceResolverRegistry.instance.reset();
+    for (final d in [fakeDocuments, fakeAppSupport]) {
+      if (await d.exists()) await d.delete(recursive: true);
+    }
+  });
+
+  Future<String> storageDir() =>
+      ServiceRegistry.instance.fileSystemService.getModelStorageDirectory();
+
+  test('installs every file into <modelId>/ with bare names; spec is a '
+      'directory model whose primary is genai_config.json', () async {
+    await ServiceRegistry.initialize(downloadService: download);
+    HuggingFaceResolverRegistry.instance.registerAll([
+      _ScriptedResolver(ModelFileType.onnx, _dirModel),
+    ]);
+
+    final install = await FlutterGemma.installModel(
+      modelType: ModelType.general, // manifest overrides → qwen3
+      fileType: ModelFileType.onnx,
+    ).fromHuggingFace('org/repo').install();
+
+    // Each file landed under <modelId>/ with its BARE leaf name.
+    final dir = await storageDir();
+    for (final name in ['genai_config.json', 'model.onnx', 'tokenizer.json']) {
+      expect(
+        File(p.join(dir, _modelId, name)).existsSync(),
+        isTrue,
+        reason: '$name must be inside the $_modelId subdir with its bare name',
+      );
+    }
+    // Downloaded from the resolver's pinned URLs, bare-named in the subdir.
+    expect(
+      download.requestedUrls,
+      containsAll(_dirModel.files!.map((f) => f.url)),
+    );
+
+    // The active spec is a directory model (3 files), family from the manifest.
+    final spec = install.spec;
+    expect(spec.directoryFiles, isNotNull);
+    expect(spec.directoryFiles!.length, 3);
+    expect(spec.modelType, ModelType.qwen3);
+    expect(spec.name, _modelId);
+
+    // getModelFilePaths.values.first (the engine's modelPath) resolves to
+    // genai_config.json INSIDE the subdir → File(modelPath).parent == the dir.
+    final manager =
+        FlutterGemmaPlugin.instance.modelManager as MobileModelManager;
+    final paths = await manager.getModelFilePaths(spec);
+    expect(paths, isNotNull);
+    final modelPath = paths!.values.first;
+    expect(p.basename(modelPath), 'genai_config.json');
+    expect(p.basename(File(modelPath).parent.path), _modelId);
+  });
+
+  test('the directory model restores on a cold relaunch (repository is the '
+      'source of truth, not a FileSource)', () async {
+    await ServiceRegistry.initialize(downloadService: download);
+    HuggingFaceResolverRegistry.instance.registerAll([
+      _ScriptedResolver(ModelFileType.onnx, _dirModel),
+    ]);
+    await FlutterGemma.installModel(
+      modelType: ModelType.general,
+      fileType: ModelFileType.onnx,
+    ).fromHuggingFace('org/repo').install();
+
+    // setActiveModel persists the active identity fire-and-forget
+    // (`unawaited`); let that SharedPreferences write flush before a cold
+    // relaunch reads it. (In production the app restarts long after; only a
+    // tight test races the two.)
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    // Cold relaunch: a fresh manager restores from persisted identity + repo.
+    final fresh = MobileModelManager();
+    await fresh.initialize();
+
+    expect(fresh.activeInferenceModel, isNotNull);
+    final restored = fresh.activeInferenceModel! as InferenceModelSpec;
+    expect(restored.directoryFiles, isNotNull);
+    expect(restored.directoryFiles!.length, 3);
+    expect(restored.name, _modelId);
+    expect(restored.modelType, ModelType.qwen3);
+    // The restored spec still resolves inside the subdir (no bare-leaf drift).
+    final paths = await fresh.getModelFilePaths(restored);
+    expect(paths, isNotNull);
+    expect(p.basename(paths!.values.first), 'genai_config.json');
+    expect(await fresh.isModelInstalled(restored), isTrue);
+  });
+
+  test('deleteModel removes the per-model subdirectory', () async {
+    await ServiceRegistry.initialize(downloadService: download);
+    HuggingFaceResolverRegistry.instance.registerAll([
+      _ScriptedResolver(ModelFileType.onnx, _dirModel),
+    ]);
+    final install = await FlutterGemma.installModel(
+      modelType: ModelType.general,
+      fileType: ModelFileType.onnx,
+    ).fromHuggingFace('org/repo').install();
+
+    final dir = await storageDir();
+    expect(Directory(p.join(dir, _modelId)).existsSync(), isTrue);
+
+    final manager =
+        FlutterGemmaPlugin.instance.modelManager as MobileModelManager;
+    await manager.deleteModel(install.spec);
+
+    expect(
+      Directory(p.join(dir, _modelId)).existsSync(),
+      isFalse,
+      reason: 'the emptied <modelId>/ subdir must be removed',
+    );
+  });
+
+  group('review fixes (codex)', () {
+    test('a directory model without directoryName is rejected (no repo-only '
+        'fallback that would collide EP variants)', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          ModelFileType.onnx,
+          const ResolvedHfModel(
+            file: 'genai_config.json',
+            url:
+                'https://huggingface.co/org/repo/resolve/main/genai_config.json',
+            fileType: ModelFileType.onnx,
+            // directoryName omitted → must throw, not fall back to repo-only.
+            files: [
+              ResolvedHfFile(
+                name: 'genai_config.json',
+                url:
+                    'https://huggingface.co/org/repo/resolve/main/genai_config.json',
+              ),
+            ],
+          ),
+        ),
+      ]);
+
+      await expectLater(
+        FlutterGemma.installModel(
+          modelType: ModelType.general,
+          fileType: ModelFileType.onnx,
+        ).fromHuggingFace('org/repo').install(),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+      'LoRA + a directory model is rejected (not silently dropped)',
+      () async {
+        await ServiceRegistry.initialize(downloadService: download);
+        HuggingFaceResolverRegistry.instance.registerAll([
+          _ScriptedResolver(ModelFileType.onnx, _dirModel),
+        ]);
+
+        await expectLater(
+          FlutterGemma.installModel(
+                modelType: ModelType.general,
+                fileType: ModelFileType.onnx,
+              )
+              .fromHuggingFace('org/repo')
+              .withLoraFromNetwork('https://example.com/adapter.bin')
+              .install(),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test('a file name with a path-traversal segment is rejected before any '
+        'download', () async {
+      await ServiceRegistry.initialize(downloadService: download);
+      HuggingFaceResolverRegistry.instance.registerAll([
+        _ScriptedResolver(
+          ModelFileType.onnx,
+          const ResolvedHfModel(
+            file: 'genai_config.json',
+            url:
+                'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+            fileType: ModelFileType.onnx,
+            directoryName: 'org__repo__cpu',
+            files: [
+              ResolvedHfFile(
+                name: 'genai_config.json',
+                url:
+                    'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+              ),
+              ResolvedHfFile(
+                name: '../victim.onnx', // escapes the model directory
+                url:
+                    'https://huggingface.co/org/repo/resolve/main/cpu/model.onnx',
+              ),
+            ],
+          ),
+        ),
+      ]);
+
+      await expectLater(
+        FlutterGemma.installModel(
+          modelType: ModelType.general,
+          fileType: ModelFileType.onnx,
+        ).fromHuggingFace('org/repo').install(),
+        throwsArgumentError,
+      );
+      expect(download.requestedUrls, isEmpty);
+    });
+
+    test('two directory specs with different members are not equal', () {
+      InferenceModelSpec dir(List<String> leaves) => InferenceModelSpec(
+        name: 'm',
+        modelSource: ModelSource.network(
+          'https://huggingface.co/o/r/resolve/main/m/genai_config.json',
+        ),
+        modelType: ModelType.general,
+        fileType: ModelFileType.onnx,
+        directoryFiles: [
+          for (final leaf in leaves)
+            DirectoryBundleFile.member(
+              modelId: 'm',
+              bareName: leaf,
+              primaryName: 'genai_config.json',
+              source: ModelSource.network(
+                'https://huggingface.co/o/r/resolve/main/m/$leaf',
+              ),
+            ),
+        ],
+      );
+      final a = dir(['genai_config.json', 'model.onnx']);
+      final b = dir(['genai_config.json', 'model.onnx', 'tokenizer.json']);
+      expect(a == b, isFalse);
+      expect(a.hashCode == b.hashCode, isFalse);
+      expect(a == dir(['genai_config.json', 'model.onnx']), isTrue);
+    });
+  });
+}
+
+class _ScriptedResolver implements HuggingFaceResolver {
+  _ScriptedResolver(this.forFileType, this.result);
+  final ModelFileType forFileType;
+  final ResolvedHfModel result;
+  @override
+  String get name => 'scripted-dir';
+  @override
+  int get priority => 0;
+  @override
+  bool canResolve(String repo, {ModelFileType? fileType}) =>
+      fileType == forFileType;
+  @override
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? token,
+    String? platform,
+    PreferredBackend? preferredBackend,
+  }) async => result;
+}
+
+class _FixedPathProviderPlatform extends PathProviderPlatform {
+  _FixedPathProviderPlatform({
+    required this.documentsPath,
+    required this.appSupportPath,
+  });
+  final String documentsPath;
+  final String appSupportPath;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+  @override
+  Future<String?> getApplicationSupportPath() async => appSupportPath;
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+/// Writes [bytes] to the requested target path, creating parent dirs (a
+/// directory install targets `<storage>/<modelId>/<file>`). Records URLs.
+class _FixtureDownloadService implements DownloadService {
+  _FixtureDownloadService(this.bytes);
+  final Uint8List bytes;
+  final List<String> requestedUrls = [];
+
+  Future<void> _write(String targetPath) async {
+    final f = File(targetPath);
+    if (!await f.parent.exists()) await f.parent.create(recursive: true);
+    await f.writeAsBytes(bytes);
+  }
+
+  @override
+  Future<void> download(
+    String url,
+    String targetPath, {
+    String? token,
+    CancelToken? cancelToken,
+  }) async {
+    requestedUrls.add(url);
+    await _write(targetPath);
+  }
+
+  @override
+  Stream<int> downloadWithProgress(
+    String url,
+    String targetPath, {
+    String? token,
+    int maxRetries = 10,
+    CancelToken? cancelToken,
+    bool? foreground,
+  }) async* {
+    requestedUrls.add(url);
+    await _write(targetPath);
+    yield 100;
+  }
+}

--- a/packages/flutter_gemma/test/core/api/onnx_directory_install_test.dart
+++ b/packages/flutter_gemma/test/core/api/onnx_directory_install_test.dart
@@ -390,6 +390,23 @@ void main() {
       expect(a.hashCode == b.hashCode, isFalse);
       expect(a == dir(['genai_config.json', 'model.onnx']), isTrue);
     });
+
+    test('an empty directory bundle is rejected by InferenceModelSpec — a '
+        'release guard, not a debug-only assert (else files.first throws far '
+        'downstream)', () {
+      expect(
+        () => InferenceModelSpec(
+          name: 'm',
+          modelSource: ModelSource.network(
+            'https://huggingface.co/o/r/resolve/main/m/genai_config.json',
+          ),
+          modelType: ModelType.general,
+          fileType: ModelFileType.onnx,
+          directoryFiles: const [],
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 }
 

--- a/packages/flutter_gemma_onnx/CHANGELOG.md
+++ b/packages/flutter_gemma_onnx/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.3.2
-- Add `OnnxHuggingFaceResolver` (auto-registered from `OnnxEngine`) so `resolveHuggingFace` gives an ONNX-specific answer; directory-based genai_config install is a follow-up (#454).
+- `OnnxHuggingFaceResolver` installs an ORT-GenAI model directory from a Hugging Face repo — lists the repo, picks a CPU execution-provider folder, downloads the whole bundle (#454).
 
 ## 0.3.1
 - Fix a rebuilt native library not reaching the build.

--- a/packages/flutter_gemma_onnx/README.md
+++ b/packages/flutter_gemma_onnx/README.md
@@ -101,8 +101,9 @@ final install = await FlutterGemma.installModel(
 
 A repo that ships several EP variants (`cpu_and_mobile/…`, `cuda/…`) resolves
 to a **CPU/mobile** folder automatically — the bundled ORT-GenAI runtime is
-CPU-only, so a GPU export it can't load is never auto-picked, and `install.notes`
-records which folder was chosen. Pin a specific folder with
+CPU-only, so a CPU/mobile folder is preferred over any GPU export. (A repo that
+ships *only* GPU variants still falls back to its GPU folder — flagged in
+`install.notes`, which records the chosen folder either way.) Pin a specific folder with
 `OnnxHuggingFaceResolver(variant: 'cpu_and_mobile/cpu-int4-…')` passed to
 `initialize(huggingFaceResolvers: [...])`; a pinned GPU variant is installed but
 flagged in `notes` as one the CPU-only runtime may fail to load.

--- a/packages/flutter_gemma_onnx/README.md
+++ b/packages/flutter_gemma_onnx/README.md
@@ -79,15 +79,47 @@ my-model/
 └── tokenizer files (tokenizer.json, tokenizer_config.json, …)
 ```
 
-`FlutterGemma.installModel()` currently downloads and tracks exactly one
-file per spec. `OnnxEngine.createModel` takes that tracked file's **parent
-directory** as the model directory, so v1 only works when the whole bundle
-already lives alongside it on disk (e.g. a directory you ship as an asset or
-pre-populate yourself) — not yet a real multi-file network install. Pointing
-`modelPath` at a directory missing `genai_config.json` fails loudly with a
-`StateError` naming the gap, rather than a confusing native error. Wiring a
-real multi-file bundle install (mirroring the TTS package's `artifactPaths`
-pattern) is a known follow-on.
+`OnnxEngine.createModel` takes that directory's `genai_config.json` and loads
+the **parent directory** as the model. There are two ways to get the directory
+onto the device.
+
+**From a Hugging Face repo (one call).** `OnnxHuggingFaceResolver` lists the
+repo's file tree, picks an execution-provider folder, and installs every file
+in it into a per-model subdirectory — so `fromHuggingFace(repo)` downloads the
+whole ORT-GenAI bundle. The resolver rides on `OnnxEngine` via
+`HuggingFaceResolverSource`, so registering the engine is enough:
+
+```dart
+await FlutterGemma.initialize(inferenceEngines: [OnnxEngine()]);
+
+final install = await FlutterGemma.installModel(
+  // ONNX repos declare no model family — the caller's modelType is used as-is.
+  modelType: ModelType.general,
+  fileType: ModelFileType.onnx, // selects the ONNX resolver
+).fromHuggingFace('microsoft/Phi-3.5-mini-instruct-onnx').install();
+```
+
+A repo that ships several EP variants (`cpu_and_mobile/…`, `cuda/…`) resolves
+to a **CPU/mobile** folder automatically — the bundled ORT-GenAI runtime is
+CPU-only, so a GPU export it can't load is never auto-picked, and `install.notes`
+records which folder was chosen. Pin a specific folder with
+`OnnxHuggingFaceResolver(variant: 'cpu_and_mobile/cpu-int4-…')` passed to
+`initialize(huggingFaceResolvers: [...])`; a pinned GPU variant is installed but
+flagged in `notes` as one the CPU-only runtime may fail to load.
+
+**From a local directory.** If you ship the bundle yourself (an asset, or a
+directory you pre-populate), point `fromFile` at its `genai_config.json`:
+
+```dart
+await FlutterGemma.installModel(
+  modelType: ModelType.general,
+  fileType: ModelFileType.onnx,
+).fromFile('/path/to/my-model/genai_config.json').install();
+```
+
+Either way, pointing `modelPath` at a directory missing `genai_config.json`
+fails loudly with a `StateError` naming the gap, rather than a confusing native
+error.
 
 ### `ORT_LIB_PATH` — you don't need to configure anything
 

--- a/packages/flutter_gemma_onnx/lib/flutter_gemma_onnx.dart
+++ b/packages/flutter_gemma_onnx/lib/flutter_gemma_onnx.dart
@@ -61,7 +61,10 @@ export 'src/web/onnx_embedding_backend_web.dart'
 export 'src/native_exports_stub.dart'
     if (dart.library.ffi) 'src/native_exports.dart';
 
-// The Hugging Face resolver (pure Dart, web-safe) — reserves the
-// `ModelFileType.onnx` slot so `resolveHuggingFace(...)` gives a clear
-// ONNX-specific error instead of core's generic "no resolver registered".
+// The Hugging Face resolver (pure Dart, web-safe) — owns the
+// `ModelFileType.onnx` slot so `fromHuggingFace(repo)` installs an ORT-GenAI
+// directory (native) or a fileless repo-id model (web). `HfFetch` /
+// `HfFetchException` are its injectable HTTP seam (test/app fakes), mirroring
+// litertlm's exported `ManifestFetch` / `ManifestFetchException`.
 export 'src/onnx_hugging_face_resolver.dart' show OnnxHuggingFaceResolver;
+export 'src/hf/hf_fetch_types.dart' show HfFetch, HfFetchException;

--- a/packages/flutter_gemma_onnx/lib/src/hf/hf_fetch_io.dart
+++ b/packages/flutter_gemma_onnx/lib/src/hf/hf_fetch_io.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'hf_fetch_types.dart';
+
+/// Default Hugging Face GET on `dart:io` platforms.
+///
+/// A plain [HttpClient] — deliberately not the plugin's model-download stack
+/// (background_downloader is sized for multi-GB files, not a few KB of JSON).
+/// [HttpClient] follows redirects for GET by default, which matters here:
+/// Hugging Face answers `/resolve/` paths with a 307 to its CDN.
+Future<String> defaultHfFetch(Uri url, Map<String, String> headers) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(url);
+    headers.forEach(request.headers.set);
+    final response = await request.close();
+    final status = response.statusCode;
+    // Status before body: an error page's bytes are not the signal, and one
+    // that fails to decode must not turn a 404 into a status-less failure.
+    if (status < 200 || status >= 300) {
+      try {
+        await response.drain<void>();
+      } catch (_) {
+        // A body that cannot even be read changes nothing: status is the answer.
+      }
+      throw HfFetchException(
+        url,
+        'GET failed with HTTP $status',
+        statusCode: status,
+      );
+    }
+    return await response
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
+  } on HfFetchException {
+    rethrow;
+  } on Exception catch (e) {
+    throw HfFetchException(url, 'GET failed: $e');
+  } finally {
+    client.close();
+  }
+}

--- a/packages/flutter_gemma_onnx/lib/src/hf/hf_fetch_types.dart
+++ b/packages/flutter_gemma_onnx/lib/src/hf/hf_fetch_types.dart
@@ -1,0 +1,25 @@
+/// A GET returning the response body as text. [OnnxHuggingFaceResolver] accepts
+/// one so tests (and apps with their own HTTP stack, proxies, or timeout
+/// policy) can replace the default; the defaults live in `hf_fetch_io.dart` /
+/// `hf_fetch_web.dart`.
+///
+/// Contract: follow redirects (Hugging Face answers `/resolve/` paths with a
+/// 307 to its CDN), send [headers] verbatim, return the body on any 2xx, and
+/// throw [HfFetchException] carrying the status on any other status — check the
+/// status before touching the body, so an unreadable error page never loses it.
+typedef HfFetch = Future<String> Function(Uri url, Map<String, String> headers);
+
+/// A Hugging Face GET that failed — carries the status so the resolver can tell
+/// "repo/path does not exist" (404) apart from auth/network trouble.
+class HfFetchException implements Exception {
+  final Uri url;
+  final int? statusCode;
+  final String message;
+
+  const HfFetchException(this.url, this.message, {this.statusCode});
+
+  @override
+  String toString() =>
+      'HfFetchException'
+      '${statusCode != null ? " (HTTP $statusCode)" : ""}: $message [$url]';
+}

--- a/packages/flutter_gemma_onnx/lib/src/hf/hf_fetch_web.dart
+++ b/packages/flutter_gemma_onnx/lib/src/hf/hf_fetch_web.dart
@@ -1,0 +1,45 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'hf_fetch_types.dart';
+
+/// Default Hugging Face GET on web: the browser's `fetch`. The browser follows
+/// the Hugging Face `/resolve/` 307 itself; `huggingface.co` serves CORS headers
+/// on these endpoints (the web model-download path relies on that already).
+Future<String> defaultHfFetch(Uri url, Map<String, String> headers) async {
+  final options = JSObject();
+  if (headers.isNotEmpty) {
+    final jsHeaders = JSObject();
+    headers.forEach((k, v) => jsHeaders.setProperty(k.toJS, v.toJS));
+    options.setProperty('headers'.toJS, jsHeaders);
+  }
+  _Response response;
+  try {
+    response =
+        (await _fetchJs(url.toString().toJS, options).toDart) as _Response;
+  } catch (e) {
+    throw HfFetchException(url, 'GET failed: $e');
+  }
+  final status = response.status.toDartInt;
+  if (!response.ok.toDart) {
+    throw HfFetchException(
+      url,
+      'GET failed with HTTP $status',
+      statusCode: status,
+    );
+  }
+  try {
+    return (await response.text().toDart).toDart;
+  } catch (e) {
+    throw HfFetchException(url, 'reading response body failed: $e');
+  }
+}
+
+@JS('fetch')
+external JSPromise<JSAny> _fetchJs(JSString url, JSAny options);
+
+extension type _Response(JSObject _) implements JSObject {
+  external JSBoolean get ok;
+  external JSNumber get status;
+  external JSPromise<JSString> text();
+}

--- a/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
@@ -137,31 +137,29 @@ class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
       );
     }
 
-    // The install layer hands inference engines a single resolved FILE path
-    // per `InferenceModelSpec` (`RuntimeConfig.modelPath` —
+    // The install layer hands inference engines a single resolved FILE path per
+    // `InferenceModelSpec` (`RuntimeConfig.modelPath` =
     // `manager.getModelFilePaths(...).values.first`, see
-    // `flutter_gemma_mobile.dart`'s createModel preamble). ORT-GenAI models
-    // are whole DIRECTORIES (`genai_config.json` + `.onnx`[+`.onnx_data`] +
-    // tokenizer files); v1 takes that file's PARENT directory as the model
-    // dir. This assumes the whole bundle already lives alongside the one
-    // tracked file on disk — true for the macOS host smoke (which points
-    // `ONNX_SMOKE_GENAI_MODEL_DIR` straight at a pre-populated directory) but
-    // NOT yet true for a real network install, which only downloads that one
-    // tracked file. Multi-file bundle install (mirroring the TTS
-    // `artifactPaths` pattern) is a known gap, left for the device-gated
-    // follow-on — this precheck turns it into a clear, loud error instead of
-    // a confusing native failure.
+    // `flutter_gemma_mobile.dart`'s createModel preamble). ORT-GenAI models are
+    // whole DIRECTORIES (`genai_config.json` + `.onnx`[+`.onnx_data`] +
+    // tokenizer files). The directory install
+    // (`installModel(fileType: onnx).fromHuggingFace(repo)`, wired via
+    // `OnnxHuggingFaceResolver` + core's directory-install path) downloads every
+    // file into a per-model subdirectory and makes the primary
+    // `genai_config.json` the spec's FIRST file — so `modelPath` resolves to
+    // `<dir>/genai_config.json` and its PARENT is exactly the model directory
+    // ORT-GenAI needs. The precheck below stays as a loud guard for a modelPath
+    // whose parent is not a complete ORT-GenAI directory (a directory pointed at
+    // directly, or a partial/incomplete install).
     final modelDir = File(config.modelPath).parent.path;
     final configFile = File('$modelDir/genai_config.json');
     if (!configFile.existsSync()) {
       throw StateError(
         'ONNX GenAI model directory "$modelDir" has no genai_config.json — '
         'expected an ORT-GenAI model directory '
-        '(genai_config.json + .onnx[+.onnx_data] + tokenizer files) '
-        'installed as a single bundle. Multi-file bundle install is not '
-        'yet wired through FlutterGemma.installModel() for ModelFileType.onnx '
-        '(hardened plan Phase 3 Task 2 known gap) — point modelPath at a '
-        'pre-populated directory for now.',
+        '(genai_config.json + .onnx[+.onnx_data] + tokenizer files). Install '
+        'one with installModel(fileType: ModelFileType.onnx).fromHuggingFace('
+        'repo), or point modelPath at a pre-populated ORT-GenAI directory.',
       );
     }
 

--- a/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_engine.dart
@@ -57,12 +57,13 @@ class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
   @override
   int get priority => 0;
 
-  /// The engine's own Hugging Face resolver. Auto-registered by
-  /// `FlutterGemma.initialize(inferenceEngines: …)` so it reserves the `.onnx`
-  /// slot: `resolveHuggingFace(fileType: onnx)` (and the one-call
-  /// `fromHuggingFace`) throws a clear `UnimplementedError` ("not implemented
-  /// yet") instead of core's generic "no resolver registered". Directory-based
-  /// `genai_config.json` resolution is a follow-up.
+  /// The engine's own Hugging Face resolver ([OnnxHuggingFaceResolver]).
+  /// Auto-registered by `FlutterGemma.initialize(inferenceEngines: …)` so it
+  /// owns the `.onnx` slot: `resolveHuggingFace(fileType: onnx)` and the
+  /// one-call `fromHuggingFace(repo)` list the repo's file tree, pick an
+  /// execution-provider folder, and install the whole ORT-GenAI directory
+  /// (`genai_config.json` + `.onnx`[+`.onnx_data`] + tokenizer). On web the
+  /// resolver returns a fileless repo-id model (Transformers.js).
   @override
   HuggingFaceResolver get huggingFaceResolver =>
       const OnnxHuggingFaceResolver();

--- a/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
@@ -27,11 +27,12 @@ import 'hf/hf_fetch_web.dart' if (dart.library.io) 'hf/hf_fetch_io.dart';
 /// handles it, no filesystem needed.
 ///
 /// EP selection: pass [variant] (the exact folder, e.g.
-/// `cpu_and_mobile/cpu-int4-…`) to pin one; otherwise it is chosen from
-/// `preferredBackend` — a GPU folder (`cuda`/`dml`/`coreml`) when GPU is
-/// requested and present, else a CPU/mobile folder, else the sole variant.
-/// **v1 note:** GPU-EP *selection* is wired, but on-device GPU execution is not
-/// bundled yet — the model still runs on CPU.
+/// `cpu_and_mobile/cpu-int4-…`) to pin one; otherwise the resolver auto-picks a
+/// CPU/mobile folder, falling back to the sole/first variant when none looks
+/// CPU. The bundled ORT-GenAI runtime is CPU-only, so GPU execution-provider
+/// folders are NOT auto-selected and `preferredBackend` is ignored. Pinning a
+/// GPU [variant] is allowed but flagged in the result notes — it will likely
+/// fail to load until a GPU runtime is bundled.
 ///
 /// Auto-registered from `OnnxEngine` (which implements
 /// `HuggingFaceResolverSource`), so registering the engine is enough; pass an
@@ -138,11 +139,24 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
         'OnnxHuggingFaceResolver(variant: …).',
       );
     }
-    final filePaths = <String>[
-      for (final e in decoded)
-        if (e is Map && e['type'] == 'file' && e['path'] is String)
-          e['path'] as String,
-    ];
+    // Keep file entries, skip directories. A `type == 'file'` entry whose
+    // `path` is missing/non-string is a MALFORMED listing, not a directory —
+    // surface it loudly rather than silently dropping what might be a required
+    // model file (a silent drop installs an incomplete directory that only
+    // fails later inside OgaCreateModel).
+    final filePaths = <String>[];
+    for (final e in decoded) {
+      if (e is! Map || e['type'] != 'file') continue;
+      final path = e['path'];
+      if (path is! String) {
+        throw StateError(
+          'Malformed Hugging Face tree entry for "$repo": a file entry has no '
+          'string "path" ($e). The listing is corrupt; refusing to install a '
+          'possibly incomplete model directory.',
+        );
+      }
+      filePaths.add(path);
+    }
 
     // Folders that contain a genai_config.json — the ORT-GenAI signal. '' means
     // the repo root. Sorted so the tie-break in [_pickFolder] is deterministic
@@ -174,9 +188,13 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
           p,
     ]..sort();
 
-    // A genai_config.json alone is not a loadable model — require the weights.
-    // Without this an incomplete export (config + tokenizer, no `.onnx`) would
-    // install "successfully" and only fail later inside OgaCreateModel.
+    // A genai_config.json alone is not a loadable model — require a `.onnx`
+    // graph. This checks the graph file is PRESENT; it does NOT parse
+    // genai_config to verify every weight it references (external `.onnx_data`,
+    // tokenizer aux) is in the folder, so a mis-export can still fail inside
+    // OgaCreateModel. It catches the common incomplete case: config + tokenizer,
+    // no `.onnx` at all. (`.onnx_data` ends in `.onnx_data`, not `.onnx`, so an
+    // external-data blob without its graph does not satisfy this.)
     if (!members.any((p) => p.endsWith('.onnx'))) {
       throw StateError(
         'The ORT-GenAI directory '
@@ -196,14 +214,20 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
         ResolvedHfFile(name: p.substring(prefix.length), url: urlFor(p)),
     ];
 
+    // Base the EP note on the folder actually PICKED, not merely on whether a
+    // variant was pinned: `_pickFolder`'s fallback (a repo with no CPU/mobile
+    // folder) and an explicit GPU `variant:` both land on a non-CPU folder while
+    // `_variant == null`/`!= null` says nothing about it. Warn only when the
+    // pick looks GPU (the bundled runtime is CPU-only → it will likely not
+    // load); a CPU/mobile, root, or unlabeled export runs on CPU as expected.
     final notes = <String>[
       'Resolved ORT-GenAI directory '
           '"${folder.isEmpty ? "(repo root)" : folder}" (${files.length} files).',
-      // v1: the bundled ORT-GenAI runtime is CPU-only, and the automatic EP pick
-      // always chooses a CPU/mobile variant. Surface that on every auto-install
-      // so a GPU-hoping caller is not silently handed CPU. Pin a GPU folder with
-      // OnnxHuggingFaceResolver(variant: …) if you have a GPU runtime.
-      if (_variant == null)
+      if (_looksGpu(folder))
+        'Selected the GPU execution-provider variant "$folder", but the bundled '
+            'ORT-GenAI runtime is CPU-only — it may fail to load. Pin a '
+            'CPU/mobile variant with OnnxHuggingFaceResolver(variant: …).'
+      else
         'Installed the CPU execution-provider variant; on-device GPU execution '
             'is not bundled yet.',
     ];
@@ -224,8 +248,9 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
   }
 
   /// Picks the EP folder among [folders] (each a path that holds a
-  /// genai_config.json). An explicit [variant] wins; otherwise a GPU folder for
-  /// a GPU request, else a CPU/mobile folder, else the sole/first variant.
+  /// genai_config.json). An explicit [variant] wins; otherwise a CPU/mobile
+  /// folder is preferred (the bundled runtime is CPU-only), falling back to the
+  /// sole/first variant when none looks CPU.
   String _pickFolder(List<String> folders, {required String repo}) {
     if (_variant != null) {
       if (!folders.contains(_variant)) {
@@ -250,4 +275,13 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
 
   static final _cpuRe = RegExp(r'cpu|mobile', caseSensitive: false);
   static bool _looksCpu(String folder) => _cpuRe.hasMatch(folder);
+
+  // GPU/NPU execution-provider folder labels the bundled CPU-only runtime
+  // cannot load. Used only to phrase the result note honestly — NOT for
+  // selection (auto-pick never chooses these; only an explicit `variant:` does).
+  static final _gpuRe = RegExp(
+    r'cuda|dml|directml|tensorrt|rocm|coreml|webgpu|gpu|npu|qnn',
+    caseSensitive: false,
+  );
+  static bool _looksGpu(String folder) => _gpuRe.hasMatch(folder);
 }

--- a/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
@@ -1,28 +1,58 @@
+import 'dart:convert';
+
 import 'package:flutter_gemma/core/domain/platform_types.dart'
     show PreferredBackend;
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
 import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart'
-    show HuggingFaceResolver, ResolvedHfModel;
+    show HuggingFaceResolver, ResolvedHfFile, ResolvedHfModel;
+import 'package:flutter_gemma/core/utils/file_name_utils.dart'
+    show FileNameUtils;
 
-/// [HuggingFaceResolver] for ONNX models.
+import 'hf/hf_fetch_types.dart';
+import 'hf/hf_fetch_web.dart' if (dart.library.io) 'hf/hf_fetch_io.dart';
+
+/// [HuggingFaceResolver] for ONNX (ORT-GenAI) models.
 ///
-/// It claims the `ModelFileType.onnx` slot in the resolver registry so that
-/// `FlutterGemma.resolveHuggingFace(repo, fileType: ModelFileType.onnx)`
-/// answers with a clear, ONNX-specific error instead of core's generic
-/// "no resolver registered" `StateError` — the "works everywhere" contract
-/// [FlutterGemma.resolveHuggingFace] promises.
+/// An ORT-GenAI model is a DIRECTORY — `genai_config.json` + `model.onnx`
+/// (+ `model.onnx_data` for external weights) + tokenizer files — and a repo
+/// usually ships several execution-provider (EP) variants, one per subfolder
+/// (`cpu_and_mobile/…`, `cuda/…`, …). On NATIVE this resolver lists the repo
+/// via the Hugging Face tree API, picks one EP folder, and returns every file
+/// in it as a directory [ResolvedHfModel] (`files` + `directoryName`) — core's
+/// directory-install path then downloads them into a per-model subdirectory.
 ///
-/// [resolve] currently throws [UnimplementedError]: ORT-GenAI models install
-/// as a DIRECTORY (`genai_config.json` + `.onnx`[+ `.onnx_data`] + tokenizer),
-/// which the single-file network-install path does not cover yet. A
-/// `genai_config.json`-driven directory resolver is the follow-up; until then
-/// install an ONNX model from a local directory.
+/// On WEB, ONNX generation is fileless (Transformers.js owns the repo id and
+/// caches it itself), so this returns a single-file/`files == null` model whose
+/// `NetworkSource` URL maps to the repo id — the existing web install path
+/// handles it, no filesystem needed.
+///
+/// EP selection: pass [variant] (the exact folder, e.g.
+/// `cpu_and_mobile/cpu-int4-…`) to pin one; otherwise it is chosen from
+/// `preferredBackend` — a GPU folder (`cuda`/`dml`/`coreml`) when GPU is
+/// requested and present, else a CPU/mobile folder, else the sole variant.
+/// **v1 note:** GPU-EP *selection* is wired, but on-device GPU execution is not
+/// bundled yet — the model still runs on CPU.
 ///
 /// Auto-registered from `OnnxEngine` (which implements
-/// `HuggingFaceResolverSource`), so registering the engine is enough; pass it in
+/// `HuggingFaceResolverSource`), so registering the engine is enough; pass an
+/// explicit `OnnxHuggingFaceResolver(variant: …)` to
 /// `FlutterGemma.initialize(huggingFaceResolvers: [...])` only to override.
 class OnnxHuggingFaceResolver implements HuggingFaceResolver {
-  const OnnxHuggingFaceResolver();
+  /// [variant] pins an exact EP subfolder (skips the backend heuristic).
+  /// [revision] is the repo revision to pin (default `main`). [fetch] is a
+  /// test/app seam for the HTTP GET; null uses the platform default (`dart:io`
+  /// [HttpClient] natively, the browser's `fetch` on web).
+  const OnnxHuggingFaceResolver({
+    String? variant,
+    String revision = 'main',
+    HfFetch? fetch,
+  }) : _variant = variant,
+       _revision = revision,
+       _fetch = fetch;
+
+  final String? _variant;
+  final String _revision;
+  final HfFetch? _fetch;
 
   @override
   String get name => 'onnx-huggingface';
@@ -41,11 +71,150 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
     String? platform,
     PreferredBackend? preferredBackend,
   }) async {
-    throw UnimplementedError(
-      'Resolving an ONNX model from a Hugging Face repo is not implemented yet '
-      '("$repo"). ORT-GenAI models install as a directory (genai_config.json + '
-      '.onnx [+ .onnx_data] + tokenizer); manifest-driven HF resolution is a '
-      'follow-up. For now install an ONNX model from a local directory.',
+    if (repo.trim().isEmpty) {
+      throw ArgumentError.value(repo, 'repo', 'must be a non-empty "org/name"');
+    }
+
+    // WEB: ONNX generation is fileless (Transformers.js resolves + caches the
+    // repo from its id). Return a files==null model whose NetworkSource URL maps
+    // to the repo id (see transformers_repo_id.dart); the web install path uses
+    // it directly, and no directory download is attempted (there is no FS).
+    if (platform == 'web') {
+      return ResolvedHfModel(
+        file: repo.split('/').last,
+        url: 'https://huggingface.co/$repo',
+        fileType: ModelFileType.onnx,
+      );
+    }
+
+    final fetch = _fetch ?? defaultHfFetch;
+    final headers = <String, String>{
+      if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+    };
+
+    // List the repo's file tree (recursive; one page is enough for the handful
+    // of files an ORT-GenAI model ships — limit guards a many-variant repo).
+    final treeUrl = Uri.parse(
+      'https://huggingface.co/api/models/$repo/tree/$_revision'
+      '?recursive=true&limit=1000',
+    );
+    final String body;
+    try {
+      body = await fetch(treeUrl, headers);
+    } on HfFetchException catch (e) {
+      if (e.statusCode == 404) {
+        throw StateError(
+          'Hugging Face repo "$repo" (revision "$_revision") was not found, or '
+          'its file tree is not accessible${token == null ? " — a gated repo "
+                    "needs a token" : ""}.',
+        );
+      }
+      rethrow;
+    }
+
+    final filePaths = <String>[
+      for (final e in (jsonDecode(body) as List).cast<Map<String, dynamic>>())
+        if (e['type'] == 'file') e['path'] as String,
+    ];
+
+    // Folders that contain a genai_config.json — the ORT-GenAI signal. '' means
+    // the repo root.
+    const marker = 'genai_config.json';
+    final configFolders = <String>[
+      for (final p in filePaths)
+        if (p == marker)
+          ''
+        else if (p.endsWith('/$marker'))
+          p.substring(0, p.length - marker.length - 1),
+    ];
+    if (configFolders.isEmpty) {
+      throw StateError(
+        'Hugging Face repo "$repo" has no genai_config.json — it is not an '
+        'ORT-GenAI model directory. Install a repo that ships an ORT-GenAI '
+        'export (genai_config.json + model.onnx + tokenizer).',
+      );
+    }
+
+    final folder = _pickFolder(
+      configFolders,
+      preferredBackend: preferredBackend,
+      repo: repo,
+    );
+    final prefix = folder.isEmpty ? '' : '$folder/';
+
+    // The chosen folder's DIRECT children (ORT-GenAI folders are flat).
+    final members = <String>[
+      for (final p in filePaths)
+        if (p.startsWith(prefix) && !p.substring(prefix.length).contains('/'))
+          p,
+    ];
+
+    String urlFor(String path) {
+      final encoded = path.split('/').map(Uri.encodeComponent).join('/');
+      return 'https://huggingface.co/$repo/resolve/$_revision/$encoded';
+    }
+
+    final files = <ResolvedHfFile>[
+      for (final p in members)
+        ResolvedHfFile(name: p.substring(prefix.length), url: urlFor(p)),
+    ];
+
+    final notes = <String>[
+      'Resolved ORT-GenAI directory "${folder.isEmpty ? "(repo root)" : folder}"'
+          ' (${files.length} files).',
+      if (preferredBackend == PreferredBackend.gpu)
+        'GPU was requested; ORT-GenAI on-device GPU execution is not bundled '
+            'yet — the model runs on CPU regardless of the chosen variant.',
+    ];
+
+    return ResolvedHfModel(
+      file: marker, // the primary the engine loads from
+      url: urlFor('${prefix}genai_config.json'),
+      fileType: ModelFileType.onnx,
+      files: files,
+      directoryName: FileNameUtils.sanitizeHfDirName(
+        repo,
+        variant: folder.isEmpty ? null : folder,
+      ),
+      notes: List.unmodifiable(notes),
     );
   }
+
+  /// Picks the EP folder among [folders] (each a path that holds a
+  /// genai_config.json). An explicit [variant] wins; otherwise a GPU folder for
+  /// a GPU request, else a CPU/mobile folder, else the sole/first variant.
+  String _pickFolder(
+    List<String> folders, {
+    required PreferredBackend? preferredBackend,
+    required String repo,
+  }) {
+    if (_variant != null) {
+      if (!folders.contains(_variant)) {
+        throw ArgumentError.value(
+          _variant,
+          'variant',
+          'has no genai_config.json in "$repo" (available: '
+              '${folders.map((f) => f.isEmpty ? "(root)" : f).join(", ")})',
+        );
+      }
+      return _variant;
+    }
+    if (folders.length == 1) return folders.first;
+
+    final wantGpu = preferredBackend == PreferredBackend.gpu;
+    final preferred = folders.where(wantGpu ? _looksGpu : _looksCpu).toList();
+    if (preferred.isNotEmpty) return preferred.first;
+    // Requested backend has no folder → prefer any CPU/mobile build, else first.
+    final cpu = folders.where(_looksCpu).toList();
+    return cpu.isNotEmpty ? cpu.first : folders.first;
+  }
+
+  static final _gpuRe = RegExp(
+    r'cuda|dml|directml|coreml|gpu',
+    caseSensitive: false,
+  );
+  static final _cpuRe = RegExp(r'cpu|mobile', caseSensitive: false);
+
+  static bool _looksGpu(String folder) => _gpuRe.hasMatch(folder);
+  static bool _looksCpu(String folder) => _cpuRe.hasMatch(folder);
 }

--- a/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
@@ -133,10 +133,11 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
     // to load). Full pagination is a follow-up; pin the variant folder to avoid.
     if (decoded.length >= _treeLimit) {
       throw StateError(
-        'Hugging Face repo "$repo" has more than $_treeLimit tree entries; '
-        'listing pagination is not supported yet, so a complete model directory '
-        'cannot be guaranteed. Pin the exact variant folder with '
-        'OnnxHuggingFaceResolver(variant: …).',
+        'Hugging Face repo "$repo" returned $_treeLimit or more tree entries; '
+        'the resolver lists the whole repo in one page and does not paginate '
+        'yet, so a complete model directory cannot be guaranteed for a repo this '
+        'large (pinning a variant does not shrink the listing). Install it from '
+        'a local directory with fromFile(genai_config.json) instead.',
       );
     }
     // Keep file entries, skip directories. A `type == 'file'` entry whose

--- a/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
+++ b/packages/flutter_gemma_onnx/lib/src/onnx_hugging_face_resolver.dart
@@ -54,6 +54,11 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
   final String _revision;
   final HfFetch? _fetch;
 
+  /// Single-page tree-listing budget. A response at this size is treated as
+  /// possibly-truncated and refused (see [resolve]) — full pagination is a
+  /// follow-up.
+  static const _treeLimit = 1000;
+
   @override
   String get name => 'onnx-huggingface';
 
@@ -96,7 +101,7 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
     // of files an ORT-GenAI model ships — limit guards a many-variant repo).
     final treeUrl = Uri.parse(
       'https://huggingface.co/api/models/$repo/tree/$_revision'
-      '?recursive=true&limit=1000',
+      '?recursive=true&limit=$_treeLimit',
     );
     final String body;
     try {
@@ -112,13 +117,36 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
       rethrow;
     }
 
+    final decoded = jsonDecode(body);
+    if (decoded is! List) {
+      throw StateError(
+        'Unexpected Hugging Face tree response for "$repo" — expected a JSON '
+        'array, got ${decoded.runtimeType}. The repo/revision may be wrong or '
+        'the request was rate-limited/redirected to an error page.',
+      );
+    }
+    // A full page means the listing may be TRUNCATED. `HfFetch` returns only the
+    // body, so HF's pagination-continuation header is invisible here — refuse
+    // rather than silently install an incomplete directory (a dropped
+    // `model.onnx_data` past the cutoff would install "successfully" then fail
+    // to load). Full pagination is a follow-up; pin the variant folder to avoid.
+    if (decoded.length >= _treeLimit) {
+      throw StateError(
+        'Hugging Face repo "$repo" has more than $_treeLimit tree entries; '
+        'listing pagination is not supported yet, so a complete model directory '
+        'cannot be guaranteed. Pin the exact variant folder with '
+        'OnnxHuggingFaceResolver(variant: …).',
+      );
+    }
     final filePaths = <String>[
-      for (final e in (jsonDecode(body) as List).cast<Map<String, dynamic>>())
-        if (e['type'] == 'file') e['path'] as String,
+      for (final e in decoded)
+        if (e is Map && e['type'] == 'file' && e['path'] is String)
+          e['path'] as String,
     ];
 
     // Folders that contain a genai_config.json — the ORT-GenAI signal. '' means
-    // the repo root.
+    // the repo root. Sorted so the tie-break in [_pickFolder] is deterministic
+    // (the HF tree order is not).
     const marker = 'genai_config.json';
     final configFolders = <String>[
       for (final p in filePaths)
@@ -126,7 +154,7 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
           ''
         else if (p.endsWith('/$marker'))
           p.substring(0, p.length - marker.length - 1),
-    ];
+    ].toSet().toList()..sort();
     if (configFolders.isEmpty) {
       throw StateError(
         'Hugging Face repo "$repo" has no genai_config.json — it is not an '
@@ -135,19 +163,28 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
       );
     }
 
-    final folder = _pickFolder(
-      configFolders,
-      preferredBackend: preferredBackend,
-      repo: repo,
-    );
+    final folder = _pickFolder(configFolders, repo: repo);
     final prefix = folder.isEmpty ? '' : '$folder/';
 
-    // The chosen folder's DIRECT children (ORT-GenAI folders are flat).
+    // The chosen folder's DIRECT children (ORT-GenAI folders are flat), sorted
+    // for a deterministic file order.
     final members = <String>[
       for (final p in filePaths)
         if (p.startsWith(prefix) && !p.substring(prefix.length).contains('/'))
           p,
-    ];
+    ]..sort();
+
+    // A genai_config.json alone is not a loadable model — require the weights.
+    // Without this an incomplete export (config + tokenizer, no `.onnx`) would
+    // install "successfully" and only fail later inside OgaCreateModel.
+    if (!members.any((p) => p.endsWith('.onnx'))) {
+      throw StateError(
+        'The ORT-GenAI directory '
+        '"${folder.isEmpty ? "(repo root)" : folder}" in "$repo" has a '
+        'genai_config.json but no .onnx model file — it cannot load. The repo '
+        'is likely an incomplete export.',
+      );
+    }
 
     String urlFor(String path) {
       final encoded = path.split('/').map(Uri.encodeComponent).join('/');
@@ -160,16 +197,22 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
     ];
 
     final notes = <String>[
-      'Resolved ORT-GenAI directory "${folder.isEmpty ? "(repo root)" : folder}"'
-          ' (${files.length} files).',
-      if (preferredBackend == PreferredBackend.gpu)
-        'GPU was requested; ORT-GenAI on-device GPU execution is not bundled '
-            'yet — the model runs on CPU regardless of the chosen variant.',
+      'Resolved ORT-GenAI directory '
+          '"${folder.isEmpty ? "(repo root)" : folder}" (${files.length} files).',
+      // v1: the bundled ORT-GenAI runtime is CPU-only, and the automatic EP pick
+      // always chooses a CPU/mobile variant. Surface that on every auto-install
+      // so a GPU-hoping caller is not silently handed CPU. Pin a GPU folder with
+      // OnnxHuggingFaceResolver(variant: …) if you have a GPU runtime.
+      if (_variant == null)
+        'Installed the CPU execution-provider variant; on-device GPU execution '
+            'is not bundled yet.',
     ];
 
     return ResolvedHfModel(
       file: marker, // the primary the engine loads from
-      url: urlFor('${prefix}genai_config.json'),
+      // Reuse the primary's URL from [files] so it can never desync from the
+      // matching ResolvedHfFile.url.
+      url: files.firstWhere((f) => f.name == marker).url,
       fileType: ModelFileType.onnx,
       files: files,
       directoryName: FileNameUtils.sanitizeHfDirName(
@@ -183,11 +226,7 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
   /// Picks the EP folder among [folders] (each a path that holds a
   /// genai_config.json). An explicit [variant] wins; otherwise a GPU folder for
   /// a GPU request, else a CPU/mobile folder, else the sole/first variant.
-  String _pickFolder(
-    List<String> folders, {
-    required PreferredBackend? preferredBackend,
-    required String repo,
-  }) {
+  String _pickFolder(List<String> folders, {required String repo}) {
     if (_variant != null) {
       if (!folders.contains(_variant)) {
         throw ArgumentError.value(
@@ -200,21 +239,15 @@ class OnnxHuggingFaceResolver implements HuggingFaceResolver {
       return _variant;
     }
     if (folders.length == 1) return folders.first;
-
-    final wantGpu = preferredBackend == PreferredBackend.gpu;
-    final preferred = folders.where(wantGpu ? _looksGpu : _looksCpu).toList();
-    if (preferred.isNotEmpty) return preferred.first;
-    // Requested backend has no folder → prefer any CPU/mobile build, else first.
+    // v1: the bundled ORT-GenAI runtime is CPU-only (GPU EP libs are not
+    // shipped), so the automatic pick always prefers a CPU/mobile variant —
+    // auto-picking a CUDA export the CPU runtime can't load would be worse than
+    // useless. Pin a GPU folder explicitly with `variant:` if you have a GPU
+    // runtime. [folders] is already sorted, so both branches are deterministic.
     final cpu = folders.where(_looksCpu).toList();
     return cpu.isNotEmpty ? cpu.first : folders.first;
   }
 
-  static final _gpuRe = RegExp(
-    r'cuda|dml|directml|coreml|gpu',
-    caseSensitive: false,
-  );
   static final _cpuRe = RegExp(r'cpu|mobile', caseSensitive: false);
-
-  static bool _looksGpu(String folder) => _gpuRe.hasMatch(folder);
   static bool _looksCpu(String folder) => _cpuRe.hasMatch(folder);
 }

--- a/packages/flutter_gemma_onnx/lib/src/web/onnx_engine_web.dart
+++ b/packages/flutter_gemma_onnx/lib/src/web/onnx_engine_web.dart
@@ -42,9 +42,10 @@ class OnnxEngine implements InferenceEngineProvider, HuggingFaceResolverSource {
   @override
   int get priority => 0;
 
-  /// The engine's own Hugging Face resolver (same stub as the native arm):
-  /// reserves the `.onnx` slot so `resolveHuggingFace(fileType: onnx)` throws a
-  /// clear `UnimplementedError` rather than core's generic "no resolver".
+  /// The engine's own Hugging Face resolver ([OnnxHuggingFaceResolver]), shared
+  /// with the native arm. On web it resolves a repo to a fileless model (the
+  /// repo id Transformers.js fetches and caches itself), so `fromHuggingFace`
+  /// and `resolveHuggingFace(fileType: onnx)` need no directory download.
   @override
   HuggingFaceResolver get huggingFaceResolver =>
       const OnnxHuggingFaceResolver();

--- a/packages/flutter_gemma_onnx/pubspec.yaml
+++ b/packages/flutter_gemma_onnx/pubspec.yaml
@@ -39,6 +39,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  # Used by test/onnx_directory_e2e_test.dart (path join + mocked
+  # PathProvider/SharedPreferences for the resolver→install→engine contract).
+  path: ^1.9.0
+  path_provider_platform_interface: ^2.1.0
+  shared_preferences: ^2.5.2
 
 # `hook/build.dart` (Phase 3 Task 4) owns the two co-located ORT-GenAI/ORT
 # CodeAssets — macOS arm64 only for now (native-assets pipeline, no

--- a/packages/flutter_gemma_onnx/test/onnx_directory_e2e_test.dart
+++ b/packages/flutter_gemma_onnx/test/onnx_directory_e2e_test.dart
@@ -1,0 +1,183 @@
+// End-to-end contract test: resolver → core directory install → OnnxEngine
+// .createModel → the directory handed to GenAiClient.load. Pins the implicit
+// contract that the active spec's modelPath resolves inside the per-model
+// subdirectory, so `File(modelPath).parent` is the ORT-GenAI directory the
+// engine loads. All FFI/native is faked (FakeGenAiClient); no network.
+//
+// Run: flutter test test/onnx_directory_e2e_test.dart
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_gemma/core/di/service_registry.dart';
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
+import 'package:flutter_gemma/core/registry/hugging_face_resolver.dart';
+import 'package:flutter_gemma/core/registry/hugging_face_resolver_registry.dart';
+import 'package:flutter_gemma/core/registry/runtime_config.dart';
+import 'package:flutter_gemma/core/services/download_service.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/mobile/flutter_gemma_mobile.dart'
+    show MobileModelManager;
+
+import 'package:flutter_gemma_onnx/src/onnx_engine.dart';
+
+import 'fakes/fake_gen_ai_client.dart';
+
+const _modelId = 'org__repo__cpu';
+const _dirModel = ResolvedHfModel(
+  file: 'genai_config.json',
+  url: 'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+  fileType: ModelFileType.onnx,
+  directoryName: _modelId,
+  files: [
+    ResolvedHfFile(
+      name: 'genai_config.json',
+      url: 'https://huggingface.co/org/repo/resolve/main/cpu/genai_config.json',
+    ),
+    ResolvedHfFile(
+      name: 'model.onnx',
+      url: 'https://huggingface.co/org/repo/resolve/main/cpu/model.onnx',
+    ),
+    ResolvedHfFile(
+      name: 'tokenizer.json',
+      url: 'https://huggingface.co/org/repo/resolve/main/cpu/tokenizer.json',
+    ),
+  ],
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory docs;
+  late Directory support;
+
+  setUp(() async {
+    docs = await Directory.systemTemp.createTemp('fg_onnx_e2e_docs_');
+    support = await Directory.systemTemp.createTemp('fg_onnx_e2e_support_');
+    PathProviderPlatform.instance = _FixedPathProvider(docs.path, support.path);
+    SharedPreferences.setMockInitialValues({});
+    ServiceRegistry.reset();
+    HuggingFaceResolverRegistry.instance.reset();
+    OnnxEngine.debugForceUnsupportedHost = null;
+  });
+
+  tearDown(() async {
+    ServiceRegistry.reset();
+    HuggingFaceResolverRegistry.instance.reset();
+    OnnxEngine.debugForceUnsupportedHost = null;
+    for (final d in [docs, support]) {
+      if (await d.exists()) await d.delete(recursive: true);
+    }
+  });
+
+  test('resolver → install → OnnxEngine.createModel hands GenAiClient the '
+      'per-model directory (its genai_config.json parent)', () async {
+    await ServiceRegistry.initialize(
+      downloadService: _FixtureDownload(Uint8List.fromList(List.filled(64, 7))),
+    );
+    HuggingFaceResolverRegistry.instance.registerAll([_ScriptedResolver()]);
+
+    final install = await FlutterGemma.installModel(
+      modelType: ModelType.general,
+      fileType: ModelFileType.onnx,
+    ).fromHuggingFace('org/repo').install();
+
+    // The active directory spec + its resolved modelPath (the engine input).
+    final manager =
+        FlutterGemmaPlugin.instance.modelManager as MobileModelManager;
+    final spec = install.spec;
+    final paths = await manager.getModelFilePaths(spec);
+    expect(paths, isNotNull);
+    final modelPath = paths!.values.first;
+    expect(p.basename(modelPath), 'genai_config.json');
+
+    // createModel on a real supported host (macOS arm64) with a FAKE client:
+    // the genai_config precheck passes (the bundle is on disk) and the model
+    // directory is handed to client.load — this is the resolver→install→engine
+    // contract Phase 1+2 rely on.
+    final fake = FakeGenAiClient();
+    final engine = OnnxEngine(clientFactory: () => fake);
+    final model = await engine.createModel(
+      spec,
+      RuntimeConfig(maxTokens: 1024, modelPath: modelPath),
+    );
+
+    expect(fake.loaded, isTrue);
+    expect(p.basename(fake.loadedModelDir!), _modelId);
+    expect(
+      File(p.join(fake.loadedModelDir!, 'genai_config.json')).existsSync(),
+      isTrue,
+    );
+    expect(
+      File(p.join(fake.loadedModelDir!, 'model.onnx')).existsSync(),
+      isTrue,
+    );
+    await model.close();
+  });
+}
+
+class _ScriptedResolver implements HuggingFaceResolver {
+  @override
+  String get name => 'scripted-e2e';
+  @override
+  int get priority => 0;
+  @override
+  bool canResolve(String repo, {ModelFileType? fileType}) =>
+      fileType == ModelFileType.onnx;
+  @override
+  Future<ResolvedHfModel> resolve(
+    String repo, {
+    String? token,
+    String? platform,
+    PreferredBackend? preferredBackend,
+  }) async => _dirModel;
+}
+
+class _FixedPathProvider extends PathProviderPlatform {
+  _FixedPathProvider(this.docs, this.support);
+  final String docs;
+  final String support;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => docs;
+  @override
+  Future<String?> getApplicationSupportPath() async => support;
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+class _FixtureDownload implements DownloadService {
+  _FixtureDownload(this.bytes);
+  final Uint8List bytes;
+  Future<void> _write(String targetPath) async {
+    final f = File(targetPath);
+    if (!await f.parent.exists()) await f.parent.create(recursive: true);
+    await f.writeAsBytes(bytes);
+  }
+
+  @override
+  Future<void> download(
+    String url,
+    String targetPath, {
+    String? token,
+    CancelToken? cancelToken,
+  }) async => _write(targetPath);
+
+  @override
+  Stream<int> downloadWithProgress(
+    String url,
+    String targetPath, {
+    String? token,
+    int maxRetries = 10,
+    CancelToken? cancelToken,
+    bool? foreground,
+  }) async* {
+    await _write(targetPath);
+    yield 100;
+  }
+}

--- a/packages/flutter_gemma_onnx/test/onnx_hugging_face_resolver_test.dart
+++ b/packages/flutter_gemma_onnx/test/onnx_hugging_face_resolver_test.dart
@@ -1,52 +1,188 @@
-// The ONNX HuggingFace resolver reserves the ModelFileType.onnx slot so
-// resolveHuggingFace(...) gives a clear "not implemented yet" instead of
-// core's generic "no resolver registered". Directory-based genai_config
-// resolution is a follow-up; until then resolve() throws.
+// OnnxHuggingFaceResolver resolves an ORT-GenAI model DIRECTORY from a Hugging
+// Face repo: it lists the repo via the tree API, picks an execution-provider
+// folder, and returns every file in it as a directory ResolvedHfModel. On web
+// it returns a fileless (files == null) repo-id model. All HTTP is injected via
+// the `fetch` seam — no network.
 
+import 'dart:convert';
+
+import 'package:flutter_gemma/core/domain/platform_types.dart'
+    show PreferredBackend;
 import 'package:flutter_gemma/core/model.dart' show ModelFileType;
 import 'package:flutter_gemma_onnx/flutter_gemma_onnx.dart'
     show OnnxHuggingFaceResolver;
 import 'package:flutter_test/flutter_test.dart';
 
+/// A repo shipping a CPU variant (with external `.onnx_data`) and a CUDA
+/// variant, each a complete ORT-GenAI directory, plus a stray root README.
+final _tree = jsonEncode([
+  {'type': 'directory', 'path': 'cpu_and_mobile'},
+  {
+    'type': 'file',
+    'path': 'cpu_and_mobile/cpu-int4/genai_config.json',
+    'size': 9,
+  },
+  {'type': 'file', 'path': 'cpu_and_mobile/cpu-int4/model.onnx', 'size': 9},
+  {
+    'type': 'file',
+    'path': 'cpu_and_mobile/cpu-int4/model.onnx_data',
+    'size': 9,
+  },
+  {'type': 'file', 'path': 'cpu_and_mobile/cpu-int4/tokenizer.json', 'size': 9},
+  {'type': 'file', 'path': 'cuda/cuda-int4/genai_config.json', 'size': 9},
+  {'type': 'file', 'path': 'cuda/cuda-int4/model.onnx', 'size': 9},
+  {'type': 'file', 'path': 'cuda/cuda-int4/tokenizer.json', 'size': 9},
+  {'type': 'file', 'path': 'README.md', 'size': 9},
+]);
+
+/// A fetch seam that returns [body] and records the URL + headers it saw.
+({
+  OnnxHuggingFaceResolver make,
+  List<Uri> urls,
+  List<Map<String, String>> headers,
+})
+_resolver(String body, {String? variant}) {
+  final urls = <Uri>[];
+  final headers = <Map<String, String>>[];
+  final r = OnnxHuggingFaceResolver(
+    variant: variant,
+    fetch: (u, h) async {
+      urls.add(u);
+      headers.add(h);
+      return body;
+    },
+  );
+  return (make: r, urls: urls, headers: headers);
+}
+
 void main() {
-  const resolver = OnnxHuggingFaceResolver();
+  test(
+    'canResolve claims exactly ModelFileType.onnx; name/priority stable',
+    () {
+      const r = OnnxHuggingFaceResolver();
+      expect(r.name, 'onnx-huggingface');
+      expect(r.priority, 0);
+      expect(r.canResolve('o/r', fileType: ModelFileType.onnx), isTrue);
+      for (final t in ModelFileType.values) {
+        if (t == ModelFileType.onnx) continue;
+        expect(r.canResolve('o/r', fileType: t), isFalse, reason: '$t');
+      }
+      expect(r.canResolve('o/r'), isFalse);
+    },
+  );
 
-  test('canResolve claims exactly ModelFileType.onnx (never a null hint)', () {
-    expect(
-      resolver.canResolve('org/repo', fileType: ModelFileType.onnx),
-      isTrue,
-    );
-    // Every OTHER declared file type must NOT match, so the stub can never
-    // shadow another engine's resolver. Iterating ModelFileType.values keeps
-    // this exhaustive if a new value is ever added.
-    for (final t in ModelFileType.values) {
-      if (t == ModelFileType.onnx) continue;
-      expect(
-        resolver.canResolve('org/repo', fileType: t),
-        isFalse,
-        reason: '$t',
+  test(
+    'native: picks the CPU variant, returns every folder file by bare name '
+    '(incl. external .onnx_data), and hits the tree API with the token',
+    () async {
+      final h = _resolver(_tree);
+      final r = await h.make.resolve(
+        'org/repo',
+        platform: 'macos',
+        token: 'hf_abc',
       );
-    }
-    // A bare hint must NOT match — otherwise resolveHuggingFace(repo) with no
-    // fileType would route by registration order.
-    expect(resolver.canResolve('org/repo'), isFalse);
+
+      expect(r.files, isNotNull);
+      expect(r.files!.map((f) => f.name).toSet(), {
+        'genai_config.json',
+        'model.onnx',
+        'model.onnx_data',
+        'tokenizer.json',
+      });
+      expect(r.file, 'genai_config.json');
+      expect(r.directoryName, 'org__repo__cpu_and_mobile__cpu-int4');
+      // Primary URL is revision-pinned into the chosen folder.
+      expect(
+        r.url,
+        'https://huggingface.co/org/repo/resolve/main/cpu_and_mobile/cpu-int4/'
+        'genai_config.json',
+      );
+      // Tree API called once, with the auth header.
+      expect(
+        h.urls.single.toString(),
+        contains('/api/models/org/repo/tree/main'),
+      );
+      expect(h.headers.single['Authorization'], 'Bearer hf_abc');
+    },
+  );
+
+  test(
+    'native: GPU request picks the cuda variant and warns execution is CPU',
+    () async {
+      final h = _resolver(_tree);
+      final r = await h.make.resolve(
+        'org/repo',
+        platform: 'windows',
+        preferredBackend: PreferredBackend.gpu,
+      );
+      expect(r.directoryName, 'org__repo__cuda__cuda-int4');
+      expect(r.files!.any((f) => f.name == 'model.onnx'), isTrue);
+      expect(
+        r.notes.any((n) => n.toLowerCase().contains('gpu')),
+        isTrue,
+        reason: 'a release-visible note that GPU execution is not bundled',
+      );
+    },
+  );
+
+  test('native: an explicit variant overrides the backend heuristic', () async {
+    final h = _resolver(_tree, variant: 'cuda/cuda-int4');
+    final r = await h.make.resolve('org/repo', platform: 'macos');
+    expect(r.directoryName, 'org__repo__cuda__cuda-int4');
   });
 
-  test('resolve throws UnimplementedError naming the repo', () {
-    expect(
-      () => resolver.resolve('onnx-community/Qwen2.5-0.5B-Instruct'),
-      throwsA(
-        isA<UnimplementedError>().having(
-          (e) => e.message,
-          'message',
-          contains('onnx-community/Qwen2.5-0.5B-Instruct'),
-        ),
-      ),
+  test('native: an unknown variant is rejected', () async {
+    final h = _resolver(_tree, variant: 'tpu/nope');
+    await expectLater(
+      h.make.resolve('org/repo', platform: 'macos'),
+      throwsArgumentError,
     );
   });
 
-  test('name and priority are stable', () {
-    expect(resolver.name, 'onnx-huggingface');
-    expect(resolver.priority, 0);
+  test('native: a repo without genai_config.json is rejected', () async {
+    final h = _resolver(
+      jsonEncode([
+        {'type': 'file', 'path': 'model.onnx', 'size': 9},
+        {'type': 'file', 'path': 'README.md', 'size': 9},
+      ]),
+    );
+    await expectLater(
+      h.make.resolve('org/repo', platform: 'macos'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test(
+    'native: a root-level ORT-GenAI directory (no EP subfolders) resolves',
+    () async {
+      final h = _resolver(
+        jsonEncode([
+          {'type': 'file', 'path': 'genai_config.json', 'size': 9},
+          {'type': 'file', 'path': 'model.onnx', 'size': 9},
+          {'type': 'file', 'path': 'tokenizer.json', 'size': 9},
+        ]),
+      );
+      final r = await h.make.resolve('org/repo', platform: 'linux');
+      expect(r.directoryName, 'org__repo');
+      expect(r.files!.map((f) => f.name).toSet(), {
+        'genai_config.json',
+        'model.onnx',
+        'tokenizer.json',
+      });
+      expect(
+        r.url,
+        'https://huggingface.co/org/repo/resolve/main/genai_config.json',
+      );
+    },
+  );
+
+  test('web: fileless — files == null and the URL maps to the repo id, '
+      'no tree fetch', () async {
+    final h = _resolver(_tree);
+    final r = await h.make.resolve('org/repo', platform: 'web');
+    expect(r.files, isNull);
+    expect(r.url, 'https://huggingface.co/org/repo');
+    expect(r.fileType, ModelFileType.onnx);
+    expect(h.urls, isEmpty, reason: 'web must not hit the tree API');
   });
 }

--- a/packages/flutter_gemma_onnx/test/onnx_hugging_face_resolver_test.dart
+++ b/packages/flutter_gemma_onnx/test/onnx_hugging_face_resolver_test.dart
@@ -128,6 +128,63 @@ void main() {
   );
 
   test(
+    'native: a GPU-only repo (no CPU folder) picks the GPU variant and WARNS '
+    'the CPU-only runtime may not load it — not a false "CPU variant" note',
+    () async {
+      final h = _resolver(
+        jsonEncode([
+          {'type': 'file', 'path': 'cuda/cuda-int4/genai_config.json'},
+          {'type': 'file', 'path': 'cuda/cuda-int4/model.onnx'},
+          {'type': 'file', 'path': 'cuda/cuda-int4/tokenizer.json'},
+        ]),
+      );
+      final r = await h.make.resolve('org/repo', platform: 'macos');
+      expect(r.directoryName, 'org__repo__cuda__cuda-int4');
+      expect(
+        r.notes.any((n) => n.toLowerCase().contains('may fail to load')),
+        isTrue,
+        reason: 'a GPU export must be flagged, not silently claimed as CPU',
+      );
+      expect(
+        r.notes.any((n) => n.toLowerCase().contains('cpu execution-provider')),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'native: pinning a GPU variant WARNS the CPU-only runtime may not load it',
+    () async {
+      final h = _resolver(_tree, variant: 'cuda/cuda-int4');
+      final r = await h.make.resolve('org/repo', platform: 'macos');
+      expect(r.directoryName, 'org__repo__cuda__cuda-int4');
+      expect(
+        r.notes.any((n) => n.toLowerCase().contains('may fail to load')),
+        isTrue,
+      );
+      expect(
+        r.notes.any((n) => n.toLowerCase().contains('cpu execution-provider')),
+        isFalse,
+      );
+    },
+  );
+
+  test('native: a file entry with a non-string path is refused (not silently '
+      'dropped, which would install an incomplete directory)', () async {
+    final h = _resolver(
+      jsonEncode([
+        {'type': 'file', 'path': 'cpu/genai_config.json'},
+        {'type': 'file', 'path': 'cpu/model.onnx'},
+        {'type': 'file', 'path': 12345}, // malformed: path is not a string
+      ]),
+    );
+    await expectLater(
+      h.make.resolve('org/repo', platform: 'macos'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test(
     'native: >1000 tree entries is refused (undetectable truncation)',
     () async {
       final many = [

--- a/packages/flutter_gemma_onnx/test/onnx_hugging_face_resolver_test.dart
+++ b/packages/flutter_gemma_onnx/test/onnx_hugging_face_resolver_test.dart
@@ -107,7 +107,8 @@ void main() {
   );
 
   test(
-    'native: GPU request picks the cuda variant and warns execution is CPU',
+    'native: a GPU request still auto-picks the CPU variant (GPU execution is '
+    'not bundled) and notes the CPU EP',
     () async {
       final h = _resolver(_tree);
       final r = await h.make.resolve(
@@ -115,15 +116,51 @@ void main() {
         platform: 'windows',
         preferredBackend: PreferredBackend.gpu,
       );
-      expect(r.directoryName, 'org__repo__cuda__cuda-int4');
-      expect(r.files!.any((f) => f.name == 'model.onnx'), isTrue);
+      // Auto pick is CPU-only in v1 — NOT the cuda folder, which the CPU runtime
+      // could not load.
+      expect(r.directoryName, 'org__repo__cpu_and_mobile__cpu-int4');
       expect(
-        r.notes.any((n) => n.toLowerCase().contains('gpu')),
+        r.notes.any((n) => n.toLowerCase().contains('cpu execution-provider')),
         isTrue,
-        reason: 'a release-visible note that GPU execution is not bundled',
+        reason: 'a release-visible note that the CPU EP variant was installed',
       );
     },
   );
+
+  test(
+    'native: >1000 tree entries is refused (undetectable truncation)',
+    () async {
+      final many = [
+        for (var i = 0; i < 1000; i++) {'type': 'file', 'path': 'f$i.bin'},
+      ];
+      final h = _resolver(jsonEncode(many));
+      await expectLater(
+        h.make.resolve('org/repo', platform: 'macos'),
+        throwsA(isA<StateError>()),
+      );
+    },
+  );
+
+  test('native: a non-array tree response is a clear StateError', () async {
+    final h = _resolver(jsonEncode({'error': 'rate limited'}));
+    await expectLater(
+      h.make.resolve('org/repo', platform: 'macos'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('native: a folder with genai_config but no .onnx is refused', () async {
+    final h = _resolver(
+      jsonEncode([
+        {'type': 'file', 'path': 'cpu/genai_config.json', 'size': 9},
+        {'type': 'file', 'path': 'cpu/tokenizer.json', 'size': 9},
+      ]),
+    );
+    await expectLater(
+      h.make.resolve('org/repo', platform: 'macos'),
+      throwsA(isA<StateError>()),
+    );
+  });
 
   test('native: an explicit variant overrides the backend heuristic', () async {
     final h = _resolver(_tree, variant: 'cuda/cuda-int4');

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -239,7 +239,7 @@ final session = await model.createSession(
 );
 ```
 
-`.onnx` and `.builtIn` repos surface their resolver's status here — ONNX reports that directory-based install is a follow-up, and built-in reports that OS models have no Hugging Face file.
+`.onnx` repos install the whole ORT-GenAI **directory** — the ONNX resolver (carried by `OnnxEngine`) lists the repo, picks a CPU execution-provider folder (the bundled runtime is CPU-only; pin one with `OnnxHuggingFaceResolver(variant: …)`) and downloads every file in it; see [ONNX](/docs/onnx). `.builtIn` repos surface that OS models have no Hugging Face file.
 
 **Explicit file** — pass `file`, and `fromHuggingFace(repo, file:)` resolves `…/resolve/<revision>/<file>` and installs it directly, for any `fileType` (no manifest needed; the HF token is applied to `huggingface.co` automatically):
 

--- a/website/content/docs/onnx.md
+++ b/website/content/docs/onnx.md
@@ -67,9 +67,24 @@ by platform.
 
 **Native — a directory, not a file.** An ORT-GenAI model is a **directory**:
 `genai_config.json`, `model.onnx` (plus `model.onnx_data` for external weights),
-and tokenizer files. `OnnxEngine` takes the tracked file's **parent directory** as
-the model directory, so the whole bundle must already live on disk together
-(e.g. shipped as an asset or pre-populated yourself):
+and tokenizer files. `OnnxEngine` takes the tracked `genai_config.json`'s
+**parent directory** as the model directory.
+
+`fromHuggingFace(repo)` installs that whole directory for you: the ONNX resolver
+(carried by `OnnxEngine`, so registering the engine is enough) lists the repo,
+picks an execution-provider folder, and downloads every file in it. A repo with
+several EP variants resolves to a **CPU/mobile** folder — the bundled runtime is
+CPU-only — unless you pin one with `OnnxHuggingFaceResolver(variant: …)`:
+
+```dart
+await FlutterGemma.installModel(
+  // ONNX repos declare no family — the caller's modelType is used as-is.
+  modelType: ModelType.general,
+  fileType: ModelFileType.onnx,
+).fromHuggingFace('microsoft/Phi-3.5-mini-instruct-onnx').install();
+```
+
+Or ship the bundle yourself and point `fromFile` at its `genai_config.json`:
 
 ```dart
 await FlutterGemma.installModel(

--- a/website/content/docs/packages.md
+++ b/website/content/docs/packages.md
@@ -104,9 +104,10 @@ public API as native, no `if (kIsWeb)` needed in app code.
 <Info>
 On native, an ORT-GenAI model installs as a **directory**, not a single file:
 `genai_config.json` + `model.onnx` (+ `model.onnx_data` for external weights)
-+ tokenizer files. `ModelFileType.onnx` models need the whole bundle on disk
-alongside the tracked file (e.g. shipped as an asset) — a real multi-file
-network install is a follow-on. On **Web** this doesn't apply — the model is a
++ tokenizer files. `fromHuggingFace(repo)` downloads the whole bundle (the ONNX
+resolver picks a CPU execution-provider folder), or ship it yourself as an asset
+/ local directory and install with `fromFile(genai_config.json)`. On **Web** this
+doesn't apply — the model is a
 Hugging Face repo id (e.g. `onnx-community/Qwen2.5-0.5B-Instruct`), not a
 directory, and install is fileless: `ModelFileType.onnx` just marks it active,
 and Transformers.js downloads and caches the repo itself.


### PR DESCRIPTION
Completes the ONNX arm of #454: `installModel(fileType: onnx).fromHuggingFace(repo)` now installs a whole ORT-GenAI model **directory** from a Hugging Face repo, not just single-file models.

## What it does
- **`OnnxHuggingFaceResolver`** (auto-registered from `OnnxEngine` via `HuggingFaceResolverSource`) lists the repo's file tree, picks an execution-provider folder, and returns every file in it as a directory `ResolvedHfModel`.
- **Core directory-install path**: `ResolvedHfModel.files`/`.directoryName`, `DirectoryBundleFile`, and an `_installDirectory` loop that downloads each member into a per-model subdirectory with its bare leaf name — the layout `OgaCreateModel` needs. Single-file installs are byte-for-byte unchanged.
- **EP pick is CPU-only in v1**: the bundled ORT-GenAI runtime is CPU-only, so a repo with several EP variants resolves to a CPU/mobile folder automatically; a GPU export it can't load is never auto-picked. Pin a folder with `OnnxHuggingFaceResolver(variant: …)` — a pinned GPU variant is installed but flagged in the result notes.
- **Web** stays fileless (Transformers.js owns the repo id).

## Safety / robustness
- Path-traversal guards on both `directoryName` and each file name (a `..`/separator-bearing name is refused before any download).
- Completeness: a directory with `genai_config.json` but no `.onnx` graph is refused (it would install "successfully" then fail in `OgaCreateModel`).
- Tree listing: a non-array response, a malformed file entry, and a full (possibly-truncated) page are all refused loudly rather than installing a partial directory.
- Directory-spec invariants (no LoRA, non-empty bundle, primary-first) are enforced in release, not just debug asserts.

## Docs / versioning
- READMEs (core + onnx) and the website (`onnx.md`, `models.md`, `packages.md`) document `fromHuggingFace` and drop the stale "directory install is a follow-up" wording.
- Rides in the already-bumped-but-unpublished core `1.7.0` / onnx `0.3.2`; onnx floor is `flutter_gemma: ^1.7.0`. No further bump.

Reviewed across two rounds (multi-agent + adversarial fix-review); all findings applied. core 698/698, onnx 102/102, `flutter analyze` clean.
