### PR TITLE
docs(agent): run_js tool takes no scriptName (0.2.5)

### DIFF
--- a/packages/flutter_gemma_agent/README.md
+++ b/packages/flutter_gemma_agent/README.md
@@ -172,13 +172,19 @@ metadata:
 ---
 # Title
 ## Instructions
-Call the `run_js` tool with: script name: index.html, data: { field: Type }
+Call the `run_js` tool with: data: { field: Type }
 ```
 
 JS skills additionally ship `scripts/index.html` exposing
 `window.ai_edge_gallery_get_result(data, secret)` returning a JSON string
 (`{ result | image | webview | error }`). Secrets are injected as the JS
 `secret` argument and **never** placed in the model prompt.
+
+The model does not choose which script runs — `run_js` always runs the skill's
+own `scripts/index.html` (or the `scriptName` its `SKILL.md` declares), resolved
+by `JsSkillExecutor`. Its tool schema therefore takes only `data` (no
+`scriptName`): a required script-name field only made the model invent a
+filename, and honouring one would let it name any file under `scripts/`.
 
 ## Registering executors
 


### PR DESCRIPTION
The `runSkill`/`run_js` tool dropped its `scriptName` parameter in 0.2.5 (the script is resolved from the skill's own `SKILL.md`, not chosen by the model — commit `9253b4e1`). The pub.dev README still told the model to pass a script name in its `SKILL.md` example, and did not document the schema change. Fix the example and document that `run_js` takes only `data`.

Needed to publish `flutter_gemma_agent` 0.2.5 — the release-docs guard requires the README to reflect the 0.2.5 lib change.