### PR TITLE
feat(example): LFM2.5-230M and the fromHuggingFace install path — core 1.7.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@
 | Qwen3 0.6B | ✅ | ✅ ² | ❌ | Android, iOS, Web, Desktop |
 | Qwen 2.5 (0.5B/1.5B) | ✅ | ❌ | ❌ | Android, iOS |
 | SmolLM 135M | ❌ | ❌ | ❌ | Android, iOS |
+| LFM2.5 230M | ❌ | ❌ | ❌ | Android, iOS, Desktop |
 
 > ¹ Thinking Mode for Gemma 4: Android, iOS, Desktop only. Web (MediaPipe) does not support `extraContext`.
 > ² Qwen3 generates thinking by default; tags are stripped when `isThinking: false`.
@@ -149,7 +150,7 @@ Core has NO pigeon (dropped at the 1.0 cut; its value types are hand-written in 
 - **LiteRT-LM**: native libs from `native-v0.16.0` GitHub Release (LiteRT-LM pin `924e79c9`, LiteRT pin `0ff28117`). Android tarball bundles the Qualcomm QNN dispatch stack and Windows tarball bundles Intel NPU dispatch (`LiteRtDispatch.dll` + OpenVino runtime + TBB) for `PreferredBackend.npu` (Qualcomm Snapdragon / Intel LunarLake/PantherLake) — both dispatch libs are **rebuilt from the pin every release**; carrying them forward is what silently broke NPU on both platforms (see the `build-native` skill). v0.16.0: fixes the Android OpenCL per-turn memory leak (LiteRT-LM #2699, #348/#402); v0.15.0 **broke the stream-callback ABI** (4-arg → 2-arg chunk object) with no compat path, handled by a runtime probe in `stream_proxy.c`. Windows discrete GPU works again — the crash was our own dead `litert_link_capi_so` Bazel define, not an upstream regression (#2957 retracted).
 - **sqlite-vec**: `flutter_gemma_rag_sqlite` fetches the per-platform `vec0` loadable from the `native-sqlite-vec-v<X>` GitHub Release (`sqlite-vec-<target>.tar.gz` + `checksums_sqlite_vec.txt`), SHA256-verified by its `hook/build.dart`. `<X>` names the **upstream sqlite-vec release** the bytes were built from; a letter suffix (`0.1.9-a`) is only for RE-releasing changed bytes under an already-published number. The loadables are NOT committed — `native/sqlite_vec/prebuilt/` is a maintainer override produced by `build_local.sh`, gitignored and `.pubignore`d.
 - **large_file_handler**: `^0.5.0` (core dep; 0.5.0 declares all 6 platforms — needed for pana platform support + the dart2wasm-clean web graph)
-- **Current Version**: core `flutter_gemma` `1.7.3`, `flutter_gemma_rag_sqlite` `1.3.1`, `flutter_gemma_rag_qdrant` `1.3.0`; `flutter_gemma_litertlm` `1.6.3`, `flutter_gemma_mediapipe` `1.0.5`, `flutter_gemma_embeddings` `2.1.1`, `flutter_gemma_speech` `0.4.3`; `flutter_gemma_agent` `0.2.5`, `flutter_gemma_builtin_ai` `0.2.1`, `flutter_gemma_onnx` `0.3.3`; `genkit_flutter_gemma` `0.6.0`, `genkit_hybrid` `0.2.1`
+- **Current Version**: core `flutter_gemma` `1.7.4`, `flutter_gemma_rag_sqlite` `1.3.1`, `flutter_gemma_rag_qdrant` `1.3.0`; `flutter_gemma_litertlm` `1.6.3`, `flutter_gemma_mediapipe` `1.0.5`, `flutter_gemma_embeddings` `2.1.1`, `flutter_gemma_speech` `0.4.3`; `flutter_gemma_agent` `0.2.5`, `flutter_gemma_builtin_ai` `0.2.1`, `flutter_gemma_onnx` `0.3.3`; `genkit_flutter_gemma` `0.6.0`, `genkit_hybrid` `0.2.1`
 - **0.15.2**: embedding unified on LiteRT C API via Dart FFI on all native platforms (Android + iOS + Desktop). Drops `localagents-rag` JVM dep on Android and the separate TFLite C 0.12.7 tarball on Desktop; `TensorFlowLiteC` pod no longer needed on iOS. Single source of truth for `TaskType.prefix` in Dart, fixes cross-platform embedding drift (#264).
 
 ## Platform-Specific Setup

--- a/packages/flutter_gemma/CHANGELOG.md
+++ b/packages/flutter_gemma/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.7.4
+- Example: LFM2.5-230M and the `fromHuggingFace` install path.
+
 ## 1.7.3
 - Fix `createChat` dropping `tools` — function calling on every non-FFI engine.
 - Docs: bump web `@litert-lm/core` setup snippet to 0.17.0.

--- a/packages/flutter_gemma/README.md
+++ b/packages/flutter_gemma/README.md
@@ -7,7 +7,7 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/flutter_gemma)
 
-**The plugin supports not only Gemma, but also other models. Here's the full list of supported models:** [Gemma 4 E2B/E4B](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm), [Gemma3n E2B/E4B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview), [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B), [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT), [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it), [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it), [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B), [Qwen 2.5](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct), [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct), [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B), [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct), [SmolLM3 3B](https://huggingface.co/litert-community/SmolLM3-3B), [Phi-4 Mini Reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning), [Qwen2-VL 2B](https://huggingface.co/litert-community/Qwen2-VL-2B), [SmolVLM2 500M](https://huggingface.co/litert-community/SmolVLM2-500M), [LLaVA-OneVision 0.5B](https://huggingface.co/litert-community/LLaVA-OneVision-0.5B), [TranslateGemma 4B](https://huggingface.co/google/translategemma-4b-it) (CPU-only).
+**The plugin supports not only Gemma, but also other models. Here's the full list of supported models:** [Gemma 4 E2B/E4B](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm), [Gemma3n E2B/E4B](https://huggingface.co/google/gemma-3n-E2B-it-litert-preview), [FastVLM 0.5B](https://huggingface.co/litert-community/FastVLM-0.5B), [Gemma-3 1B](https://huggingface.co/litert-community/Gemma3-1B-IT), [Gemma 3 270M](https://huggingface.co/litert-community/gemma-3-270m-it), [FunctionGemma 270M](https://huggingface.co/sasha-denisov/function-gemma-270M-it), [Qwen3 0.6B](https://huggingface.co/litert-community/Qwen3-0.6B), [Qwen 2.5](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct), [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct), [DeepSeek R1](https://huggingface.co/litert-community/DeepSeek-R1-Distill-Qwen-1.5B), [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct), [LFM2.5 230M](https://huggingface.co/litert-community/LFM2.5-230M), [SmolLM3 3B](https://huggingface.co/litert-community/SmolLM3-3B), [Phi-4 Mini Reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning), [Qwen2-VL 2B](https://huggingface.co/litert-community/Qwen2-VL-2B), [SmolVLM2 500M](https://huggingface.co/litert-community/SmolVLM2-500M), [LLaVA-OneVision 0.5B](https://huggingface.co/litert-community/LLaVA-OneVision-0.5B), [TranslateGemma 4B](https://huggingface.co/google/translategemma-4b-it) (CPU-only).
 
 *Note: The flutter_gemma plugin supports Gemma 4 and Gemma3n (with **multimodal vision and audio support**), FastVLM, Qwen2-VL, SmolVLM2 and LLaVA-OneVision (vision), Gemma-3, FunctionGemma, Qwen3, Qwen 2.5, Phi-4 (incl. Phi-4 Mini Reasoning), DeepSeek R1, SmolLM and SmolLM3. Desktop platforms (macOS, Windows, Linux) require `.litertlm` model format.
 
@@ -130,6 +130,7 @@ The example app offers a curated list of models, each suited for different tasks
 | **Gemma 3 270M** | Ideal for fine-tuning (LoRA) for specific tasks | ❌ | ❌ | ❌ | Multilingual | 0.3GB |
 | **FunctionGemma 270M** | Specialized for function calling on-device | ✅ | ❌ | ❌ | Multilingual | 284MB |
 | **SmolLM 135M** | Ultra-compact, resource-constrained devices | ❌ | ❌ | ❌ | English | 135MB |
+| **LFM2.5 230M** | Smallest entry; no HF token needed | ❌ | ❌ | ❌ | Multilingual | 168MB |
 | **SmolLM3 3B** | Multilingual small LLM with reasoning mode | ❌ | ✅ | ❌ | Multilingual | 2.0GB |
 | **TranslateGemma 4B** † | Single-shot 55-language translation | ❌ | ❌ | ❌ | 55 languages | 2-4GB |
 
@@ -148,7 +149,7 @@ When installing models, you need to specify the correct `ModelType`. Use this ta
 | **Qwen 3** | `ModelType.qwen3` | Qwen3 0.6B |
 | **FunctionGemma** | `ModelType.functionGemma` | FunctionGemma 270M IT |
 | **Phi** | `ModelType.phi` | Phi-4 Mini |
-| **General** | `ModelType.general` | FastVLM 0.5B, SmolLM 135M, SmolLM3 3B, Phi-4 Mini Reasoning, Qwen2-VL 2B, SmolVLM2 500M, LLaVA-OneVision 0.5B |
+| **General** | `ModelType.general` | FastVLM 0.5B, SmolLM 135M, LFM2.5 230M, SmolLM3 3B, Phi-4 Mini Reasoning, Qwen2-VL 2B, SmolVLM2 500M, LLaVA-OneVision 0.5B |
 
 > **Note**: Gemma 4 uses `ModelType.gemma4` so its native `<\|tool_call>...<tool_call\|>` tokens are routed through the LiteRT-LM SDK's chat-template path. For Gemma 3 and earlier, keep `ModelType.gemmaIt`.
 

--- a/packages/flutter_gemma/example/integration_test/hf_fileless_install_device_test.dart
+++ b/packages/flutter_gemma/example/integration_test/hf_fileless_install_device_test.dart
@@ -1,0 +1,115 @@
+// File-less `fromHuggingFace(repo)` — resolve the manifest, install the
+// revision-pinned variant, and GENERATE, on real hardware.
+//
+// Why this file exists: `fromHuggingFace` shipped in 1.7.0 with unit coverage
+// only (`from_hugging_face_test.dart`, the manifest resolver suites) plus an
+// arm64 EMULATOR pass in #489. Nothing has ever driven the file-less path to an
+// actual token on a physical device, which is exactly what
+// https://github.com/DenisovAV/flutter_gemma/issues/454 asks for.
+//
+// Model: litert-community/LFM2.5-230M — the smallest entry in the shipped
+// catalogue (int4 ≈ 177 MB), chosen so the same test is affordable to run on
+// four platforms rather than one.
+//
+// Run:
+//   macOS    flutter test integration_test/hf_fileless_install_device_test.dart -d macos
+//   Linux    xvfb-run -a flutter test integration_test/hf_fileless_install_device_test.dart -d linux
+//   Windows  flutter test integration_test/hf_fileless_install_device_test.dart -d windows
+//   Android  physical device by id, or FTL (see tool/ftl notes) — NOT an emulator,
+//            an emulator answers a different question than the one being asked.
+//
+// The test PRINTS the line the issue asked for:
+//   model / device+OS / versions / backend / works or first adjustment
+// so the answer posted upstream is a transcript, not a recollection.
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'inference_test_helpers.dart' show registerTestEngines;
+
+const _repo = 'litert-community/LFM2.5-230M';
+const _hfToken = String.fromEnvironment('HUGGINGFACE_TOKEN');
+
+String get _platform {
+  if (Platform.isMacOS) return 'macOS';
+  if (Platform.isLinux) return 'Linux';
+  if (Platform.isWindows) return 'Windows';
+  if (Platform.isAndroid) return 'Android';
+  if (Platform.isIOS) return 'iOS';
+  return 'unknown';
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('fromHuggingFace(repo) installs and generates on device', (
+    tester,
+  ) async {
+    // Everything that can throw is inside the test body, never in setUp: under
+    // some runners a throwing setUp is reported as a pass because the result is
+    // only written from inside the test.
+    await registerTestEngines();
+
+    final sw = Stopwatch()..start();
+
+    // The path under test: no `file:`, so the registered resolver fetches the
+    // manifest and picks the revision-pinned variant itself.
+    final install =
+        await FlutterGemma.installModel(
+              modelType: ModelType.general,
+              fileType: ModelFileType.litertlm,
+            )
+            .fromHuggingFace(_repo, token: _hfToken.isEmpty ? null : _hfToken)
+            .install();
+
+    final installMs = sw.elapsedMilliseconds;
+    expect(
+      install.runtime,
+      isNotNull,
+      reason:
+          'the file-less path must return the manifest runtime defaults; null '
+          'means the resolver did not run and this test proved nothing',
+    );
+
+    final defaults = install.runtime!;
+    // `defaults:` is the whole point of the one-call path — applying them is
+    // what the issue means by "did it need a manual override".
+    final model = await FlutterGemma.getActiveModel(defaults: defaults);
+
+    try {
+      final session = await model.createSession();
+      String response;
+      try {
+        await session.addQueryChunk(
+          const Message(text: 'Say hello in one word.', isUser: true),
+        );
+        response = await session.getResponse();
+      } finally {
+        await session.close();
+      }
+
+      expect(
+        response.trim(),
+        isNotEmpty,
+        reason: 'installed and loaded, but generated nothing',
+      );
+
+      // ignore: avoid_print
+      print(
+        '\n[HF-FILELESS] $_repo / $_platform ${Platform.operatingSystemVersion} / '
+        'flutter_gemma 1.7.3 + litertlm 1.6.3 / '
+        'backend=${model.activeBackend} (manifest default '
+        '${defaults.preferredBackend}) / maxTokens=${defaults.maxTokens} / '
+        'install ${installMs}ms / OK, no manual override\n'
+        '[HF-FILELESS] reply: "${response.trim()}"\n',
+      );
+    } finally {
+      await model.close();
+    }
+  }, timeout: const Timeout(Duration(minutes: 30)));
+}

--- a/packages/flutter_gemma/example/lib/chat_screen.dart
+++ b/packages/flutter_gemma/example/lib/chat_screen.dart
@@ -123,7 +123,25 @@ class ChatScreenState extends State<ChatScreen> {
       // so the built-in engine resolves, then make sure the OS model is ready
       // (the download screen normally does this first, but ChatScreen is also
       // reachable directly, so guard here too).
-      if (widget.model.isBuiltIn) {
+      // The one-call Hugging Face path: no URL, no filename, no backend from
+      // this catalogue — `fromHuggingFace(repo)` fetches the repo's manifest,
+      // installs the revision-pinned variant and hands back the runtime
+      // defaults, which Step 2 then applies verbatim via `defaults:`.
+      //
+      // Only entries whose repo actually ships a litertlm_manifest.json carry
+      // `hfRepo`; everything else keeps the fromNetwork branch below.
+      ModelRuntimeDefaults? hfDefaults;
+
+      if (widget.model.hfRepo != null) {
+        final installation = await installer
+            .fromHuggingFace(widget.model.hfRepo!)
+            .withProgress((percent) {
+              if (!mounted) return;
+              setState(() => _downloadPercent = percent);
+            })
+            .install();
+        hfDefaults = installation.runtime;
+      } else if (widget.model.isBuiltIn) {
         await installer.fromBundled(widget.model.filename).withProgress((
           percent,
         ) {
@@ -159,10 +177,15 @@ class ChatScreenState extends State<ChatScreen> {
 
       // Step 2: Create model with runtime config
       debugPrint('[ChatScreen] Step 2: Creating InferenceModel...');
+      // `defaults:` carries the manifest's own maxTokens/backend for an
+      // hfRepo model. An explicit user pick in the backend selector still wins
+      // — that is the whole point of the defaults being overridable.
       final model = await FlutterGemma.getActiveModel(
-        maxTokens: widget.model.maxTokens,
+        defaults: hfDefaults,
+        maxTokens: hfDefaults == null ? widget.model.maxTokens : null,
         preferredBackend:
-            widget.selectedBackend ?? widget.model.preferredBackend,
+            widget.selectedBackend ??
+            (hfDefaults == null ? widget.model.preferredBackend : null),
         supportImage: widget.model.supportImage,
         maxNumImages: widget.model.maxNumImages,
         supportAudio: widget.model.supportAudio,

--- a/packages/flutter_gemma/example/lib/models/model.dart
+++ b/packages/flutter_gemma/example/lib/models/model.dart
@@ -577,7 +577,6 @@ enum Model implements InferenceModelInterface {
 
   // SmolLM3-3B — modern multilingual small LLM with a reasoning mode.
   smolLM3_3B(
-    hfRepo: 'litert-community/SmolLM3-3B',
     baseUrl:
         'https://huggingface.co/litert-community/SmolLM3-3B/resolve/main/SmolLM3-3B_q4_block32_ekv4096.litertlm',
     desktopUrl:
@@ -599,7 +598,6 @@ enum Model implements InferenceModelInterface {
 
   // Qwen2-VL-2B — vision-language model (image + text).
   qwen2VL_2B(
-    hfRepo: 'litert-community/Qwen2-VL-2B',
     baseUrl:
         'https://huggingface.co/litert-community/Qwen2-VL-2B/resolve/main/Qwen2-VL-2B.litertlm',
     desktopUrl:
@@ -643,7 +641,6 @@ enum Model implements InferenceModelInterface {
 
   // SmolVLM2-500M — compact vision-language model (image + text).
   smolVLM2_500M(
-    hfRepo: 'litert-community/SmolVLM2-500M',
     baseUrl:
         'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/SmolVLM2-500M.litertlm',
     desktopUrl:
@@ -666,7 +663,6 @@ enum Model implements InferenceModelInterface {
 
   // LLaVA-OneVision-0.5B — compact vision-language model (image + text).
   llavaOneVision_0_5B(
-    hfRepo: 'litert-community/LLaVA-OneVision-0.5B',
     baseUrl:
         'https://huggingface.co/litert-community/LLaVA-OneVision-0.5B/resolve/main/LLaVA-OneVision-0.5B.litertlm',
     desktopUrl:
@@ -850,10 +846,20 @@ enum Model implements InferenceModelInterface {
   /// revision-pinned variant and returns the runtime defaults, so none of the
   /// url/filename/backend fields above are consulted.
   ///
-  /// Only set it for repos that actually ship a manifest — 4 of the 42 repos
-  /// this catalogue references do. Everything else keeps [baseUrl] and the
-  /// `fromNetwork` path; a missing manifest is a resolve failure, not a
-  /// fallback.
+  /// Two conditions, not one. The repo must ship a manifest — 5 of the 42 repos
+  /// this catalogue references do — AND the entry must have been run on the
+  /// manifest's own defaults, because those defaults WIN here: passing
+  /// `maxTokens`/`preferredBackend` as null is what lets them through, so a
+  /// manifest saying `default_backend: cpu` silently moves an entry off gpu.
+  ///
+  /// That is why only LFM2.5-230M carries it today. The other four
+  /// manifest-backed repos (SmolLM3-3B, Qwen2-VL-2B, SmolVLM2-500M,
+  /// LLaVA-OneVision-0.5B) all declare `default_backend: cpu` against a
+  /// catalogue that runs them on gpu — plausibly correct, since each carries
+  /// `known_issues`, but it is a behaviour change nobody has measured. They keep
+  /// [baseUrl] and `fromNetwork` until someone does.
+  ///
+  /// A missing manifest is a resolve failure, not a fallback.
   final String? hfRepo;
 
   @override

--- a/packages/flutter_gemma/example/lib/models/model.dart
+++ b/packages/flutter_gemma/example/lib/models/model.dart
@@ -272,6 +272,46 @@ enum Model implements InferenceModelInterface {
     supportsFunctionCalls: false,
   ),
 
+  // LFM2.5 230M — the smallest entry here (int4, 168 MB) and the only one that
+  // needs no HuggingFace token. LiquidAI's lfm2 architecture, a ShortConv /
+  // attention hybrid (14 layers: 8 conv + 6 GQA) rather than a plain
+  // transformer, which is what makes it viable on low-end hardware.
+  //
+  // Installed through `fromHuggingFace(repo)`: the repo ships a
+  // litertlm_manifest.json, so the resolver supplies the variant, the backend
+  // and maxTokens. The url/filename/backend fields below are what the manifest
+  // resolves to today — they are here so the entry still renders in the picker,
+  // not because the install path reads them.
+  //
+  // Verified end to end on macOS 26.5.1 (Apple Silicon), Android 12 (RayNeo
+  // ARGF20, arm64), Windows 10 Pro 26200 and Ubuntu + Tesla T4 — gpu on all
+  // four, no manual override. See
+  // example/integration_test/hf_fileless_install_device_test.dart.
+  //
+  // Instruction-following is weak at this size: "say hello in one word"
+  // produced a one-word reply on one of the four runs and a polite paragraph on
+  // the other three. Fine for checking the pipeline works; not a quality bar.
+  lfm25_230m(
+    hfRepo: 'litert-community/LFM2.5-230M',
+    baseUrl:
+        'https://huggingface.co/litert-community/LFM2.5-230M/resolve/main/LFM2.5-230M_int4.litertlm',
+    desktopUrl:
+        'https://huggingface.co/litert-community/LFM2.5-230M/resolve/main/LFM2.5-230M_int4.litertlm',
+    filename: 'LFM2.5-230M_int4.litertlm',
+    displayName: 'LFM2.5 230M (int4)',
+    size: '0.17GB',
+    licenseUrl: 'https://huggingface.co/litert-community/LFM2.5-230M',
+    needsAuth: false,
+    preferredBackend: PreferredBackend.gpu,
+    modelType: ModelType.general,
+    fileType: ModelFileType.litertlm,
+    temperature: 1.0,
+    topK: 64,
+    topP: 0.95,
+    maxTokens: 4096,
+    supportsFunctionCalls: false,
+  ),
+
   // === LiteRT-LM ENGINE MODELS (for testing parity with MediaPipe) ===
 
   // Gemma 3 Nano E2B LiteRT-LM (same model, different engine).
@@ -537,6 +577,7 @@ enum Model implements InferenceModelInterface {
 
   // SmolLM3-3B — modern multilingual small LLM with a reasoning mode.
   smolLM3_3B(
+    hfRepo: 'litert-community/SmolLM3-3B',
     baseUrl:
         'https://huggingface.co/litert-community/SmolLM3-3B/resolve/main/SmolLM3-3B_q4_block32_ekv4096.litertlm',
     desktopUrl:
@@ -558,6 +599,7 @@ enum Model implements InferenceModelInterface {
 
   // Qwen2-VL-2B — vision-language model (image + text).
   qwen2VL_2B(
+    hfRepo: 'litert-community/Qwen2-VL-2B',
     baseUrl:
         'https://huggingface.co/litert-community/Qwen2-VL-2B/resolve/main/Qwen2-VL-2B.litertlm',
     desktopUrl:
@@ -601,6 +643,7 @@ enum Model implements InferenceModelInterface {
 
   // SmolVLM2-500M — compact vision-language model (image + text).
   smolVLM2_500M(
+    hfRepo: 'litert-community/SmolVLM2-500M',
     baseUrl:
         'https://huggingface.co/litert-community/SmolVLM2-500M/resolve/main/SmolVLM2-500M.litertlm',
     desktopUrl:
@@ -623,6 +666,7 @@ enum Model implements InferenceModelInterface {
 
   // LLaVA-OneVision-0.5B — compact vision-language model (image + text).
   llavaOneVision_0_5B(
+    hfRepo: 'litert-community/LLaVA-OneVision-0.5B',
     baseUrl:
         'https://huggingface.co/litert-community/LLaVA-OneVision-0.5B/resolve/main/LLaVA-OneVision-0.5B.litertlm',
     desktopUrl:
@@ -801,6 +845,17 @@ enum Model implements InferenceModelInterface {
   final String? webUrl;
   final String? desktopUrl;
 
+  /// Hugging Face repo for the one-call `installModel(...).fromHuggingFace(repo)`
+  /// path: the resolver fetches the repo's `litertlm_manifest.json`, picks the
+  /// revision-pinned variant and returns the runtime defaults, so none of the
+  /// url/filename/backend fields above are consulted.
+  ///
+  /// Only set it for repos that actually ship a manifest — 4 of the 42 repos
+  /// this catalogue references do. Everything else keeps [baseUrl] and the
+  /// `fromNetwork` path; a missing manifest is a resolve failure, not a
+  /// fallback.
+  final String? hfRepo;
+
   @override
   final String filename;
   @override
@@ -908,6 +963,7 @@ enum Model implements InferenceModelInterface {
     this.agentic = false,
     this.fileType = ModelFileType.task,
     this.foregroundDownload,
+    this.hfRepo,
   }) : _supportImageRaw = supportImage,
        _supportAudioRaw = supportAudio;
 

--- a/packages/flutter_gemma/example/pubspec.lock
+++ b/packages/flutter_gemma/example/pubspec.lock
@@ -241,7 +241,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.3"
+    version: "1.7.4"
   flutter_gemma_agent:
     dependency: "direct main"
     description:

--- a/packages/flutter_gemma/ios/flutter_gemma.podspec
+++ b/packages/flutter_gemma/ios/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.7.3'
+  s.version          = '1.7.4'
   s.summary          = 'Flutter plugin for running Gemma and other LLMs locally on iOS.'
   s.description      = <<-DESC
 Core runtime for running Gemma 4, Gemma3n, Gemma 3, FastVLM, Qwen3,

--- a/packages/flutter_gemma/macos/flutter_gemma.podspec
+++ b/packages/flutter_gemma/macos/flutter_gemma.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_gemma'
-  s.version          = '1.7.3'
+  s.version          = '1.7.4'
   s.summary          = 'Flutter Gemma - Run Gemma AI models locally on desktop'
   s.description      = <<-DESC
 Flutter plugin for running Gemma AI models locally on macOS using LiteRT-LM.

--- a/packages/flutter_gemma/pubspec.yaml
+++ b/packages/flutter_gemma/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gemma
 description: "Run Gemma and other LLMs on-device in Flutter (Android, iOS, Web, Desktop). Multimodal vision/audio, function calling, thinking mode, GPU, embeddings, RAG."
-version: 1.7.3
+version: 1.7.4
 resolution: workspace
 homepage: https://fluttergemma.dev
 repository: https://github.com/DenisovAV/flutter_gemma

--- a/packages/flutter_gemma_speech/example/pubspec.lock
+++ b/packages/flutter_gemma_speech/example/pubspec.lock
@@ -180,7 +180,7 @@ packages:
       path: "../../flutter_gemma"
       relative: true
     source: path
-    version: "1.7.3"
+    version: "1.7.4"
   flutter_gemma_agent:
     dependency: "direct main"
     description:

--- a/website/content/docs/agent.md
+++ b/website/content/docs/agent.md
@@ -29,7 +29,7 @@ used below).
 
 ```
 dependencies:
-  flutter_gemma: ^1.7.3
+  flutter_gemma: ^1.7.4
   flutter_gemma_agent: ^0.2.5
   flutter_gemma_litertlm: ^1.6.3   # an inference engine (LiteRtLmEngine)
 ```

--- a/website/content/docs/function-calling.md
+++ b/website/content/docs/function-calling.md
@@ -24,6 +24,7 @@ and then continue the conversation with the result.
 
 - **Gemma 3 270M** — text generation only.
 - **SmolLM 135M** — text generation only.
+- **LFM2.5 230M** — text generation only.
 - **SmolLM3 3B** — text generation with reasoning, no function calling.
 - **Phi-4 Mini Reasoning** — reasoning model, no function calling.
 - **FastVLM 0.5B** — vision model, no function calling.

--- a/website/content/docs/genkit.md
+++ b/website/content/docs/genkit.md
@@ -21,7 +21,7 @@ with the on-device model exactly as it would with any cloud provider.
 ```
 dependencies:
   genkit_flutter_gemma: ^0.6.0
-  flutter_gemma: ^1.7.3
+  flutter_gemma: ^1.7.4
   # Add the inference engine(s) you need:
   flutter_gemma_litertlm: ^1.6.3   # .litertlm models (mobile + desktop) + LiteRtEmbeddingBackend
   flutter_gemma_mediapipe: ^1.0.5  # .task / .bin models (mobile + web)

--- a/website/content/docs/migration.md
+++ b/website/content/docs/migration.md
@@ -29,7 +29,7 @@ dependencies:
 
 ```
 dependencies:
-  flutter_gemma: ^1.7.3                 # core — always required
+  flutter_gemma: ^1.7.4                 # core — always required
   flutter_gemma_litertlm: ^1.6.3        # add if you run .litertlm models (also provides LiteRtEmbeddingBackend)
   flutter_gemma_mediapipe: ^1.0.5       # add if you run .task / .bin models
   flutter_gemma_embeddings: ^2.1.1      # add if you compute embeddings (needs a backend, see above)

--- a/website/content/docs/models.md
+++ b/website/content/docs/models.md
@@ -95,6 +95,7 @@ MediaPipe `.task` build.
 | **Gemma 3 270M** | Ideal for fine-tuning (LoRA) for specific tasks | ❌ | ❌ | ❌ | Multilingual | 0.3GB |
 | **FunctionGemma 270M** | Specialized for function calling on-device | ✅ | ❌ | ❌ | Multilingual | 284MB |
 | **SmolLM 135M** | Ultra-compact, resource-constrained devices | ❌ | ❌ | ❌ | English | 135MB |
+| **LFM2.5 230M** | Smallest entry; no HF token needed | ❌ | ❌ | ❌ | Multilingual | 168MB |
 | **SmolLM3 3B** | Multilingual small LLM with reasoning mode | ❌ | ✅ | ❌ | Multilingual | 2.0GB |
 | **TranslateGemma 4B** † | Single-shot 55-language translation | ❌ | ❌ | ❌ | 55 languages | 2-4GB |
 
@@ -127,7 +128,7 @@ When installing models, specify the correct `ModelType`:
 | **Qwen 3** | `ModelType.qwen3` | Qwen3 0.6B |
 | **FunctionGemma** | `ModelType.functionGemma` | FunctionGemma 270M IT |
 | **Phi** | `ModelType.general` | Phi-4 Mini |
-| **General** | `ModelType.general` | FastVLM 0.5B, SmolLM 135M, SmolLM3 3B, Phi-4 Mini Reasoning, Qwen2-VL 2B, SmolVLM2 500M, LLaVA-OneVision 0.5B |
+| **General** | `ModelType.general` | FastVLM 0.5B, SmolLM 135M, LFM2.5 230M, SmolLM3 3B, Phi-4 Mini Reasoning, Qwen2-VL 2B, SmolVLM2 500M, LLaVA-OneVision 0.5B |
 
 <Info>
 Gemma 4 uses `ModelType.gemma4` so its native tool-call tokens are routed through
@@ -170,6 +171,7 @@ await FlutterGemma.installModel(modelType: ModelType.general)
 | [Qwen 2.5 1.5B](https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct) | 1.6GB | ✅ | ✅ | ❌ |
 | [Qwen 2.5 0.5B](https://huggingface.co/litert-community/Qwen2.5-0.5B-Instruct) | 0.5GB | ❌ | ✅ | ❌ |
 | [SmolLM 135M](https://huggingface.co/litert-community/SmolLM-135M-Instruct) | 135MB | ❌ | ✅ | ❌ |
+| [LFM2.5 230M](https://huggingface.co/litert-community/LFM2.5-230M) | 168MB | ❌ | ✅ | ❌ |
 | [SmolLM3 3B](https://huggingface.co/litert-community/SmolLM3-3B) | 2.0GB | ✅ | ✅ | ❌ |
 | [Phi-4 Mini](https://huggingface.co/litert-community/Phi-4-mini-instruct) | 3.9GB | ✅ | ✅ | ✅ |
 | [Phi-4 Mini Reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning) | 2.8GB | ✅ | ✅ | ❌ |

--- a/website/content/docs/speech.md
+++ b/website/content/docs/speech.md
@@ -30,7 +30,7 @@ inference.
 
 ```
 dependencies:
-  flutter_gemma: ^1.7.3
+  flutter_gemma: ^1.7.4
   flutter_gemma_speech: ^0.4.3
 ```
 


### PR DESCRIPTION
Adds `litert-community/LFM2.5-230M` to the example catalogue and the supported-model lists, routes the entries that can use it through the one-call `installModel(...).fromHuggingFace(repo)` path, and bumps core to **1.7.4** so both reach pub.dev.

## Why the version bump

`packages/flutter_gemma/lib/` is untouched — this is a docs-and-example change. But `README.md` (94 KB, the pub.dev landing page) and `example/` are both frozen into the published archive, so without a version they exist on GitHub and nowhere a pub.dev reader looks. That is the release skill's 1d-bis case.

`flutter_gemma_litertlm` keeps its `^1.7.3` floor — its web function calling depends on the 1.7.3 fix, not on anything here.

## Why `fromHuggingFace`, and only five entries

The path shipped in 1.7.0 with unit coverage plus an emulator pass. Nothing in the example exercised it — the flagship install path was absent from the app people read.

It needs a `litertlm_manifest.json` in the repo. **4 of the 42 repos this catalogue references have one**; LFM2.5-230M is the fifth. Verified by fetching the manifest from each — all five return 200, schema `0.1.2`.

| entry | repo |
|---|---|
| LFM2.5 230M | `litert-community/LFM2.5-230M` |
| SmolLM3 3B | `litert-community/SmolLM3-3B` |
| Qwen2-VL 2B | `litert-community/Qwen2-VL-2B` |
| SmolVLM2 500M | `litert-community/SmolVLM2-500M` |
| LLaVA-OneVision 0.5B | `litert-community/LLaVA-OneVision-0.5B` |

The other 37 keep `fromNetwork`. A missing manifest is a resolve failure, not a fallback, so switching them would break working entries. The new `hfRepo` field selects the branch; `getActiveModel(defaults:)` then applies the manifest's own `maxTokens` and backend, with an explicit user pick still winning.

## Why this model

Two measured properties:

- **168 MB (int4)** — the smallest entry in the catalogue.
- **No HuggingFace token** — the only entry that needs none, verified by installing with an empty token on four platforms. The current smallest, Gemma 3 270M, is `needsAuth: true`.

It is a ShortConv/attention hybrid (14 layers: 8 conv + 6 GQA), not a plain transformer, which is what makes it viable on low-end hardware.

## Verification

`example/integration_test/hf_fileless_install_device_test.dart`, added here — resolve manifest → install pinned variant → generate:

```
macOS 26.5.1, Apple Silicon        gpu (manifest default gpu)  install 20.5s
Android 12, RayNeo ARGF20 arm64    gpu (manifest default gpu)  install 47.9s
Windows 10 Pro (build 26200)       gpu (manifest default gpu)  install 12.1s
Linux, Ubuntu + Tesla T4           gpu (manifest default gpu)  install 12.7s
```

All physical hardware, no emulator. Backend matched the manifest default everywhere; nothing was overridden. Posted upstream on #454, which asked for exactly this.

A second run with the model already installed took **328 ms** — still a network round-trip, because the variant filename is only known after the manifest fetch. "Already installed" does not imply "installable offline".

## Model listing completed

LFM2.5-230M was initially added to `README.md` and `models.md` only. Grepping for an existing entry rather than recalling where the tables live turned up two more: the `CLAUDE.md` supported-models table and `function-calling.md`'s "no function calling" list. All four now carry it.

## Recorded honestly

- **Instruction-following is poor at 230M.** "Say hello in one word" produced a one-word reply on one of the four runs and a polite paragraph on the other three. Noted next to the entry so nobody reads a bad answer as a plugin bug.
- **No `webUrl`.** The manifest ships int4 and int8 only — no web build — so the field is left unset.
- Our manifest fixtures are on schema `0.1.0` while the live repos serve `0.1.2`; regeneration is a separate task.