### PR TITLE
feat(website): a codelab catalogue at /codelabs

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -62,7 +62,10 @@ jobs:
           done
           # Guard against an empty glob / wrong cwd / claat emitting nothing —
           # a green build that shipped zero codelabs would 404 the live page.
-          if [ -z "$(find build/jaspr/codelabs -name index.html -print -quit)" ]; then
+          # `-mindepth 2` is load-bearing: the catalogue route writes
+          # build/jaspr/codelabs/index.html itself, which would match at depth 1
+          # and pass this guard on zero codelabs. Only claat writes <id>/.
+          if [ -z "$(find build/jaspr/codelabs -mindepth 2 -name index.html -print -quit)" ]; then
             echo "ERROR: no codelab HTML produced under build/jaspr/codelabs" >&2
             exit 1
           fi

--- a/.github/workflows/website-build-check.yml
+++ b/.github/workflows/website-build-check.yml
@@ -56,7 +56,10 @@ jobs:
           done
           # Guard against an empty glob / wrong cwd / claat emitting nothing, so
           # the PR gate fails loudly instead of passing green on zero codelabs.
-          if [ -z "$(find build/jaspr/codelabs -name index.html -print -quit)" ]; then
+          # `-mindepth 2` is load-bearing: the catalogue route writes
+          # build/jaspr/codelabs/index.html itself, which would match at depth 1
+          # and pass this guard on zero codelabs. Only claat writes <id>/.
+          if [ -z "$(find build/jaspr/codelabs -mindepth 2 -name index.html -print -quit)" ]; then
             echo "ERROR: no codelab HTML produced under build/jaspr/codelabs" >&2
             exit 1
           fi

--- a/website/deploy.sh
+++ b/website/deploy.sh
@@ -2,9 +2,10 @@
 # Build + deploy the flutter_gemma website to Firebase Hosting.
 #
 # Ships two artifacts on one hosting site:
-#   /            + /docs/*   -> Jaspr static site (this package)
-#   /try/...                 -> the Flutter web example app (live demo)
-#   /codelabs/...            -> Google Codelabs (claat static export)
+#   /  + /docs/*  + /codelabs -> Jaspr static site (this package); the Jaspr
+#                                route owns codelabs/index.html (the catalogue)
+#   /try/...                  -> the Flutter web example app (live demo)
+#   /codelabs/<id>/...        -> Google Codelabs (claat static export)
 #
 # Usage:  ./deploy.sh            (build both + deploy)
 #         ./deploy.sh --no-example   (skip rebuilding the example app)
@@ -45,7 +46,9 @@ echo "==> Exporting codelabs (claat static export)…"
 # Codelab sources live under website/codelabs/<id>/index.md. Each is claat-exported
 # to self-contained HTML under /codelabs/<id>/ and served as STATIC — not rendered
 # through Jaspr, so the bash/yaml/xml code fences that break Jaspr's CodeBlock
-# grammar are fine here. Runs after the `rm -rf build/jaspr` wipe above.
+# grammar are fine here. Runs after the `rm -rf build/jaspr` wipe above, and
+# after `jaspr build` wrote the catalogue at codelabs/index.html — claat only
+# ever writes into codelabs/<id>/, so the two never collide.
 CLAAT="$(command -v claat || echo "$HOME/.local/bin/claat")"
 if [[ -x "$CLAAT" ]]; then
   mkdir -p build/jaspr/codelabs
@@ -56,7 +59,10 @@ if [[ -x "$CLAAT" ]]; then
   # A Firebase deploy is a full-site REPLACE (public=build/jaspr, no /codelabs
   # rewrite) — so "no HTML produced" (empty glob, wrong cwd, or claat emitted
   # nothing) would silently 404 the live codelab. Fail instead.
-  if [[ -z "$(find build/jaspr/codelabs -name index.html -print -quit)" ]]; then
+  # `-mindepth 2` is load-bearing: the catalogue route writes
+  # build/jaspr/codelabs/index.html itself, which would match at depth 1 and
+  # make this guard pass on zero codelabs. Only claat writes <id>/index.html.
+  if [[ -z "$(find build/jaspr/codelabs -mindepth 2 -name index.html -print -quit)" ]]; then
     echo "ERROR: no codelab HTML produced under build/jaspr/codelabs." >&2
     exit 1
   fi

