### PR TITLE
docs(genkit): description covers all models, not just Gemma

### DIFF
--- a/packages/genkit_flutter_gemma/README.md
+++ b/packages/genkit_flutter_gemma/README.md
@@ -1,6 +1,6 @@
 # genkit_flutter_gemma
 
-Genkit Dart plugin for [flutter_gemma](https://pub.dev/packages/flutter_gemma) — local on-device AI inference via Google Gemma and other supported models.
+Genkit Dart plugin for [flutter_gemma](https://pub.dev/packages/flutter_gemma) — local, on-device LLM inference (Gemma, Qwen, Phi, DeepSeek, and more), fully offline.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/DenisovAV/flutter_gemma/main/packages/genkit_flutter_gemma/assets/cover.jpeg" alt="genkit_flutter_gemma_cover">

--- a/packages/genkit_flutter_gemma/pubspec.yaml
+++ b/packages/genkit_flutter_gemma/pubspec.yaml
@@ -1,5 +1,5 @@
 name: genkit_flutter_gemma
-description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
+description: Genkit Dart plugin for flutter_gemma — on-device LLM inference (Gemma, Qwen, Phi, DeepSeek, and more) with streaming, tools, JSON output, and embeddings.
 version: 0.5.0
 homepage: https://github.com/DenisovAV/flutter_gemma/tree/main/packages/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/flutter_gemma


### PR DESCRIPTION
The pub.dev description and README tagline said `flutter_gemma` does inference "via Google Gemma models" — but it runs Gemma **and** Qwen, Phi, DeepSeek, SmolLM, FastVLM, … (litertlm/task/onnx). Broaden both to match core's "Gemma and other LLMs" framing.

Metadata/docs only — no `lib/` change. The corrected description reaches pub.dev with the next `genkit_flutter_gemma` release (no republish now).