### PR TITLE
docs(embeddings): document the bare-content tokenizer contract in the README

### DIFF
--- a/packages/flutter_gemma_embeddings/README.md
+++ b/packages/flutter_gemma_embeddings/README.md
@@ -113,6 +113,21 @@ That library is native-only, which is why it sits outside the package barrel.
 engine's web arm can apply the same rule) reads exactly those two blocks, and
 requires both: plenty of models declare one alone.
 
+### What the tokenizer loaders return
+
+Both loaders return a tokenizer with any `padding` and `truncation` the file
+declares switched OFF: `encode()` gives back bare content, never a fixed-width
+row. Width and terminators belong to the profile — `encodeForSiglipEmbedding`
+applies SigLIP2's 64-token rule itself — and to the forward pass, which owns the
+engine's compiled `seqLen`.
+
+This matters if you build a `ForwardPassDescriptor` by hand: do not expect the
+file's `"padding": {"strategy": {"Fixed": 64}}` to have been applied for you.
+
+The loaders throw `StateError` if the resolved `dart_sentencepiece_tokenizer`
+accepts the calls that disable those settings and leaves them set anyway. That
+is a check on the tokenizer's config, not a guarantee about `encode()`'s output.
+
 ### The task-type prefix
 
 `TaskType` has two values and both prefixes are non-empty, and


### PR DESCRIPTION
Follow-up to #490, before publishing 2.1.1.

#490 changed what `loadEmbeddingTokenizer` and both profile loaders return: any
`padding` and `truncation` the `tokenizer.json` declares is switched off, so
`encode()` hands back bare content, and the loader throws `StateError` if the
resolved `dart_sentencepiece_tokenizer` accepts those calls and leaves the
settings set anyway.

That went into `website/content/docs`, but not into the package README — which is
the pub.dev landing page and the only doc that ships inside the archive. The
release guard caught it at publish time.

It matters for the workflow this README section exists to describe: building a
`ForwardPassDescriptor` by hand for the SigLIP2 profile. A caller who expects the
file's `{"Fixed": 64}` padding to have been applied gets bare content instead,
with nothing to tell them why.

No version bump and no CHANGELOG line: 2.1.1 is not published yet, so this ships
inside it, and it is the same issue that entry already covers.