--- a/website/lib/codelabs/codelabs_page.dart
+++ b/website/lib/codelabs/codelabs_page.dart
@@ -45,8 +45,10 @@ class _Codelab {
 class CodelabsPage extends StatelessComponent {
   const CodelabsPage({super.key});
 
-  /// Ordered as a learning path, not a feature list: start, then model
-  /// capabilities, then the pipelines that combine them.
+  /// Ordered as a learning path, not a feature list: first run, then the
+  /// engines that run a model, then the model capabilities built on top
+  /// (multimodal, function calling), then the pipelines that combine several
+  /// of them (RAG, voice, hybrid routing).
   static const _items = <_Codelab>[
     _Codelab(
       title: 'Getting Started with On-Device LLMs in Flutter',
@@ -125,7 +127,9 @@ class CodelabsPage extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    return main_(classes: 'landing-root codelabs-root', [
+    // `.landing-root` supplies the navy canvas, `min-height: 100vh` and the
+    // element resets the NavBar/SiteFooter styles are scoped to.
+    return main_(classes: 'landing-root', [
       const NavBar(),
       section(classes: 'cl-head', [
         div(classes: 'cl-head-inner', [
@@ -184,11 +188,6 @@ class CodelabsPage extends StatelessComponent {
 
   @css
   static List<StyleRule> get styles => [
-    css('.codelabs-root').styles(
-      backgroundColor: Brand.navy,
-      minHeight: 100.vh,
-    ),
-
     // ---- header ----
     css('.cl-head').styles(
       padding: Padding.symmetric(horizontal: 2.rem, vertical: 4.rem),
@@ -238,8 +237,18 @@ class CodelabsPage extends StatelessComponent {
       maxWidth: 1100.px,
       margin: Margin.symmetric(horizontal: Unit.auto),
       display: Display.grid,
+      // 280px matches `.features-grid` — an auto-fit track cannot shrink below
+      // its minimum, so a larger floor makes the page scroll sideways on a
+      // ≤360px viewport (iPhone SE 1st gen, Galaxy Fold cover screen).
+      gridTemplate: GridTemplate(
+        columns: GridTracks([
+          GridTrack.repeat(
+            TrackRepeat.autoFit,
+            [GridTrack(TrackSize.minmax(TrackSize(280.px), TrackSize.fr(1)))],
+          ),
+        ]),
+      ),
       gap: Gap.all(1.25.rem),
-      raw: {'grid-template-columns': 'repeat(auto-fit, minmax(320px, 1fr))'},
     ),
 
     // ---- card ----
@@ -259,7 +268,12 @@ class CodelabsPage extends StatelessComponent {
       transform: Transform.translate(y: (-3).px),
       border: Border.all(color: Color('rgba(147,197,253,0.55)'), width: 1.px),
     ),
-    css('.cl-card--soon').styles(raw: {'opacity': '0.62'}),
+    // The unwritten state used to be carried by `opacity: 0.62` on the whole
+    // card, which composited the white70 blurb down to ~3.6:1 against the navy
+    // page — below the 4.5:1 WCAG AA floor for normal text, on six of seven
+    // cards. Only the decorative accent bar is dimmed now; the "Coming soon"
+    // pill and the absent "Start codelab →" carry the signal in text.
+    css('.cl-card--soon .cl-accent').styles(opacity: 0.45),
     css('.cl-accent').styles(height: 3.px, width: 100.percent),
     css('.cl-card-body').styles(
       display: Display.flex,
@@ -269,9 +283,15 @@ class CodelabsPage extends StatelessComponent {
     ),
 
     // ---- meta row ----
+    // Wraps on purpose: `.cl-card` is `overflow: hidden`, so a non-wrapping row
+    // clipped the "Coming soon" pill off a narrow card — and that pill is the
+    // only signal that the codelab does not exist yet.
+    // white70, not white50: at 0.75rem this is normal-size text, and white50 on
+    // the card sits at ~4.2:1, under the 4.5:1 AA floor.
     css('.cl-meta').styles(
       display: Display.flex,
       flexDirection: FlexDirection.row,
+      flexWrap: FlexWrap.wrap,
       alignItems: AlignItems.center,
       gap: Gap.all(0.45.rem),
       fontFamily: Brand.fontSans,
@@ -279,9 +299,9 @@ class CodelabsPage extends StatelessComponent {
       fontWeight: FontWeight.w600,
       letterSpacing: 0.06.em,
       textTransform: TextTransform.upperCase,
-      color: Brand.white50,
+      color: Brand.white70,
     ),
-    css('.cl-dot').styles(color: Brand.white50),
+    css('.cl-dot').styles(color: Brand.white70),
     css('.cl-soon').styles(
       margin: Margin.only(left: Unit.auto),
       padding: Padding.symmetric(horizontal: 0.5.rem, vertical: 0.15.rem),

--- a/website/lib/codelabs/codelabs_page.dart
+++ b/website/lib/codelabs/codelabs_page.dart
@@ -1,0 +1,341 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../landing/sections/nav_bar.dart';
+import '../landing/sections/site_footer.dart';
+import '../theme/brand.dart';
+
+/// One entry in the codelab catalogue.
+///
+/// [href] is null for a codelab that is not written yet: the card renders as
+/// "Coming soon" and is deliberately NOT a link, so nothing on this page can
+/// lead to an empty page.
+class _Codelab {
+  const _Codelab({
+    required this.title,
+    required this.blurb,
+    required this.duration,
+    required this.level,
+    required this.tags,
+    required this.accent,
+    this.href,
+  });
+
+  final String title;
+  final String blurb;
+
+  /// Rough time to complete, e.g. `30 min`.
+  final String duration;
+
+  /// `Beginner` / `Intermediate` / `Advanced`.
+  final String level;
+
+  final List<String> tags;
+  final Color accent;
+  final String? href;
+
+  bool get isPublished => href != null;
+}
+
+/// `/codelabs` — the catalogue that the nav's "Codelabs" link opens.
+///
+/// The codelabs themselves are static claat exports living at
+/// `/codelabs/<id>/`; this page is a plain Jaspr route rendered into
+/// `codelabs/index.html`, so the two never collide.
+class CodelabsPage extends StatelessComponent {
+  const CodelabsPage({super.key});
+
+  /// Ordered as a learning path, not a feature list: start, then model
+  /// capabilities, then the pipelines that combine them.
+  static const _items = <_Codelab>[
+    _Codelab(
+      title: 'Getting Started with On-Device LLMs in Flutter',
+      blurb:
+          'Install flutter_gemma, pick and download a model, and stream your '
+          'first reply — with a progress bar that survives a cold start.',
+      duration: '30 min',
+      level: 'Beginner',
+      tags: ['flutter_gemma', 'Gemma 3', 'streaming'],
+      accent: Brand.blue,
+    ),
+    _Codelab(
+      title: 'Multimodal Inference in Flutter: Vision and Audio on Device',
+      blurb:
+          'Send images and audio to Gemma 3n and Gemma 4, and learn which '
+          'platforms accelerate them — and why a simulator is not a device.',
+      duration: '45 min',
+      level: 'Intermediate',
+      tags: ['vision', 'audio', 'Gemma 4'],
+      accent: Brand.orange,
+    ),
+    _Codelab(
+      title: 'Function Calling with On-Device Models in Flutter',
+      blurb:
+          'Declare Dart functions the model can call, drive the call/response '
+          'loop, and watch it reason first with thinking mode.',
+      duration: '45 min',
+      level: 'Intermediate',
+      tags: ['function calling', 'tools', 'thinking mode'],
+      accent: Brand.green,
+    ),
+    _Codelab(
+      title: 'On-Device RAG in Flutter: Embeddings and Vector Search',
+      blurb:
+          'Embed your own documents with EmbeddingGemma, store the vectors in '
+          'sqlite-vec, and ground the answers — no network at any step.',
+      duration: '60 min',
+      level: 'Advanced',
+      tags: ['embeddings', 'sqlite-vec', 'RAG'],
+      accent: Brand.green,
+    ),
+    _Codelab(
+      title: 'Building an Offline Voice Assistant in Flutter: STT, LLM, and TTS',
+      blurb:
+          'Wire speech-to-text, the model, and text-to-speech into one loop '
+          'that runs in airplane mode — including barge-in.',
+      duration: '60 min',
+      level: 'Advanced',
+      tags: ['STT', 'TTS', 'voice loop'],
+      accent: Brand.orange,
+    ),
+    _Codelab(
+      title: 'Hybrid AI in Flutter: From Cloud to On-Device with Genkit Dart',
+      blurb:
+          'Build an offline travel guide that routes each message between '
+          'Gemini and on-device Gemma — five policies, images, and RAG.',
+      duration: '90 min',
+      level: 'Advanced',
+      tags: ['Genkit', 'hybrid routing', 'RAG'],
+      accent: Brand.blue,
+      href: '/codelabs/hybrid-ai-flutter-genkit/',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return main_(classes: 'landing-root codelabs-root', [
+      const NavBar(),
+      section(classes: 'cl-head', [
+        div(classes: 'cl-head-inner', [
+          p(classes: 'cl-eyebrow', [Component.text('Codelabs')]),
+          h1(classes: 'cl-title', [
+            Component.text('Build something that runs on the device'),
+          ]),
+          p(classes: 'cl-standfirst', [
+            Component.text(
+              'Hands-on, step-by-step guides for running language models '
+              'inside a Flutter app, ordered from first run to full '
+              'pipelines. The hybrid-AI codelab is ready to take now; the '
+              'rest are being written.',
+            ),
+          ]),
+        ]),
+      ]),
+      section(classes: 'cl-grid-wrap', [
+        div(classes: 'cl-grid', [
+          for (final c in _items) _card(c),
+        ]),
+      ]),
+      const SiteFooter(),
+    ]);
+  }
+
+  /// A published codelab is an `<a>`; an unwritten one is a `<div>` so it is
+  /// not focusable and cannot be followed.
+  static Component _card(_Codelab c) {
+    final children = <Component>[
+      div(
+        classes: 'cl-accent',
+        styles: Styles(raw: {'background': c.accent.value}),
+        [],
+      ),
+      div(classes: 'cl-card-body', [
+        div(classes: 'cl-meta', [
+          span(classes: 'cl-level', [Component.text(c.level)]),
+          span(classes: 'cl-dot', [Component.text('·')]),
+          span(classes: 'cl-duration', [Component.text(c.duration)]),
+          if (!c.isPublished) span(classes: 'cl-soon', [Component.text('Coming soon')]),
+        ]),
+        h2(classes: 'cl-card-title', [Component.text(c.title)]),
+        p(classes: 'cl-blurb', [Component.text(c.blurb)]),
+        div(classes: 'cl-tags', [
+          for (final t in c.tags) span(classes: 'cl-tag', [Component.text(t)]),
+        ]),
+        if (c.isPublished) span(classes: 'cl-start', [Component.text('Start codelab →')]),
+      ]),
+    ];
+
+    return c.isPublished
+        ? a(href: c.href!, classes: 'cl-card cl-card--live', children)
+        : div(classes: 'cl-card cl-card--soon', children);
+  }
+
+  @css
+  static List<StyleRule> get styles => [
+    css('.codelabs-root').styles(
+      backgroundColor: Brand.navy,
+      minHeight: 100.vh,
+    ),
+
+    // ---- header ----
+    css('.cl-head').styles(
+      padding: Padding.symmetric(horizontal: 2.rem, vertical: 4.rem),
+    ),
+    css('.cl-head-inner').styles(
+      maxWidth: 760.px,
+      margin: Margin.symmetric(horizontal: Unit.auto),
+      display: Display.flex,
+      flexDirection: FlexDirection.column,
+      gap: Gap.all(1.rem),
+    ),
+    css('.cl-eyebrow').styles(
+      margin: Margin.zero,
+      fontFamily: Brand.fontSans,
+      fontSize: 0.8.rem,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.14.em,
+      textTransform: TextTransform.upperCase,
+      color: Brand.blueLight,
+    ),
+    css('.cl-title').styles(
+      margin: Margin.zero,
+      fontFamily: Brand.fontSans,
+      fontSize: 2.6.rem,
+      fontWeight: FontWeight.w700,
+      lineHeight: 1.1.em,
+      letterSpacing: (-0.02).em,
+      color: Brand.white,
+    ),
+    css('.cl-standfirst').styles(
+      margin: Margin.zero,
+      fontFamily: Brand.fontSans,
+      fontSize: 1.05.rem,
+      lineHeight: 1.6.em,
+      color: Brand.white70,
+    ),
+
+    // ---- grid ----
+    css('.cl-grid-wrap').styles(
+      padding: Padding.only(
+        left: 2.rem,
+        right: 2.rem,
+        bottom: 5.rem,
+      ),
+    ),
+    css('.cl-grid').styles(
+      maxWidth: 1100.px,
+      margin: Margin.symmetric(horizontal: Unit.auto),
+      display: Display.grid,
+      gap: Gap.all(1.25.rem),
+      raw: {'grid-template-columns': 'repeat(auto-fit, minmax(320px, 1fr))'},
+    ),
+
+    // ---- card ----
+    css('.cl-card').styles(
+      display: Display.flex,
+      flexDirection: FlexDirection.column,
+      overflow: Overflow.hidden,
+      backgroundColor: Brand.navyLight,
+      radius: BorderRadius.circular(10.px),
+      border: Border.all(color: Color('rgba(255,255,255,0.08)'), width: 1.px),
+      textDecoration: TextDecoration.none,
+    ),
+    css('.cl-card--live').styles(
+      raw: {'transition': 'transform .15s ease, border-color .15s ease'},
+    ),
+    css('.cl-card--live:hover').styles(
+      transform: Transform.translate(y: (-3).px),
+      border: Border.all(color: Color('rgba(147,197,253,0.55)'), width: 1.px),
+    ),
+    css('.cl-card--soon').styles(raw: {'opacity': '0.62'}),
+    css('.cl-accent').styles(height: 3.px, width: 100.percent),
+    css('.cl-card-body').styles(
+      display: Display.flex,
+      flexDirection: FlexDirection.column,
+      gap: Gap.all(0.7.rem),
+      padding: Padding.all(1.4.rem),
+    ),
+
+    // ---- meta row ----
+    css('.cl-meta').styles(
+      display: Display.flex,
+      flexDirection: FlexDirection.row,
+      alignItems: AlignItems.center,
+      gap: Gap.all(0.45.rem),
+      fontFamily: Brand.fontSans,
+      fontSize: 0.75.rem,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.06.em,
+      textTransform: TextTransform.upperCase,
+      color: Brand.white50,
+    ),
+    css('.cl-dot').styles(color: Brand.white50),
+    css('.cl-soon').styles(
+      margin: Margin.only(left: Unit.auto),
+      padding: Padding.symmetric(horizontal: 0.5.rem, vertical: 0.15.rem),
+      backgroundColor: Color('rgba(255,255,255,0.10)'),
+      radius: BorderRadius.circular(999.px),
+      color: Brand.white70,
+      letterSpacing: 0.04.em,
+    ),
+
+    css('.cl-card-title').styles(
+      margin: Margin.zero,
+      fontFamily: Brand.fontSans,
+      fontSize: 1.15.rem,
+      fontWeight: FontWeight.w700,
+      lineHeight: 1.3.em,
+      letterSpacing: (-0.01).em,
+      color: Brand.white,
+    ),
+    css('.cl-blurb').styles(
+      margin: Margin.zero,
+      fontFamily: Brand.fontSans,
+      fontSize: 0.93.rem,
+      lineHeight: 1.55.em,
+      color: Brand.white70,
+    ),
+
+    // ---- tags ----
+    css('.cl-tags').styles(
+      display: Display.flex,
+      flexWrap: FlexWrap.wrap,
+      gap: Gap.all(0.4.rem),
+      margin: Margin.only(top: 0.15.rem),
+    ),
+    css('.cl-tag').styles(
+      padding: Padding.symmetric(horizontal: 0.55.rem, vertical: 0.2.rem),
+      backgroundColor: Color('rgba(255,255,255,0.07)'),
+      radius: BorderRadius.circular(4.px),
+      fontFamily: Brand.fontMono,
+      fontSize: 0.72.rem,
+      color: Brand.white70,
+    ),
+
+    css('.cl-start').styles(
+      margin: Margin.only(top: 0.35.rem),
+      fontFamily: Brand.fontSans,
+      fontSize: 0.9.rem,
+      fontWeight: FontWeight.w600,
+      color: Brand.blueLight,
+    ),
+
+    // ---- narrow screens ----
+    StyleRule.media(
+      query: MediaQuery.screen(maxWidth: 640.px),
+      styles: [
+        css('.cl-head').styles(
+          padding: Padding.symmetric(horizontal: 1.25.rem, vertical: 2.5.rem),
+        ),
+        css('.cl-title').styles(fontSize: 1.9.rem),
+        css('.cl-grid-wrap').styles(
+          padding: Padding.only(
+            left: 1.25.rem,
+            right: 1.25.rem,
+            bottom: 3.rem,
+          ),
+        ),
+      ],
+    ),
+  ];
+}

--- a/website/lib/codelabs/codelabs_page.dart
+++ b/website/lib/codelabs/codelabs_page.dart
@@ -59,14 +59,15 @@ class CodelabsPage extends StatelessComponent {
       accent: Brand.blue,
     ),
     _Codelab(
-      title: 'Swapping Inference Engines in Flutter: LiteRT-LM, MediaPipe, and ONNX',
+      title: 'Inference Engines in Flutter: From a Downloaded Model to Built-in AI',
       blurb:
-          'Engines are opt-in packages registered at startup. Declare a file '
-          'type, let the registry pick the runtime, and run the same '
-          'inference code on a different engine — or on no model file at all.',
+          'LiteRT-LM runs a .litertlm file you ship or download. Built-in AI '
+          'runs Gemini Nano and Apple Foundation Models with nothing to '
+          'download at all — the OS owns the weights. Register either engine '
+          'at startup; the inference code never changes.',
       duration: '45 min',
       level: 'Intermediate',
-      tags: ['engines', 'MediaPipe', 'ONNX'],
+      tags: ['LiteRT-LM', 'built-in AI', 'Gemini Nano'],
       accent: Brand.green,
     ),
     _Codelab(

--- a/website/lib/codelabs/codelabs_page.dart
+++ b/website/lib/codelabs/codelabs_page.dart
@@ -59,6 +59,17 @@ class CodelabsPage extends StatelessComponent {
       accent: Brand.blue,
     ),
     _Codelab(
+      title: 'Swapping Inference Engines in Flutter: LiteRT-LM, MediaPipe, and ONNX',
+      blurb:
+          'Engines are opt-in packages registered at startup. Declare a file '
+          'type, let the registry pick the runtime, and run the same '
+          'inference code on a different engine — or on no model file at all.',
+      duration: '45 min',
+      level: 'Intermediate',
+      tags: ['engines', 'MediaPipe', 'ONNX'],
+      accent: Brand.green,
+    ),
+    _Codelab(
       title: 'Multimodal Inference in Flutter: Vision and Audio on Device',
       blurb:
           'Send images and audio to Gemma 3n and Gemma 4, and learn which '

--- a/website/lib/codelabs/codelabs_page.dart
+++ b/website/lib/codelabs/codelabs_page.dart
@@ -39,9 +39,11 @@ class _Codelab {
 
 /// `/codelabs` — the catalogue that the nav's "Codelabs" link opens.
 ///
-/// The codelabs themselves are static claat exports living at
-/// `/codelabs/<id>/`; this page is a plain Jaspr route rendered into
-/// `codelabs/index.html`, so the two never collide.
+/// The codelabs themselves are static claat exports written to the directory
+/// `codelabs/<id>/`; this page is a plain Jaspr route rendered into
+/// `codelabs/index.html`, so the two never collide. Their [href]s are
+/// slash-less all the same — `cleanUrls` serves the directory index at
+/// `/codelabs/<id>` and `trailingSlash: false` 301s the slashed form.
 class CodelabsPage extends StatelessComponent {
   const CodelabsPage({super.key});
 
@@ -121,7 +123,7 @@ class CodelabsPage extends StatelessComponent {
       level: 'Advanced',
       tags: ['Genkit', 'hybrid routing', 'RAG'],
       accent: Brand.blue,
-      href: '/codelabs/hybrid-ai-flutter-genkit/',
+      href: '/codelabs/hybrid-ai-flutter-genkit',
     ),
   ];
 

--- a/website/lib/landing/sections/nav_bar.dart
+++ b/website/lib/landing/sections/nav_bar.dart
@@ -16,7 +16,7 @@ class NavBar extends StatelessComponent {
 
   static const _links = <({String text, String href, bool external, bool cta})>[
     (text: 'Docs', href: '/docs/getting-started', external: false, cta: false),
-    (text: 'Codelabs', href: '/codelabs/hybrid-ai-flutter-genkit/', external: false, cta: false),
+    (text: 'Codelabs', href: '/codelabs/', external: false, cta: false),
     (text: 'Models', href: '#models', external: false, cta: false),
     (
       text: 'GitHub',

--- a/website/lib/landing/sections/nav_bar.dart
+++ b/website/lib/landing/sections/nav_bar.dart
@@ -16,8 +16,13 @@ class NavBar extends StatelessComponent {
 
   static const _links = <({String text, String href, bool external, bool cta})>[
     (text: 'Docs', href: '/docs/getting-started', external: false, cta: false),
-    (text: 'Codelabs', href: '/codelabs/', external: false, cta: false),
-    (text: 'Models', href: '#models', external: false, cta: false),
+    // Slash-less: firebase.json sets `trailingSlash: false`, so `/codelabs/`
+    // would 301 to `/codelabs` on every click.
+    (text: 'Codelabs', href: '/codelabs', external: false, cta: false),
+    // Root-anchored on purpose. The `id="models"` target lives in
+    // models_gallery.dart, which only LandingPage renders — a bare `#models`
+    // resolves against the current page and does nothing from /codelabs.
+    (text: 'Models', href: '/#models', external: false, cta: false),
     (
       text: 'GitHub',
       href: 'https://github.com/DenisovAV/flutter_gemma',

--- a/website/lib/main.server.dart
+++ b/website/lib/main.server.dart
@@ -39,6 +39,22 @@ const String _codelabsDescription =
     'Flutter app — on-device inference, multimodal input, function calling, '
     'RAG, voice, and hybrid cloud/on-device routing with Genkit.';
 
+/// JSON-LD for `/codelabs`.
+///
+/// Without this the route falls back to `seo.dart`'s site-wide
+/// `SoftwareApplication` schema, whose `url` is the site origin — publishing
+/// the same package entity from two different pages. A `CollectionPage` is what
+/// this page actually is: a listing whose items are the codelabs. Deliberately
+/// minimal — no `ItemList`, because six of the seven entries have no URL yet
+/// and listing them would assert pages that do not exist.
+const Map<String, Object?> _codelabsCollectionSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  'name': 'flutter_gemma Codelabs',
+  'description': _codelabsDescription,
+  'url': '$kSiteOrigin/codelabs',
+};
+
 void main() {
   // Initializes the server environment with the generated default options.
   Jaspr.initializeApp(
@@ -106,12 +122,12 @@ void main() {
                 SidebarGroup(
                   title: 'Workshop',
                   links: [
-                    // Static claat export under /codelabs/ (see deploy.sh), not a
-                    // Jaspr route — a plain href leaves the SPA into the codelab.
-                    SidebarLink(
-                      text: 'Hybrid AI Codelab',
-                      href: '/codelabs/hybrid-ai-flutter-genkit/',
-                    ),
+                    // Points at the catalogue, the same place the nav's
+                    // "Codelabs" link goes — the two surfaces must not disagree.
+                    // `/codelabs` is a Jaspr route (it owns codelabs/index.html);
+                    // the codelabs themselves are static claat exports under
+                    // codelabs/<id>/ (see deploy.sh).
+                    SidebarLink(text: 'Codelabs', href: '/codelabs'),
                   ],
                 ),
                 SidebarGroup(
@@ -217,6 +233,8 @@ void main() {
           // The codelab catalogue. The codelabs themselves are static claat
           // exports dropped into `codelabs/<id>/` after `jaspr build`, so this
           // route owns only `codelabs/index.html` and the two never collide.
+          // Path is slash-less to agree with `trailingSlash: false`
+          // (firebase.json), the generated sitemap, and the nav link.
           Route(
             path: '/codelabs',
             builder: (context, state) => Document(
@@ -226,7 +244,8 @@ void main() {
               head: seoHead(
                 title: 'Codelabs — flutter_gemma',
                 description: _codelabsDescription,
-                path: '/codelabs/',
+                path: '/codelabs',
+                structuredData: _codelabsCollectionSchema,
               ),
               body: const CodelabsPage(),
             ),

--- a/website/lib/main.server.dart
+++ b/website/lib/main.server.dart
@@ -19,6 +19,7 @@ import 'package:jaspr_content/jaspr_content.dart';
 import 'package:jaspr_content/theme.dart';
 import 'package:jaspr_router/jaspr_router.dart';
 
+import 'codelabs/codelabs_page.dart';
 import 'components/clicker.dart';
 import 'landing/landing_page.dart';
 import 'seo.dart';
@@ -32,6 +33,11 @@ const String _landingDescription =
     'Android, iOS, Web, and Desktop. Multimodal vision & audio, '
     'function calling, on-device agent skills, thinking mode, '
     'GPU acceleration, embeddings, and RAG.';
+
+const String _codelabsDescription =
+    'Hands-on, step-by-step guides for running language models inside a '
+    'Flutter app — on-device inference, multimodal input, function calling, '
+    'RAG, voice, and hybrid cloud/on-device routing with Genkit.';
 
 void main() {
   // Initializes the server environment with the generated default options.
@@ -206,6 +212,23 @@ void main() {
                 path: '/',
               ),
               body: const LandingPage(),
+            ),
+          ),
+          // The codelab catalogue. The codelabs themselves are static claat
+          // exports dropped into `codelabs/<id>/` after `jaspr build`, so this
+          // route owns only `codelabs/index.html` and the two never collide.
+          Route(
+            path: '/codelabs',
+            builder: (context, state) => Document(
+              title: 'Codelabs — flutter_gemma',
+              lang: 'en',
+              meta: const {'description': _codelabsDescription},
+              head: seoHead(
+                title: 'Codelabs — flutter_gemma',
+                description: _codelabsDescription,
+                path: '/codelabs/',
+              ),
+              body: const CodelabsPage(),
             ),
           ),
           for (final group in routes) ...group,

--- a/website/lib/main.server.options.dart
+++ b/website/lib/main.server.options.dart
@@ -5,6 +5,8 @@
 // Generated with jaspr_builder
 
 import 'package:jaspr/server.dart';
+import 'package:fluttergemma_website/codelabs/codelabs_page.dart'
+    as _codelabs_page;
 import 'package:fluttergemma_website/components/clicker.dart' as _clicker;
 import 'package:fluttergemma_website/landing/sections/cta_section.dart'
     as _cta_section;
@@ -81,6 +83,7 @@ ServerOptions get defaultServerOptions => ServerOptions(
     ),
   },
   styles: () => [
+    ..._codelabs_page.CodelabsPage.styles,
     ..._clicker.ClickerState.styles,
     ..._landing_page.LandingPage.styles,
     ..._cta_section.CtaSection.styles,


### PR DESCRIPTION
## Why

The nav's **Codelabs** link jumped straight into `/codelabs/hybrid-ai-flutter-genkit/` — the single codelab that exists. There was nowhere to put a second one, and no page that says what else is coming.

## What this adds

`/codelabs` is now a catalogue. Seven entries, ordered as a learning path rather than a feature list — first run, then the runtime question, then model capabilities, then the pipelines that combine them:

| | Codelab | |
|---|---|---|
| 1 | Getting Started with On-Device LLMs in Flutter | Beginner · 30 min |
| 2 | Inference Engines in Flutter: From a Downloaded Model to Built-in AI | Intermediate · 45 min |
| 3 | Multimodal Inference in Flutter: Vision and Audio on Device | Intermediate · 45 min |
| 4 | Function Calling with On-Device Models in Flutter | Intermediate · 45 min |
| 5 | On-Device RAG in Flutter: Embeddings and Vector Search | Advanced · 60 min |
| 6 | Building an Offline Voice Assistant in Flutter: STT, LLM, and TTS | Advanced · 60 min |
| 7 | **Hybrid AI in Flutter: From Cloud to On-Device with Genkit Dart** | Advanced · 90 min — **live** |

Entry 2 is deliberately scoped to LiteRT-LM against built-in AI: a `.litertlm` you download versus Gemini Nano / Apple Foundation Models, where there is no file to download because the OS owns the weights. MediaPipe (`.task`) is the legacy path and ONNX is host-gated, so neither belongs in a reader's first look at engines.

The six unwritten entries are placeholders. Each renders as a `div`, not an `a` — a card with nothing behind it cannot be clicked or focused, so nothing on the page leads to an empty page. The standfirst says plainly that one is ready today and the rest are being written.

## How it fits the existing build

The codelabs themselves stay static claat exports. `jaspr build` writes `codelabs/index.html` for this route; `claat export` then drops each codelab into `codelabs/<id>/`. Verified locally that the export leaves the catalogue **byte-identical** (48922 bytes before and after), so `deploy.sh` and both CI workflows need no change — their existing order already runs the Jaspr build first.

`main.server.options.dart` is regenerated and committed because it is what collects the page's `@css` styles; without it the catalogue would ship unstyled.

Built and rendered locally: `dart analyze lib` clean, the live card links to the existing codelab, and the nav now points at `/codelabs/`.