### PR TITLE
The multimodal codelab's starter is its own app, not a copy of another codelab's

### DIFF
--- a/codelabs/multimodal-flutter-gemma/complete/lib/main.dart
+++ b/codelabs/multimodal-flutter-gemma/complete/lib/main.dart
@@ -17,9 +17,9 @@ Future<void> main() async {
   // Without LiteRtLmEngine here, the first model call throws a StateError
   // that tells you to add an engine package.
   //
-  // No `huggingFaceToken:` — both models this codelab uses from Step 2 on are
-  // ungated. (Step 1 inherits Gemma 3 1B from Getting Started, and that repo
-  // IS behind a licence gate: it needs `--dart-define=HF_TOKEN=hf_...`.)
+  // No Hugging Face token is passed, and none is needed: both repositories
+  // this codelab downloads from are ungated, so every step in it runs on a
+  // plain `flutter run` with no `--dart-define`.
   //
   // Guarded, because every other failure in this app reaches the screen — the
   // gate's error card, the chat's load error, the notice line — and this is the

--- a/codelabs/multimodal-flutter-gemma/step_01_starter/lib/download_page.dart
+++ b/codelabs/multimodal-flutter-gemma/step_01_starter/lib/download_page.dart
@@ -5,8 +5,9 @@ import 'model.dart';
 
 /// Installs the model file, reporting progress as it goes.
 ///
-/// Nothing here is Gemma-specific: `installModel` takes the model's identity
-/// (what it is) and `fromNetwork` takes the source (where the bytes are).
+/// Nothing here is multimodal-specific: `installModel` takes the model's
+/// identity (what it is) and `fromNetwork` takes the source (where the bytes
+/// are). A vision model installs exactly like a text one.
 class DownloadPage extends StatefulWidget {
   const DownloadPage({
     super.key,
@@ -36,21 +37,14 @@ class _DownloadPageState extends State<DownloadPage> {
 
     try {
       await FlutterGemma.installModel(
-            // What the model IS — used to pick the right chat template.
-            modelType: widget.model.modelType,
-            // Which runtime reads it. `.litertlm` routes to LiteRtLmEngine;
-            // the default is `task` (MediaPipe), so this line is load-bearing.
-            fileType: ModelFileType.litertlm,
-          )
-          // No `token:` here — the Hugging Face token passed to
-          // FlutterGemma.initialize() is attached automatically, and only to
-          // URLs whose host contains `huggingface.co`, so it does not ride
-          // along to the other hosts an app downloads from.
-          .fromNetwork(widget.model.url)
-          .withProgress((percent) {
-            if (mounted) setState(() => _percent = percent);
-          })
-          .install();
+        // What the model IS — used to pick the right chat template.
+        modelType: widget.model.modelType,
+        // Which runtime reads it. `.litertlm` routes to LiteRtLmEngine;
+        // the default is `task` (MediaPipe), so this line is load-bearing.
+        fileType: ModelFileType.litertlm,
+      ).fromNetwork(widget.model.url).withProgress((percent) {
+        if (mounted) setState(() => _percent = percent);
+      }).install();
 
       if (mounted) widget.onInstalled();
     } catch (error) {
@@ -94,10 +88,7 @@ class _DownloadPageState extends State<DownloadPage> {
                   ),
                 if (_error != null) ...[
                   const SizedBox(height: 16),
-                  _ErrorCard(
-                    error: _error!,
-                    requiresToken: widget.model.requiresToken,
-                  ),
+                  _ErrorCard(error: _error!),
                 ],
               ],
             ),
@@ -108,27 +99,19 @@ class _DownloadPageState extends State<DownloadPage> {
   }
 }
 
-/// A failed download is usually one of two things, and the message says which.
+/// Says what failed, in the plugin's own words where it has any.
 class _ErrorCard extends StatelessWidget {
-  const _ErrorCard({required this.error, required this.requiresToken});
+  const _ErrorCard({required this.error});
 
   final Object error;
-  final bool requiresToken;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     // The plugin reports a failed download as a typed `DownloadException`
     // wrapping a sealed `DownloadError`, so match on the type rather than
-    // sniffing the message for "401".
+    // sniffing the message for a status code.
     final (title, body) = switch (error) {
-      DownloadException(error: UnauthorizedError() || ForbiddenError())
-          when requiresToken =>
-        (
-          'Hugging Face refused the download',
-          'Accept the model licence on its Hugging Face page, then run with '
-              '--dart-define=HF_TOKEN=hf_your_token.',
-        ),
       DownloadException(:final error) => (
         'Download failed',
         error.toUserMessage(),

--- a/codelabs/multimodal-flutter-gemma/step_01_starter/lib/main.dart
+++ b/codelabs/multimodal-flutter-gemma/step_01_starter/lib/main.dart
@@ -6,12 +6,9 @@ import 'chat_page.dart';
 import 'download_page.dart';
 import 'model.dart';
 
-/// Supplied at run time, never committed:
-///   flutter run --dart-define=HF_TOKEN=hf_your_token
-const _hfToken = String.fromEnvironment('HF_TOKEN');
-
-/// Change this one line to run the whole app on a different model.
-const _model = Models.gemma3;
+/// The model this step runs. Step 3 needs one that can also hear, and pays
+/// for it.
+const _model = Models.smolVlm2;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -19,21 +16,60 @@ Future<void> main() async {
   // Engines are fully opt-in: the core package registers none by itself.
   // Without LiteRtLmEngine here, the first model call throws a StateError
   // that tells you to add an engine package.
-  await FlutterGemma.initialize(
-    inferenceEngines: [LiteRtLmEngine()],
-    huggingFaceToken: _hfToken.isEmpty ? null : _hfToken,
-  );
+  //
+  // No Hugging Face token is passed, and none is needed: both repositories
+  // this codelab downloads from are ungated, so every step in it runs on a
+  // plain `flutter run` with no `--dart-define`.
+  //
+  // Guarded, because every other failure in this app reaches the screen — the
+  // gate's error card, the chat's load error, the notice line — and this is the
+  // earliest one, so it is the one a learner meets first. Hot-restarting after
+  // adding a plugin throws `MissingPluginException` right here; unguarded, it
+  // never reaches `runApp` and the symptom is a blank window and a stack trace
+  // in a console nobody is looking at.
+  try {
+    await FlutterGemma.initialize(inferenceEngines: [LiteRtLmEngine()]);
+  } catch (error) {
+    runApp(_StartupFailed(error: error));
+    return;
+  }
 
-  runApp(const QuickstartApp());
+  runApp(const MultimodalApp());
 }
 
-class QuickstartApp extends StatelessWidget {
-  const QuickstartApp({super.key});
+/// Shown in place of the app when `FlutterGemma.initialize` throws, so a
+/// failure before the first frame is a sentence instead of a blank window.
+class _StartupFailed extends StatelessWidget {
+  const _StartupFailed({required this.error});
+
+  final Object error;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Gemma Quickstart',
+      title: 'Gemma Multimodal',
+      home: Scaffold(
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'flutter_gemma could not start.\n$error',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class MultimodalApp extends StatelessWidget {
+  const MultimodalApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Gemma Multimodal',
       theme: ThemeData(colorSchemeSeed: Colors.indigo),
       home: const ModelGate(model: _model),
     );
@@ -59,7 +95,21 @@ class ModelGate extends StatefulWidget {
 class _ModelGateState extends State<ModelGate> {
   late Future<bool> _installed = _check();
 
-  Future<bool> _check() => FlutterGemma.isModelInstalled(widget.model.fileName);
+  /// Installed is not the same as active. This codelab puts two checkpoints in
+  /// one app, so the model `getActiveModel` opens is whichever was installed
+  /// LAST — which, after a trip through the other step, is the other model.
+  /// `install()` is idempotent: on a file already here it downloads nothing
+  /// and just records this model as the current one.
+  Future<bool> _check() async {
+    if (!await FlutterGemma.isModelInstalled(widget.model.fileName)) {
+      return false;
+    }
+    await FlutterGemma.installModel(
+      modelType: widget.model.modelType,
+      fileType: ModelFileType.litertlm,
+    ).fromNetwork(widget.model.url).install();
+    return true;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/codelabs/multimodal-flutter-gemma/step_01_starter/lib/model.dart
+++ b/codelabs/multimodal-flutter-gemma/step_01_starter/lib/model.dart
@@ -11,7 +11,6 @@ class ModelChoice {
     required this.fileName,
     required this.modelType,
     required this.sizeLabel,
-    required this.requiresToken,
   });
 
   final String label;
@@ -19,41 +18,39 @@ class ModelChoice {
   final String fileName;
   final ModelType modelType;
   final String sizeLabel;
-
-  /// Hugging Face serves this repo behind a licence gate. Accept the licence
-  /// once on the model page, then run with `--dart-define=HF_TOKEN=hf_...`.
-  final bool requiresToken;
 }
 
-/// The models this quickstart offers.
+/// The model this step runs.
 ///
-/// Both are `.litertlm`, the format the LiteRT-LM engine reads on Android,
-/// iOS, desktop and the web. (`.task` files are MediaPipe-only — a different
-/// engine package, and no desktop support.)
+/// The repository is ungated, so nothing here needs a Hugging Face token and
+/// no run needs `--dart-define`.
 abstract final class Models {
-  /// The plugin's namesake. `ekv4096` in the file name is the KV-cache the
-  /// weights were built for, so this model can carry a 4096-token context.
-  static const gemma3 = ModelChoice(
-    label: 'Gemma 3 1B',
+  /// A vision-language model small enough to feel like a text model. 0.36 GB
+  /// is roughly what a photo-heavy app already spends on its image cache, so
+  /// this is the version of "multimodal" you can put in a shipping app
+  /// without an argument about download size — about a minute of download,
+  /// and then it is looking at your photograph.
+  ///
+  /// It cannot hear, and that is not a gap in this step: it is a
+  /// vision-language model, and the plugin lists audio input for Gemma 4 and
+  /// Gemma 3n only (`flutter_gemma/README.md`). A session flag cannot switch
+  /// on an encoder the checkpoint does not carry. It is why Step 3
+  /// changes models, and it is the model half of the question `complete` asks
+  /// at the end — a half that says no here while the device, happily holding
+  /// a microphone, says yes.
+  /// Run on macOS 2026-09-07: installs (0.36 GB) and answers "RED" to a
+  /// 16x16 red square, with `supportImage` set on both `getActiveModel` and
+  /// `createChat`. Nothing in CI runs a model, so this line is the only
+  /// evidence these weights were ever executed.
+  static const smolVlm2 = ModelChoice(
+    label: 'SmolVLM2 500M',
     url:
-        'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/'
-        'Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm',
-    fileName: 'Gemma3-1B-IT_multi-prefill-seq_q4_ekv4096.litertlm',
-    modelType: ModelType.gemmaIt,
-    sizeLabel: '0.5 GB',
-    requiresToken: true,
-  );
-
-  /// No Hugging Face account? This repo is ungated. Same code path — the only
-  /// thing that changes is which constant you hand to the app.
-  static const qwen3 = ModelChoice(
-    label: 'Qwen3 0.6B',
-    url:
-        'https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/'
-        'Qwen3-0.6B.litertlm',
-    fileName: 'Qwen3-0.6B.litertlm',
-    modelType: ModelType.qwen3,
-    sizeLabel: '0.6 GB',
-    requiresToken: false,
+        'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/'
+        'SmolVLM2-500M.litertlm',
+    fileName: 'SmolVLM2-500M.litertlm',
+    // `general` and not `gemmaIt`: SmolVLM2 is not a Gemma, and the chat
+    // template that ships inside the `.litertlm` is the right one to use.
+    modelType: ModelType.general,
+    sizeLabel: '0.36 GB',
   );
 }

--- a/codelabs/multimodal-flutter-gemma/step_01_starter/lib/model.dart
+++ b/codelabs/multimodal-flutter-gemma/step_01_starter/lib/model.dart
@@ -48,8 +48,13 @@ abstract final class Models {
         'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/'
         'SmolVLM2-500M.litertlm',
     fileName: 'SmolVLM2-500M.litertlm',
-    // `general` and not `gemmaIt`: SmolVLM2 is not a Gemma, and the chat
-    // template that ships inside the `.litertlm` is the right one to use.
+    // `general` and not `gemmaIt`, and the reason is not turn markers. For a
+    // `.litertlm` file the runtime owns the chat template on every platform
+    // this codelab targets except iOS (`extensions.dart:74-77` returns
+    // `raw`, which never consults this field). What the field still picks is
+    // what the SDK does to the reply on the way out: `gemmaIt` is on the
+    // thinking-tag-stripping list in `cleanResponse` and `general` is not.
+    // SmolVLM2 is not a Gemma, so it should not be post-processed as one.
     modelType: ModelType.general,
     sizeLabel: '0.36 GB',
   );

--- a/codelabs/multimodal-flutter-gemma/step_01_starter/test/widget_test.dart
+++ b/codelabs/multimodal-flutter-gemma/step_01_starter/test/widget_test.dart
@@ -6,11 +6,12 @@ import 'package:gemma_quickstart/model.dart';
 void main() {
   // `isModelInstalled` is keyed by file name. `install()` skips bytes it
   // already has, so a name that drifts from its URL does not re-download — it
-  // strands the app on a download screen the gate is never satisfied by.
-  test('every model id matches the last segment of its URL', () {
-    for (final model in [Models.gemma3, Models.qwen3]) {
-      expect(model.fileName, model.url.split('/').last, reason: model.label);
-    }
+  // strands the app on a download screen the gate is never satisfied by. It is
+  // a cheap mistake to make here and an expensive one to carry into Step 3,
+  // where the same gate stands in front of 2.59 GB.
+  test('the model id matches the last segment of its URL', () {
+    const model = Models.smolVlm2;
+    expect(model.fileName, model.url.split('/').last, reason: model.label);
   });
 
   testWidgets('the download screen offers the model before any plugin call', (
@@ -18,10 +19,10 @@ void main() {
   ) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: DownloadPage(model: Models.qwen3, onInstalled: () {}),
+        home: DownloadPage(model: Models.smolVlm2, onInstalled: () {}),
       ),
     );
-    expect(find.text('Qwen3 0.6B'), findsOneWidget);
+    expect(find.text('SmolVLM2 500M'), findsOneWidget);
     expect(find.text('Download model'), findsOneWidget);
   });
 }

--- a/codelabs/multimodal-flutter-gemma/step_02_vision/lib/main.dart
+++ b/codelabs/multimodal-flutter-gemma/step_02_vision/lib/main.dart
@@ -17,9 +17,9 @@ Future<void> main() async {
   // Without LiteRtLmEngine here, the first model call throws a StateError
   // that tells you to add an engine package.
   //
-  // No `huggingFaceToken:` — both models this codelab uses from Step 2 on are
-  // ungated. (Step 1 inherits Gemma 3 1B from Getting Started, and that repo
-  // IS behind a licence gate: it needs `--dart-define=HF_TOKEN=hf_...`.)
+  // No Hugging Face token is passed, and none is needed: both repositories
+  // this codelab downloads from are ungated, so every step in it runs on a
+  // plain `flutter run` with no `--dart-define`.
   //
   // Guarded, because every other failure in this app reaches the screen — the
   // gate's error card, the chat's load error, the notice line — and this is the

--- a/codelabs/multimodal-flutter-gemma/step_02_vision/lib/model.dart
+++ b/codelabs/multimodal-flutter-gemma/step_02_vision/lib/model.dart
@@ -48,8 +48,13 @@ abstract final class Models {
         'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/'
         'SmolVLM2-500M.litertlm',
     fileName: 'SmolVLM2-500M.litertlm',
-    // `general` and not `gemmaIt`: SmolVLM2 is not a Gemma, and the chat
-    // template that ships inside the `.litertlm` is the right one to use.
+    // `general` and not `gemmaIt`, and the reason is not turn markers. For a
+    // `.litertlm` file the runtime owns the chat template on every platform
+    // this codelab targets except iOS (`extensions.dart:74-77` returns
+    // `raw`, which never consults this field). What the field still picks is
+    // what the SDK does to the reply on the way out: `gemmaIt` is on the
+    // thinking-tag-stripping list in `cleanResponse` and `general` is not.
+    // SmolVLM2 is not a Gemma, so it should not be post-processed as one.
     modelType: ModelType.general,
     sizeLabel: '0.36 GB',
   );

--- a/codelabs/multimodal-flutter-gemma/step_03_audio/lib/main.dart
+++ b/codelabs/multimodal-flutter-gemma/step_03_audio/lib/main.dart
@@ -17,9 +17,9 @@ Future<void> main() async {
   // Without LiteRtLmEngine here, the first model call throws a StateError
   // that tells you to add an engine package.
   //
-  // No `huggingFaceToken:` — both models this codelab uses from Step 2 on are
-  // ungated. (Step 1 inherits Gemma 3 1B from Getting Started, and that repo
-  // IS behind a licence gate: it needs `--dart-define=HF_TOKEN=hf_...`.)
+  // No Hugging Face token is passed, and none is needed: both repositories
+  // this codelab downloads from are ungated, so every step in it runs on a
+  // plain `flutter run` with no `--dart-define`.
   //
   // Guarded, because every other failure in this app reaches the screen — the
   // gate's error card, the chat's load error, the notice line — and this is the

--- a/tool/check_codelabs.sh
+++ b/tool/check_codelabs.sh
@@ -122,6 +122,54 @@ for pair in "${MIRRORS[@]}"; do
   done
 done
 
+# Consecutive steps INSIDE one codelab, where the whole lesson is that almost
+# nothing changed. MIRRORS cannot express this: it compares a lib/ directory
+# whole, and here exactly one file has to differ — it is the step.
+#
+# Multimodal's Step 2 text tells the learner to diff the two apps and says
+# which files come back identical. That sentence is the evidence for the
+# codelab's central claim — a modality is a session flag, not a second model —
+# so it has to be enforced rather than believed. Add a comment to
+# step_01_starter/lib/main.dart, forget step_02_vision, and without this the
+# text goes quietly false while every other check stays green.
+#
+# `<src>|<dst>|<same...>|<differs>`: the files that must match, then the one
+# that must NOT. Both halves are asserted. Guarding only the first would let a
+# step that teaches nothing pass — if chat_page.dart ever matched too, Step 2
+# would have no diff at all, and that is just as wrong as drift.
+SHARED_STEPS=(
+  "codelabs/multimodal-flutter-gemma/step_01_starter|codelabs/multimodal-flutter-gemma/step_02_vision|lib/model.dart lib/main.dart lib/download_page.dart|lib/chat_page.dart"
+)
+
+# Fail closed, as above: an emptied table must not read as "every step holds".
+if [ "${#SHARED_STEPS[@]}" -eq 0 ]; then
+  echo "::error::SHARED_STEPS is empty — the within-codelab check cannot run"
+  exit 1
+fi
+
+for row in "${SHARED_STEPS[@]}"; do
+  IFS='|' read -r src dst same differs <<< "$row"
+  echo ""
+  echo "=== $dst shares all but $differs with $src ==="
+  for f in $same; do
+    # Fail closed: a renamed file must not read as "nothing to compare".
+    if [ ! -f "$src/$f" ] || [ ! -f "$dst/$f" ]; then
+      echo "::error::$src/$f or $dst/$f is missing — the shared-file check cannot run"
+      failed=1
+      continue
+    fi
+    diff "$src/$f" "$dst/$f" \
+      || { echo "::error::$dst/$f has drifted from $src/$f — the text says these are identical"; failed=1; }
+  done
+  if [ ! -f "$src/$differs" ] || [ ! -f "$dst/$differs" ]; then
+    echo "::error::$src/$differs or $dst/$differs is missing — the shared-file check cannot run"
+    failed=1
+  elif diff -q "$src/$differs" "$dst/$differs" >/dev/null; then
+    echo "::error::$dst/$differs is identical to $src/$differs — this step teaches nothing"
+    failed=1
+  fi
+done
+
 # One identity per codelab, and the two halves pull in opposite directions, so
 # both are asserted:
 #

--- a/tool/check_codelabs.sh
+++ b/tool/check_codelabs.sh
@@ -151,6 +151,17 @@ for row in "${SHARED_STEPS[@]}"; do
   IFS='|' read -r src dst same differs <<< "$row"
   echo ""
   echo "=== $dst shares all but $differs with $src ==="
+
+  # Fail closed on a half-emptied row, the way the table itself does above. An
+  # empty file list runs the loop below zero times and reports nothing, and an
+  # empty last field leaves the other half of the invariant unasserted — both
+  # read as "checked and fine" without a single comparison having happened.
+  if [ -z "$same" ] || [ -z "$differs" ]; then
+    echo "::error::the SHARED_STEPS row for $dst is missing a file list — the check cannot run"
+    failed=1
+    continue
+  fi
+
   for f in $same; do
     # Fail closed: a renamed file must not read as "nothing to compare".
     if [ ! -f "$src/$f" ] || [ ! -f "$dst/$f" ]; then
@@ -158,15 +169,30 @@ for row in "${SHARED_STEPS[@]}"; do
       failed=1
       continue
     fi
+    # Every non-zero status fails here — 1 (they differ) and 2 (could not be
+    # compared) alike — which is what makes this half safe by construction.
     diff "$src/$f" "$dst/$f" \
       || { echo "::error::$dst/$f has drifted from $src/$f — the text says these are identical"; failed=1; }
   done
+
   if [ ! -f "$src/$differs" ] || [ ! -f "$dst/$differs" ]; then
     echo "::error::$src/$differs or $dst/$differs is missing — the shared-file check cannot run"
     failed=1
-  elif diff -q "$src/$differs" "$dst/$differs" >/dev/null; then
-    echo "::error::$dst/$differs is identical to $src/$differs — this step teaches nothing"
-    failed=1
+  else
+    # The other half cannot be written the same way, because here a difference
+    # is the PASS. `diff` exits 0 identical, 1 different, and >1 when it could
+    # not compare at all — and `elif diff -q …; then` reads every non-zero
+    # alike, so an unreadable file (2) took the "they differ" branch and this
+    # invariant passed without having been checked. Status 1 has to be named.
+    # `|| status=$?` and not a bare call: under `set -e` an untested non-zero
+    # would abort the script before the case could run.
+    status=0
+    diff -q "$src/$differs" "$dst/$differs" >/dev/null || status=$?
+    case "$status" in
+      0) echo "::error::$dst/$differs is identical to $src/$differs — this step teaches nothing"; failed=1 ;;
+      1) ;;
+      *) echo "::error::diff could not compare $src/$differs with $dst/$differs (status $status)"; failed=1 ;;
+    esac
   fi
 done
 

--- a/tool/check_codelabs.sh
+++ b/tool/check_codelabs.sh
@@ -88,12 +88,14 @@ fi
 # starter IS an earlier codelab's finished app, and both texts tell the learner
 # so. Without this the property drifts the first time someone edits one side.
 #
-# One source can feed several starters — Getting Started's finished app is where
-# both of the codelabs that continue it begin — so this is a list of pairs, not
-# a map, and a new row is all a new continuation needs.
+# One source can feed several starters, so this is a list of pairs, not a map,
+# and a new row is all a new continuation needs. Only Inference Engines starts
+# from Getting Started's finished app today: Multimodal used to and no longer
+# does — its Step 1 is now its own Step 2 minus the vision flag, so that the
+# one thing changing between those two steps is the flag rather than the
+# checkpoint.
 MIRRORS=(
   "codelabs/getting-started-flutter-gemma/complete|codelabs/inference-engines-flutter-gemma/step_01_starter"
-  "codelabs/getting-started-flutter-gemma/complete|codelabs/multimodal-flutter-gemma/step_01_starter"
 )
 
 # Fail closed, the way discovery does above. An emptied or mistyped table must

--- a/website/codelabs/multimodal-flutter-gemma/index.md
+++ b/website/codelabs/multimodal-flutter-gemma/index.md
@@ -12,15 +12,16 @@ Duration: 3
 
 ### What you'll build
 
-The chat app from the *Getting Started* codelab, taught to send a **picture**
-and a **recording** to the model — and, at the end, taught to know where it
-cannot.
+A small on-device chat app, taught to send a **picture** and a **recording**
+to the model — and, at the end, taught to know where it cannot.
 
-Two models, and the second one is the point. Step 2 starts on **SmolVLM2
-500M**: 0.36 GB, about a minute of download, and the app is describing your
-own photograph. Step 3 wants audio — and no flag switches on an encoder the
-weights do not contain, so it moves to **Gemma 4 E2B**, 2.59 GB. Seven times
-the size, said plainly rather than in a footnote.
+Two models, and the second one is the point. Step 1 downloads **SmolVLM2
+500M** — 0.36 GB, about a minute — and chats with it in text. Step 2 sets one
+boolean, and that same file starts describing your own photograph: no second
+download, because the encoder was in there the whole time. Step 3 wants audio
+— and no flag switches on an encoder the weights do not contain, so it moves
+to **Gemma 4 E2B**, 2.59 GB. Seven times the size, said plainly rather than in
+a footnote.
 
 You pay it once. Those weights read pictures *and* hear you, so the app never
 ends up juggling one model per modality: `complete` ships exactly one.
@@ -67,15 +68,16 @@ this codelab hands you one of each.
 
 ### What you'll need
 
-* The finished app from
-  [Getting Started with On-Device LLMs in Flutter](/codelabs/getting-started-flutter-gemma)
-  — or just its `complete/` directory, which is this codelab's starter
-* **No Hugging Face token** from Step 2 on: both repositories this codelab
-  introduces are ungated, so every `flutter run` from there is a plain
-  `flutter run` with no `--dart-define`. Step 1 is Getting Started's finished
-  app unchanged, and it still runs that codelab's gated Gemma 3 1B, which needs
-  `--dart-define=HF_TOKEN=hf_...`
-* Room for **0.36 GB** in Step 2, and for **2.59 GB** from Step 3 on — plus the
+* [Getting Started with On-Device LLMs in Flutter](/codelabs/getting-started-flutter-gemma)
+  builds the background this one assumes: installing a model, the gate that
+  decides between the download screen and the chat, the streaming loop. Its
+  finished app is *not* the starter here, though — `step_01_starter` is this
+  codelab's own Step 2 with the vision flag taken out, so the model file never
+  changes between Step 1 and Step 2
+* **No Hugging Face token, in any step.** Both repositories this codelab
+  downloads from are ungated, so every `flutter run` in it is a plain
+  `flutter run` — there is no `--dart-define` anywhere in this codelab
+* Room for **0.36 GB** from Step 1, and **2.59 GB** from Step 3 on — plus the
   memory to open the larger one, roughly 6 GB of RAM. A 4 GB phone is killed by
   the OS rather than told no
 * Android, a real iPhone or iPad, macOS, Windows or Linux for the full thing.
@@ -91,19 +93,89 @@ ls
 ```
 
 ```text
-step_01_starter/     the Getting Started app, unchanged
-step_02_vision/      after Step 2 — a small vision model, and it can see
+step_01_starter/     a text chat on the model Step 2 will teach to see
+step_02_vision/      after Step 2 — the same model, and it can see
 step_03_audio/       after Step 3 — a bigger one, and it hears too
 complete/            after Step 4 — and it knows where it cannot
 ```
 
 ## Step 1: A modality is a session flag
-Duration: 4
+Duration: 7
 
 ### Run the starter
 
-Open `step_01_starter` and run it. It is the Getting Started app: download a
-`.litertlm` file, chat with it, in text.
+Open `step_01_starter` and run it — a plain `flutter run`, no `--dart-define`,
+no Hugging Face account. It downloads a `.litertlm` file and chats with it, in
+text.
+
+### The model you just downloaded
+
+```dart
+  /// A vision-language model small enough to feel like a text model. 0.36 GB
+  /// is roughly what a photo-heavy app already spends on its image cache, so
+  /// this is the version of "multimodal" you can put in a shipping app
+  /// without an argument about download size — about a minute of download,
+  /// and then it is looking at your photograph.
+  ///
+  /// It cannot hear, and that is not a gap in this step: it is a
+  /// vision-language model, and the plugin lists audio input for Gemma 4 and
+  /// Gemma 3n only (`flutter_gemma/README.md`). A session flag cannot switch
+  /// on an encoder the checkpoint does not carry. It is why Step 3
+  /// changes models, and it is the model half of the question `complete` asks
+  /// at the end — a half that says no here while the device, happily holding
+  /// a microphone, says yes.
+  /// Run on macOS 2026-09-07: installs (0.36 GB) and answers "RED" to a
+  /// 16x16 red square, with `supportImage` set on both `getActiveModel` and
+  /// `createChat`. Nothing in CI runs a model, so this line is the only
+  /// evidence these weights were ever executed.
+  static const smolVlm2 = ModelChoice(
+    label: 'SmolVLM2 500M',
+    url:
+        'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/'
+        'SmolVLM2-500M.litertlm',
+    fileName: 'SmolVLM2-500M.litertlm',
+    // `general` and not `gemmaIt`: SmolVLM2 is not a Gemma, and the chat
+    // template that ships inside the `.litertlm` is the right one to use.
+    modelType: ModelType.general,
+    sizeLabel: '0.36 GB',
+  );
+```
+
+A vision-language model, running a text chat. That is deliberate, and it is
+what makes Step 2 readable: the file on disk will not change between here and
+there, so the one thing that turns the pictures on is the one thing you edit.
+
+`ModelType.general` and not `gemmaIt` is the line worth pausing on: SmolVLM2 is
+not a Gemma, so the right chat template is the one shipped inside the
+`.litertlm` file. Naming the wrong family does not fail loudly — it wraps the
+prompt in another model's turn markers, and the answers simply get worse.
+
+0.36 GB is roughly a minute of download, which is the other reason this
+codelab starts here rather than on the 2.59 GB model it ends on: you should be
+reading a description of your own photograph before you have finished reading
+this page.
+
+The repository is ungated, so there is no Hugging Face plumbing in `main.dart`
+at all — no token, no `--dart-define`, no 401 to explain. What there is, is a
+`try`:
+
+```dart
+  try {
+    await FlutterGemma.initialize(inferenceEngines: [LiteRtLmEngine()]);
+  } catch (error) {
+    runApp(_StartupFailed(error: error));
+    return;
+  }
+```
+
+That is not ceremony. This is the earliest thing in the app that can fail —
+hot-restarting after adding a plugin throws `MissingPluginException` right here
+— and an `await` before `runApp` that throws never reaches `runApp` at all. The
+symptom is a blank window and a stack trace in a console you are probably not
+looking at. Every other failure in this app arrives on screen; this one has to
+be made to.
+
+### The call this codelab changes
 
 Now look at the call that opens the chat, because that is where this codelab's
 central change lands:
@@ -115,6 +187,10 @@ central change lands:
       );
 ```
 
+Nothing in it mentions pictures, and yet the weights it is opening have a
+vision encoder in them. Step 2 downloads nothing: it opens this same file with
+one more capability switched on.
+
 ### One checkpoint, several sessions
 
 `createChat` takes `supportImage` and `supportAudio`. They map to
@@ -124,13 +200,15 @@ pictures. Set both and they will take pictures and sound.
 
 Nothing is downloaded in between, and nothing about the model changes: a
 `.litertlm` file ships whatever encoders it was built with, and a session
-decides which of them are wired up.
+decides which of them are wired up. Step 2 is where you watch that happen on
+the file already sitting on this device.
 
 Which is also the limit of the idea, and Step 3 walks straight into it. A flag
-can only switch on an encoder that is in the file. Step 2's SmolVLM2 has a
-vision encoder and no audio one, so `supportAudio: true` there is not a cheap
-way to get sound — it asks for a part the checkpoint does not contain. Audio
-means different weights, and different weights mean a download, not a boolean.
+can only switch on an encoder that is in the file. The SmolVLM2 you just
+downloaded has a vision encoder and no audio one, so `supportAudio: true` on it
+is not a cheap way to get sound — it asks for a part the checkpoint does not
+contain. Audio means different weights, and different weights mean a download,
+not a boolean.
 
 ### What is not yours to decide
 
@@ -166,7 +244,20 @@ greyed-out microphone. One is information; the other is a bug report waiting to
 be filed.
 
 ## Step 2: Send a picture
-Duration: 12
+Duration: 9
+
+### The model does not change
+
+`lib/model.dart` is untouched. `step_02_vision` opens the same
+`SmolVLM2-500M.litertlm` that Step 1 downloaded — same constant, same URL, same
+bytes on disk — so running this step fetches nothing. Diff the two apps and
+`model.dart`, `main.dart` and `download_page.dart` come back identical: beyond
+the package and the entitlement below, every line of Step 2 is in
+`chat_page.dart`.
+
+That is the claim this codelab is making, and it is only checkable because
+Step 1 was already running these weights. If the checkpoint changed here too,
+"a modality is a flag" would be a sentence you had to take on trust.
 
 ### Add the package
 
@@ -197,71 +288,6 @@ Android needs nothing — the system photo picker hands back a URI without a
 permission. iOS needs nothing either: since iOS 14 `image_picker` uses
 `PHPicker`, which runs out of process and requires no
 `NSPhotoLibraryUsageDescription`. Windows, Linux and the web need nothing.
-
-### The model
-
-`step_02_vision` replaces Getting Started's Gemma 3 1B with something smaller
-that can see:
-
-```dart
-  /// A vision-language model small enough to feel like a text model. 0.36 GB
-  /// is roughly what a photo-heavy app already spends on its image cache, so
-  /// this is the version of "multimodal" you can put in a shipping app
-  /// without an argument about download size — about a minute of download,
-  /// and then it is looking at your photograph.
-  ///
-  /// It cannot hear, and that is not a gap in this step: it is a
-  /// vision-language model, and the plugin lists audio input for Gemma 4 and
-  /// Gemma 3n only (`flutter_gemma/README.md`). A session flag cannot switch
-  /// on an encoder the checkpoint does not carry. It is why Step 3
-  /// changes models, and it is the model half of the question `complete` asks
-  /// at the end — a half that says no here while the device, happily holding
-  /// a microphone, says yes.
-  /// Run on macOS 2026-09-07: installs (0.36 GB) and answers "RED" to a
-  /// 16x16 red square, with `supportImage` set on both `getActiveModel` and
-  /// `createChat`. Nothing in CI runs a model, so this line is the only
-  /// evidence these weights were ever executed.
-  static const smolVlm2 = ModelChoice(
-    label: 'SmolVLM2 500M',
-    url:
-        'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/'
-        'SmolVLM2-500M.litertlm',
-    fileName: 'SmolVLM2-500M.litertlm',
-    // `general` and not `gemmaIt`: SmolVLM2 is not a Gemma, and the chat
-    // template that ships inside the `.litertlm` is the right one to use.
-    modelType: ModelType.general,
-    sizeLabel: '0.36 GB',
-  );
-```
-
-`ModelType.general` and not `gemmaIt` is the line worth pausing on: SmolVLM2 is
-not a Gemma, so the right chat template is the one shipped inside the
-`.litertlm` file. Naming the wrong family does not fail loudly — it wraps the
-prompt in another model's turn markers, and the answers simply get worse.
-
-0.36 GB is roughly a minute of download. That is the reason this step starts
-here: you should be reading a model's description of your own photograph before
-you have finished reading this page, not waiting out a multi-gigabyte download
-to find out whether the wiring is right.
-
-The repository is ungated, so `main.dart` also loses the Hugging Face plumbing
-it inherited from Getting Started. It gains a `try` in exchange:
-
-```dart
-  try {
-    await FlutterGemma.initialize(inferenceEngines: [LiteRtLmEngine()]);
-  } catch (error) {
-    runApp(_StartupFailed(error: error));
-    return;
-  }
-```
-
-That is not ceremony. This is the earliest thing in the app that can fail —
-hot-restarting after adding a plugin throws `MissingPluginException` right here
-— and an `await` before `runApp` that throws never reaches `runApp` at all. The
-symptom is a blank window and a stack trace in a console you are probably not
-looking at. Every other failure in this app arrives on screen; this one has to
-be made to.
 
 ### Open a session that can see
 
@@ -369,7 +395,7 @@ One line changes in `_send`: which factory builds the message.
 ```
 
 Everything downstream — `generateChatResponseAsync`, the streaming loop, the
-error handling — is byte-for-byte the code from Getting Started.
+error handling — is byte-for-byte the code Step 1 already ran.
 
 Run `step_02_vision` on a phone or a desktop, attach a photo, and ask what is
 in it.

--- a/website/codelabs/multimodal-flutter-gemma/index.md
+++ b/website/codelabs/multimodal-flutter-gemma/index.md
@@ -259,6 +259,11 @@ That is the claim this codelab is making, and it is only checkable because
 Step 1 was already running these weights. If the checkpoint changed here too,
 "a modality is a flag" would be a sentence you had to take on trust.
 
+Which is also why the paragraph above is a CI check and not a promise. This
+repository's `tool/check_codelabs.sh` asserts both halves of it on every run —
+that those three files match, and that `chat_page.dart` does **not**. A
+sentence in a codelab that nothing enforces is true on the day it is written.
+
 ### Add the package
 
 ```bash

--- a/website/codelabs/multimodal-flutter-gemma/index.md
+++ b/website/codelabs/multimodal-flutter-gemma/index.md
@@ -71,8 +71,8 @@ this codelab hands you one of each.
 * [Getting Started with On-Device LLMs in Flutter](/codelabs/getting-started-flutter-gemma)
   builds the background this one assumes: installing a model, the gate that
   decides between the download screen and the chat, the streaming loop. Its
-  finished app is *not* the starter here, though — `step_01_starter` is this
-  codelab's own Step 2 with the vision flag taken out, so the model file never
+  finished app is *not* the starter here, though — `step_01_starter` runs the
+  same weights Step 2 does, opened as a text session, so the model file never
   changes between Step 1 and Step 2
 * **No Hugging Face token, in any step.** Both repositories this codelab
   downloads from are ungated, so every `flutter run` in it is a plain
@@ -134,8 +134,13 @@ text.
         'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/'
         'SmolVLM2-500M.litertlm',
     fileName: 'SmolVLM2-500M.litertlm',
-    // `general` and not `gemmaIt`: SmolVLM2 is not a Gemma, and the chat
-    // template that ships inside the `.litertlm` is the right one to use.
+    // `general` and not `gemmaIt`, and the reason is not turn markers. For a
+    // `.litertlm` file the runtime owns the chat template on every platform
+    // this codelab targets except iOS (`extensions.dart:74-77` returns
+    // `raw`, which never consults this field). What the field still picks is
+    // what the SDK does to the reply on the way out: `gemmaIt` is on the
+    // thinking-tag-stripping list in `cleanResponse` and `general` is not.
+    // SmolVLM2 is not a Gemma, so it should not be post-processed as one.
     modelType: ModelType.general,
     sizeLabel: '0.36 GB',
   );
@@ -143,12 +148,25 @@ text.
 
 A vision-language model, running a text chat. That is deliberate, and it is
 what makes Step 2 readable: the file on disk will not change between here and
-there, so the one thing that turns the pictures on is the one thing you edit.
+there. Step 2 does write a fair amount of code — a picker, a preview, a
+thumbnail in the transcript — but none of that is what makes the model see.
+Two flags are, and because the checkpoint is held fixed you can watch them do
+it on their own.
 
-`ModelType.general` and not `gemmaIt` is the line worth pausing on: SmolVLM2 is
-not a Gemma, so the right chat template is the one shipped inside the
-`.litertlm` file. Naming the wrong family does not fail loudly — it wraps the
-prompt in another model's turn markers, and the answers simply get worse.
+`ModelType.general` and not `gemmaIt` is the line worth pausing on, and it is
+worth pausing on for a reason that is easy to get backwards. It is tempting to
+read this field as "which chat template" — it is not, at least not here. For a
+`.litertlm` model the runtime owns the template on Android, macOS, Windows,
+Linux and the web: `extensions.dart:74-77` returns `raw` for that file type on
+every one of them, and `raw` never looks at `modelType` at all. iOS is the lone
+exception, and there both `general` and `gemmaIt` emit Gemma's own
+`<start_of_turn>` markers — so neither of them is "the template inside the
+file".
+
+What the field does still decide is what the SDK does to the reply on the way
+out. `cleanResponse` strips thinking tags for a fixed list of families, and
+`gemmaIt` is on it while `general` is not. Declare SmolVLM2 a Gemma and you
+have asked for a Gemma's post-processing on a model that is not one.
 
 0.36 GB is roughly a minute of download, which is the other reason this
 codelab starts here rather than on the 2.59 GB model it ends on: you should be
@@ -251,9 +269,10 @@ Duration: 9
 `lib/model.dart` is untouched. `step_02_vision` opens the same
 `SmolVLM2-500M.litertlm` that Step 1 downloaded — same constant, same URL, same
 bytes on disk — so running this step fetches nothing. Diff the two apps and
-`model.dart`, `main.dart` and `download_page.dart` come back identical: beyond
-the package and the entitlement below, every line of Step 2 is in
-`chat_page.dart`.
+`model.dart`, `main.dart` and `download_page.dart` come back identical. Beyond
+`chat_page.dart` the diff prints only what the package below drags in with it:
+`pubspec.yaml`, the two entitlements files, and the five plugin registrants
+`flutter pub add` regenerates for Linux, macOS and Windows.
 
 That is the claim this codelab is making, and it is only checkable because
 Step 1 was already running these weights. If the checkpoint changed here too,
@@ -383,7 +402,14 @@ failure; an app that shows an error there is an app people learn to distrust.
 
 ### Send it
 
-One line changes in `_send`: which factory builds the message.
+`_send` changes in five places, and only the last one is about pictures
+reaching the model: the guard now lets a turn through with no text (a photo on
+its own is a valid question), the local `_Turn` carries the image so the
+transcript can draw it, and the picker state is cleared once the turn is
+committed. Housekeeping — but if you followed the diff instruction above, you
+will see it, so here it is named rather than glossed.
+
+The line that matters is which factory builds the message.
 
 ```dart
       await chat.addQueryChunk(


### PR DESCRIPTION
`codelabs/multimodal-flutter-gemma/step_01_starter/` was a byte-identical copy of Getting Started's `complete/`, enforced by a `MIRRORS` row. Two things followed from that, and both are worth fixing.

## The learner downloaded half a gigabyte and then abandoned it

Getting Started ends on **Gemma 3 1B** — 0.5 GB, behind a Hugging Face licence gate, so Step 1 needed a token and `--dart-define=HF_TOKEN=hf_...`. Step 2 then downloaded **SmolVLM2 500M** instead and never opened the first model again. Accept a licence, wait out 0.5 GB, throw it away.

## Worse: the code contradicted the step it was under

Step 1 is titled **"A modality is a session flag"**. But Step 2 swapped the model *and* set `supportImage`, so a learner had no way to tell which of the two made the picture work. The codelab asserted its thesis and then demonstrated something else.

## The change

`step_01_starter` is now **Step 2 minus the vision flag**: the same SmolVLM2 weights, opened as a text session.

`model.dart`, `main.dart` and `download_page.dart` are byte-identical to `step_02_vision`'s. `chat_page.dart` is that file minus the vision machinery — `image_picker`, `supportImage` on both `getActiveModel` and `createChat`, `Message.withImages`, and the token budget, which stays at `1024` here so Step 2's *"the call above it changes too — in two ways"* stays true.

So Step 2's diff is now the lesson and nothing else. The file on disk does not change between Step 1 and Step 2, which means "a modality is a session flag" is something the learner watches happen rather than something they take on trust.

It also removes the last Hugging Face plumbing from this codelab. The comment in `step_02` / `step_03` / `complete`'s `main.dart` still told the reader Step 1 was gated; it isn't, and there is now **no token and no `--dart-define` in any step**.

## Text

The `smolVlm2` block, the `ModelType.general` paragraph and the `main.dart` `try` passage move from Step 2 into Step 1, where the code now lives. Step 2 gains a short section saying what did *not* change, and why that is checkable only because Step 1 was already running these weights.

Durations move with the material (Step 1 4 → 7, Step 2 12 → 9). The 46-minute total the catalogue carries is unchanged.

## Gate

The `getting-started/complete → multimodal/step_01_starter` row leaves `MIRRORS`. One row remains — Inference Engines genuinely does start from Getting Started's finished app — so the fail-closed `#MIRRORS -eq 0` guard still has something to guard.

Removing it would have traded one unenforced invariant for another, because Step 2's text now tells the learner to diff the two apps and says which files come back identical. `MIRRORS` cannot express that: it compares a `lib/` directory whole, and here exactly one file has to differ — it is the step. A comment added to the starter's `main.dart` would have made the text quietly false with every other check still green.

So the gate gains `SHARED_STEPS`, for consecutive steps inside one codelab. Each row names the files that must match and the one that must **not**, and both halves are asserted: if `chat_page.dart` ever matched too, Step 2 would have no diff at all, which is as wrong as drift. Proved to fail closed three ways — a comment appended to the starter's `main.dart`, the starter's `chat_page.dart` replaced with Step 2's, and `model.dart` renamed away — each naming the offender, each reverted and re-run clean.


## Review round

Three reviewers plus Codex read this branch. Six findings, every one confirmed against the tree before it was fixed.

Two were fail-opens in the `SHARED_STEPS` check this PR adds — both mine, both the exact class the check exists to prevent. `diff` exits 0 identical, 1 different, and >1 when it could not compare at all; `elif diff -q …; then` reads every non-zero alike, so a file that exists but cannot be read took the "they differ" branch and the must-differ half of the invariant passed without being checked. Status 1 is now named in a `case`, with `|| status=$?` so `set -e` does not abort before it runs. The other: a half-emptied row ran the shared-file loop zero times and reported nothing. Six perturbations now tested, each red, each reverted.

The `ModelType.general` paragraph was wrong in both halves, and this PR had promoted it into Step 1. For a `.litertlm` file `extensions.dart:74-77` returns `raw` on every platform this codelab targets except iOS, and `raw` never consults `modelType` — so naming the wrong family does not "wrap the prompt in another model's turn markers", it does nothing at all. On iOS, the one manual target, `general` and `gemmaIt` both emit Gemma's own `<start_of_turn>` markers, so `general` is not "the template inside the file" either. What the field does decide is post-processing: `cleanResponse` strips thinking tags for a fixed list of families that includes `gemmaIt` and not `general`. The text says that now.

The other three were claims this PR itself made checkable by telling the learner to diff the two apps, and which then failed on sight: "one line changes in `_send`" (five places do), "the one thing you edit" (contradicted by Step 2's own "in two ways" a page later), and a diff promise that omitted the five plugin registrants `flutter pub add` regenerates.
