### PR TITLE
fix(codelab): lookupAction takes ActionType in genkit 0.16

### DIFF
--- a/website/codelabs/hybrid-ai-flutter-genkit/index.md
+++ b/website/codelabs/hybrid-ai-flutter-genkit/index.md
@@ -569,7 +569,7 @@ class AiEngine {
   // A plugin model is registered by name; genkit's `Model` is an `Action`, so
   // look the concrete model up from the registry and cast.
   Future<Model> _resolve(ModelRef ref) async {
-    final action = await ai.registry.lookupAction('model', ref.name);
+    final action = await ai.registry.lookupAction(ActionType.model, ref.name);
     if (action == null) {
       throw StateError('model "${ref.name}" is not registered');
     }


### PR DESCRIPTION
The published codelab pins genkit `^0.16.0` but the AiEngine listing called `ai.registry.lookupAction('model', ...)` — a `String` where genkit 0.16's `lookupAction` takes `ActionType`. A learner copying the listing hits a compile error. Fixed to `ActionType.model` (exported from `package:genkit`, already imported).

Follow-up to #482 — same fix the workshop branch `ai_engine.dart` already got; the codelab copy was missed. Deploys to fluttergemma.dev on merge.