### PR TITLE
site: make the author credit a link, matching litetune's footer

### DIFF
--- a/website/lib/landing/sections/site_footer.dart
+++ b/website/lib/landing/sections/site_footer.dart
@@ -156,14 +156,6 @@ class SiteFooter extends StatelessComponent {
               ul(classes: 'footer-links', [
                 li([
                   a(
-                    href: 'https://sashadenisov.dev',
-                    classes: 'footer-link',
-                    attributes: {'target': '_blank', 'rel': 'noopener'},
-                    [Component.text('Author')],
-                  ),
-                ]),
-                li([
-                  a(
                     href: 'https://github.com/DenisovAV/flutter_gemma',
                     classes: 'footer-link',
                     attributes: {'target': '_blank', 'rel': 'noopener'},
@@ -207,7 +199,15 @@ class SiteFooter extends StatelessComponent {
           ]),
           // Bottom bar
           div(classes: 'footer-bottom', [
-            span(classes: 'footer-copy', [Component.text('MIT © Sasha Denisov')]),
+            span(classes: 'footer-copy', [
+              a(
+                href: 'https://sashadenisov.dev',
+                classes: 'footer-author',
+                attributes: {'target': '_blank', 'rel': 'noopener'},
+                [Component.text('Sasha Denisov')],
+              ),
+              Component.text(' · MIT'),
+            ]),
             span(classes: 'footer-copy', [
               Component.text('Made with '),
               a(
@@ -296,5 +296,19 @@ class SiteFooter extends StatelessComponent {
       fontSize: 0.825.rem,
       color: Brand.white50,
     ),
+    // The name is the only link down here that is not a project resource, so it
+    // is underlined rather than left to read as plain text.
+    //
+    // Font and colour are INHERITED from `.footer-copy` on purpose: the name
+    // and the licence beside it are one sentence, and setting a family or size
+    // here renders half of it in a different typeface at a different size.
+    css('.footer-author').styles(
+      raw: const {
+        'color': 'inherit',
+        'text-decoration': 'underline',
+        'text-underline-offset': '2px',
+      },
+    ),
+    css('.footer-author:hover').styles(color: Brand.white),
   ];
 }


### PR DESCRIPTION
The name and the link to it were both already in the footer, just not connected: `MIT © Sasha Denisov` sat in the bottom bar as plain text, while `sashadenisov.dev` was a separate entry in the Links column under the faceless label **Author**.

Now the name itself is the link, in the shape litetune's footer uses:

```
Sasha Denisov · MIT
```

Same treatment, translated to this site's dark palette — mono at the muted foreground, underlined with a 2px offset, hover to full white. It is the only link down there that is not a project resource, so it reads as a link rather than as part of the copyright.

The **Author** entry is dropped; keeping it would put one URL in the footer twice.

## Verified on the rendered output

Not on the build's success line — checked the generated HTML:

```html
<span class="footer-copy">
  <a class="footer-author" target="_blank" rel="noopener"
     href="https://sashadenisov.dev">Sasha Denisov</a> · MIT
</span>
```

`sashadenisov.dev` appears exactly once, both CSS rules are emitted, and the footer updates on all 21 pages.

## Note on the diff

22 lines added, 9 removed. `dart format` on a current SDK wants to rewrite this whole file (225/198), because it was already unformatted against that formatter before this change — repo-wide debt, not this PR's. Left alone so the diff stays reviewable.
